### PR TITLE
Fix gh-pages deployment

### DIFF
--- a/.github/workflows/gh-pages.yml
+++ b/.github/workflows/gh-pages.yml
@@ -23,5 +23,5 @@ jobs:
         uses: peaceiris/actions-gh-pages@v3
         if: github.ref == 'refs/heads/main'
         with:
-          personal_token: ${{ secrets.DEPLOY_TOKEN }}
+          personal_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: ./website/public


### PR DESCRIPTION
Turns out this Deploy_token can be the github_token which is built in. 

Once I re-generated a github token, the deploy token secret was no longer valid (because it pointed to the old github token).

This should fix things