### PR TITLE
Add plotly candle

### DIFF
--- a/website/content/stocks/candle/_index.md
+++ b/website/content/stocks/candle/_index.md
@@ -1,5 +1,5 @@
 ```
-usage: candle [-s S_START] [-h]
+usage: candle [-s S_START] [--plotly] [-h]
 ```
 
 Displays candle chart of loaded ticker
@@ -8,6 +8,7 @@ Displays candle chart of loaded ticker
 optional arguments:
   -s S_START, --start_date S_START
                         Start date for candle data (default: 2021-03-19)
+  --plotly              Flag to show interactive plot using plotly. (default: False)
   -h, --help            show this help message (default: False)
 ```
 


### PR DESCRIPTION
This PR adds the ability to show interactive candles using plotly.  Accessed with a `--plotly` flag.
![Screen Shot 2021-10-13 at 10 13 48 PM](https://user-images.githubusercontent.com/18151143/137239162-5ca34939-54ed-48fc-b7c1-10835149c2a8.png)
 