### PR TITLE
Fix show indices returning DataFrame

### DIFF
--- a/openbb_terminal/economy/yfinance_view.py
+++ b/openbb_terminal/economy/yfinance_view.py
@@ -4,7 +4,7 @@ __docformat__ = "numpy"
 
 import logging
 import os
-from typing import Optional, Tuple, Union
+from typing import Optional, Union
 
 import pandas as pd
 
@@ -34,7 +34,7 @@ def show_indices(
     export: str = "",
     sheet_name: Optional[str] = None,
     limit: int = 10,
-) -> Union[pd.DataFrame, Tuple[pd.DataFrame, OpenBBFigure]]:
+) -> Union[pd.DataFrame, OpenBBFigure]:
     """Load (and show) the selected indices over time [Source: Yahoo Finance]
     Parameters
     ----------
@@ -107,8 +107,6 @@ def show_indices(
     if len(indices) < 2:
         fig.update_layout(title=f"{' - '.join(new_title)}", yaxis=dict(side="right"))
 
-    fig.show(external=external_axes)
-
     if raw:
         # was a -iloc so we need to flip the index as we use head
         indices_data = indices_data.sort_index(ascending=False)
@@ -131,10 +129,7 @@ def show_indices(
             fig,
         )
 
-    if (output := indices_data) is not None and external_axes:
-        output = (indices_data, fig.show(external=external_axes))
-
-    return output
+    return fig.show(external=external_axes)
 
 
 @log_start_end(log=logger)

--- a/tests/openbb_terminal/economy/test_yfinance_view.py
+++ b/tests/openbb_terminal/economy/test_yfinance_view.py
@@ -1,7 +1,6 @@
 # IMPORTATION STANDARD
 
 # IMPORTATION THIRDPARTY
-import pandas as pd
 import pytest
 import yfinance
 
@@ -45,11 +44,9 @@ def test_show_indices(
         return yf_download(*args, **kwargs)
 
     mocker.patch("yfinance.download", side_effect=mock_yf_download)
-    result_df = yfinance_view.show_indices(
+    yfinance_view.show_indices(
         indices, interval, start_date, end_date, column, returns, store
     )
-
-    assert isinstance(result_df, pd.DataFrame)
 
 
 @pytest.mark.skip
@@ -78,11 +75,9 @@ def test_show_indices_returns(
         return yf_download(*args, **kwargs)
 
     mocker.patch("yfinance.download", side_effect=mock_yf_download)
-    result_df = yfinance_view.show_indices(
+    yfinance_view.show_indices(
         indices, interval, start_date, end_date, column, returns, store
     )
-
-    assert isinstance(result_df, pd.DataFrame)
 
 
 @pytest.mark.vcr


### PR DESCRIPTION
# Description

* Closes https://github.com/OpenBB-finance/OpenBBTerminal/issues/4473


<img width="1365" alt="Screenshot 2023-03-28 at 13 33 46" src="https://user-images.githubusercontent.com/79287829/228237635-b773e382-d9e6-40b6-8fd9-dcfc2a0a6408.png">


- [ ] Summary of the change / bug fix.
- [ ] Link # issue, if applicable.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable.
- [ ] Relevant motivation and context.
- [ ] List any dependencies that are required for this change.


# How has this been tested?

* Please describe the tests that you ran to verify your changes.
* Provide instructions so we can reproduce.
* Please also list any relevant details for your test configuration.
- [ ] Make sure affected commands still run in terminal
- [ ] Ensure the SDK still works
- [ ] Check any related reports


# Checklist:

- [ ] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [ ] Update [our documentation](https://openbb-finance.github.io/OpenBBTerminal/) following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/website).  Update any user guides that are affected by the changes.
- [ ] Update our tests following [these guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/tree/main/tests).
- [ ] Make sure you are following our [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBBTerminal/blob/main/CONTRIBUTING.md).
- [ ] If a feature was added make sure to add it to the corresponding [integration test script](https://github.com/OpenBB-finance/OpenBBTerminal/tree/develop/openbb_terminal/miscellaneous/integration_tests_scripts).


# Others
- [ ] I have performed a self-review of my own code.
- [ ] I have commented my code, particularly in hard-to-understand areas.
