### PR TITLE
[Enhancement] Add **extra_params To POST Router Commands

### DIFF
--- a/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
+++ b/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
@@ -1,5 +1,7 @@
 """Econometrics Router."""
 
+# pylint: disable=unused-argument
+
 import re
 from itertools import combinations
 from typing import Dict, List, Literal
@@ -43,7 +45,10 @@ router = Router(prefix="")
         APIEx(parameters={"data": APIEx.mock_data("timeseries")}),
     ],
 )
-def correlation_matrix(data: List[Data]) -> OBBject[List[Data]]:
+def correlation_matrix(
+    data: List[Data],
+    **extra_params,
+) -> OBBject[List[Data]]:
     """Get the correlation matrix of an input dataset.
 
     The correlation matrix provides a view of how different variables in your dataset relate to one another.
@@ -55,6 +60,9 @@ def correlation_matrix(data: List[Data]) -> OBBject[List[Data]]:
     ----------
     data : List[Data]
         Input dataset.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -101,6 +109,7 @@ def ols_regression(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Perform Ordinary Least Squares (OLS) regression.
 
@@ -117,6 +126,9 @@ def ols_regression(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -153,6 +165,7 @@ def ols_regression_summary(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Data]:
     """Perform Ordinary Least Squares (OLS) regression.
 
@@ -166,6 +179,9 @@ def ols_regression_summary(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -238,6 +254,7 @@ def autocorrelation(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Data]:
     """Perform Durbin-Watson test for autocorrelation.
 
@@ -257,6 +274,9 @@ def autocorrelation(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -293,6 +313,7 @@ def residual_autocorrelation(
     y_column: str,
     x_columns: List[str],
     lags: PositiveInt = 1,
+    **extra_params,
 ) -> OBBject[Data]:
     """Perform Breusch-Godfrey Lagrange Multiplier tests for residual autocorrelation.
 
@@ -314,6 +335,9 @@ def residual_autocorrelation(
         List of columns to use as exogenous variables.
     lags: PositiveInt
         Number of lags to use in the test.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -351,6 +375,7 @@ def residual_autocorrelation(
 def cointegration(
     data: List[Data],
     columns: List[str],
+    **extra_params,
 ) -> OBBject[Data]:
     """Show co-integration between two timeseries using the two step Engle-Granger test.
 
@@ -371,6 +396,9 @@ def cointegration(
         Data columns to check cointegration
     maxlag: PositiveInt
         Number of lags to use in the test.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -426,6 +454,7 @@ def causality(
     y_column: str,
     x_column: str,
     lag: PositiveInt = 3,
+    **extra_params,
 ) -> OBBject[Data]:
     """Perform Granger causality test to determine if X 'causes' y.
 
@@ -447,6 +476,9 @@ def causality(
         Columns to use as exogenous variables.
     lag: PositiveInt
         Number of lags to use in the test.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -494,6 +526,7 @@ def unit_root(
     data: List[Data],
     column: str,
     regression: Literal["c", "ct", "ctt"] = "c",
+    **extra_params,
 ) -> OBBject[Data]:
     """Perform Augmented Dickey-Fuller (ADF) unit root test.
 
@@ -515,6 +548,9 @@ def unit_root(
     regression: Literal["c", "ct", "ctt"]
         Regression type to use in the test.  Either "c" for constant only, "ct" for constant and trend, or "ctt" for
         constant, trend, and trend-squared.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -549,6 +585,7 @@ def panel_random_effects(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Perform One-way Random Effects model for panel data.
 
@@ -565,6 +602,9 @@ def panel_random_effects(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -596,6 +636,7 @@ def panel_between(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Perform a Between estimator regression on panel data.
 
@@ -612,6 +653,9 @@ def panel_between(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -641,6 +685,7 @@ def panel_pooled(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Perform a Pooled coefficient estimator regression on panel data.
 
@@ -658,6 +703,9 @@ def panel_pooled(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -687,6 +735,7 @@ def panel_fixed(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """One- and two-way fixed effects estimator for panel data.
 
@@ -703,6 +752,9 @@ def panel_fixed(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -732,6 +784,7 @@ def panel_first_difference(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Perform a first-difference estimate for panel data.
 
@@ -748,6 +801,9 @@ def panel_first_difference(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -777,6 +833,7 @@ def panel_fmac(
     data: List[Data],
     y_column: str,
     x_columns: List[str],
+    **extra_params,
 ) -> OBBject[Dict]:
     """Fama-MacBeth estimator for panel data.
 
@@ -794,6 +851,9 @@ def panel_fmac(
         Target column.
     x_columns: List[str]
         List of columns to use as exogenous variables.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
@@ -1,3 +1,7 @@
+"""Quantitative Performance Router."""
+
+# pylint: disable=unused-argument
+
 from typing import List
 
 import numpy as np
@@ -47,6 +51,7 @@ def omega_ratio(
     target: str,
     threshold_start: float = 0.0,
     threshold_end: float = 1.5,
+    **extra_params,
 ) -> OBBject[List[OmegaModel]]:
     """Calculate the Omega Ratio.
 
@@ -64,6 +69,9 @@ def omega_ratio(
         Start threshold, by default 0.0
     threshold_end : float, optional
         End threshold, by default 1.5
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -122,6 +130,7 @@ def sharpe_ratio(
     rfr: float = 0.0,
     window: PositiveInt = 252,
     index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Get Rolling Sharpe Ratio.
 
@@ -143,6 +152,9 @@ def sharpe_ratio(
     window : PositiveInt, optional
         Window size, by default 252
     index : str, optional
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -193,6 +205,7 @@ def sortino_ratio(
     window: PositiveInt = 252,
     adjusted: bool = False,
     index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Get rolling Sortino Ratio.
 
@@ -222,6 +235,10 @@ def sortino_ratio(
         Adjust sortino ratio to compare it to sharpe ratio, by default False
     index:str
         Index column for input data
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
+
     Returns
     -------
     OBBject[List[Data]]

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
@@ -1,5 +1,7 @@
 """Quantitative Analysis Router."""
 
+# pylint: disable=unused-argument
+
 from typing import List, Literal
 
 import pandas as pd
@@ -49,7 +51,11 @@ router.include_router(performance_router)
         APIEx(parameters={"target": "close", "data": APIEx.mock_data("timeseries", 8)}),
     ],
 )
-def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
+def normality(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[NormalityModel]:
     """Get Normality Statistics.
 
     - **Kurtosis**: whether the kurtosis of a sample differs from the normal distribution.
@@ -64,6 +70,9 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
         Time series data.
     target : str
         Target column name.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -107,7 +116,11 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
         ),
     ],
 )
-def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
+def capm(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[CAPMModel]:
     """Get Capital Asset Pricing Model (CAPM).
 
     CAPM offers a streamlined way to assess the expected return on an investment while accounting for its risk relative
@@ -120,6 +133,9 @@ def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
         Time series data.
     target : str
         Target column name.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -175,6 +191,7 @@ def unitroot_test(
     target: str,
     fuller_reg: Literal["c", "ct", "ctt", "nc", "c"] = "c",
     kpss_reg: Literal["c", "ct"] = "c",
+    **extra_params,
 ) -> OBBject[UnitRootModel]:
     """Get Unit Root Test.
 
@@ -196,6 +213,9 @@ def unitroot_test(
         Regression type for ADF test.
     kpss_reg : Literal["c", "ct"]
         Regression type for KPSS test.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -241,7 +261,11 @@ def unitroot_test(
         APIEx(parameters={"target": "close", "data": APIEx.mock_data("timeseries", 5)}),
     ],
 )
-def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
+def summary(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[SummaryModel]:
     """Get Summary Statistics.
 
     The summary that offers a snapshot of its central tendencies, variability, and distribution.
@@ -257,6 +281,9 @@ def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
         Time series data.
     target : str
         Target column name.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/rolling/rolling_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/rolling/rolling_router.py
@@ -1,5 +1,7 @@
 """Rolling submenu of quantitative models for rolling statistics."""
 
+# pylint: disable=unused-argument
+
 from typing import List
 
 import pandas as pd
@@ -49,7 +51,11 @@ router = Router(prefix="/rolling")
     ],
 )
 def skew(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
+    data: List[Data],
+    target: str,
+    window: PositiveInt = 21,
+    index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Get Rolling Skew.
 
@@ -69,6 +75,9 @@ def skew(
         Window size.
     index : str, optional
         Index column name, by default "date"
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -112,7 +121,11 @@ def skew(
     ],
 )
 def variance(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
+    data: List[Data],
+    target: str,
+    window: PositiveInt = 21,
+    index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the rolling variance of a target column within a given window size.
@@ -130,6 +143,9 @@ def variance(
         The number of observations used for calculating the rolling measure.
     index: str, optional
         The name of the index column, default is "date".
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -170,7 +186,11 @@ def variance(
     ],
 )
 def stdev(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
+    data: List[Data],
+    target: str,
+    window: PositiveInt = 21,
+    index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the rolling standard deviation of a target column within a given window size.
@@ -189,6 +209,9 @@ def stdev(
         The number of observations used for calculating the rolling measure.
     index: str, optional
         The name of the index column, default is "date".
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -231,7 +254,11 @@ def stdev(
     ],
 )
 def kurtosis(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
+    data: List[Data],
+    target: str,
+    window: PositiveInt = 21,
+    index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the rolling kurtosis of a target column within a given window size.
@@ -252,6 +279,9 @@ def kurtosis(
         The number of observations used for calculating the rolling measure.
     index: str, optional
         The name of the index column, default is "date".
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -300,6 +330,7 @@ def quantile(
     window: PositiveInt = 21,
     quantile_pct: NonNegativeFloat = 0.5,
     index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the rolling quantile of a target column within a given window size at a specified quantile percentage.
@@ -320,6 +351,9 @@ def quantile(
         The quantile percentage to calculate (e.g., 0.5 for median), default is 0.5.
     index: str, optional
         The name of the index column, default is "date".
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -374,7 +408,11 @@ def quantile(
     ],
 )
 def mean(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
+    data: List[Data],
+    target: str,
+    window: PositiveInt = 21,
+    index: str = "date",
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the rolling mean (average) of a target column within a given window size.
@@ -393,6 +431,9 @@ def mean(
         The number of observations used for calculating the rolling measure.
     index: str, optional
         The name of the index column, default is "date".
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/stats/stats_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/stats/stats_router.py
@@ -49,6 +49,7 @@ router = Router(prefix="/stats")
 def skew(
     data: List[Data],
     target: str,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Get the skew of the data set.
 
@@ -64,6 +65,9 @@ def skew(
         Time series data.
     target : str
         Target column name.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -100,7 +104,11 @@ def skew(
         ),
     ],
 )
-def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
+def variance(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[List[Data]]:
     """
     Calculate the  variance of a target column.
 
@@ -113,6 +121,9 @@ def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate variance.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -149,7 +160,11 @@ def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
         ),
     ],
 )
-def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
+def stdev(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[List[Data]]:
     """
     Calculate the rolling standard deviation of a target column.
 
@@ -163,6 +178,9 @@ def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate standard deviation.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -199,7 +217,11 @@ def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
         ),
     ],
 )
-def kurtosis(data: List[Data], target: str) -> OBBject[List[Data]]:
+def kurtosis(
+    data: List[Data],
+    target: str,
+    **extra_params,
+) -> OBBject[List[Data]]:
     """
     Calculate the rolling kurtosis of a target column.
 
@@ -214,6 +236,9 @@ def kurtosis(data: List[Data], target: str) -> OBBject[List[Data]]:
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate kurtosis.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -254,6 +279,7 @@ def quantile(
     data: List[Data],
     target: str,
     quantile_pct: NonNegativeFloat = 0.5,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the quantile of a target column at a specified quantile percentage.
@@ -269,6 +295,9 @@ def quantile(
         The name of the column for which to calculate the quantile.
     quantile_pct: NonNegativeFloat, optional
         The quantile percentage to calculate (e.g., 0.5 for median), default is 0.5.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -311,6 +340,7 @@ def quantile(
 def mean(
     data: List[Data],
     target: str,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """
     Calculate the  mean (average) of a target column.
@@ -325,6 +355,9 @@ def mean(
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate the mean.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------

--- a/openbb_platform/extensions/technical/openbb_technical/technical_router.py
+++ b/openbb_platform/extensions/technical/openbb_technical/technical_router.py
@@ -1,6 +1,7 @@
 """Technical Analysis Router."""
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines, unused-argument
+
 from typing import List, Literal, Optional
 
 import pandas as pd
@@ -48,6 +49,7 @@ def atr(
     mamode: Literal["rma", "ema", "sma", "wma"] = "rma",
     drift: NonNegativeInt = 1,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Average True Range.
 
@@ -73,7 +75,9 @@ def atr(
         The difference period, by default 1
     offset : int, optional
         How many periods to offset the result, by default 0
-
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
     Returns
     -------
     OBBject[List[Data]]
@@ -112,6 +116,7 @@ def fib(
     period: PositiveInt = 120,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Create Fibonacci Retracement Levels.
 
@@ -129,6 +134,9 @@ def fib(
         Index column name, by default "date"
     period : PositiveInt, optional
         Period to calculate the indicator, by default 120
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -180,6 +188,7 @@ def obv(
     data: List[Data],
     index: str = "date",
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the On Balance Volume (OBV).
 
@@ -200,6 +209,9 @@ def obv(
         Index column name, by default "date"
     offset : int, optional
         How many periods to offset the result, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -234,6 +246,7 @@ def fisher(
     index: str = "date",
     length: PositiveInt = 14,
     signal: PositiveInt = 1,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Perform the Fisher Transform.
 
@@ -253,6 +266,9 @@ def fisher(
         Fisher period, by default 14
     signal : PositiveInt, optional
         Fisher Signal period, by default 1
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -289,6 +305,7 @@ def adosc(
     fast: PositiveInt = 3,
     slow: PositiveInt = 10,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Accumulation/Distribution Oscillator.
 
@@ -311,6 +328,9 @@ def adosc(
         Number of periods to be used for the slow calculation, by default 10.
     offset : int, optional
         Offset to be used for the calculation, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -349,6 +369,7 @@ def bbands(
     std: NonNegativeFloat = 2,
     mamode: Literal["sma", "ema", "wma", "rma"] = "sma",
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Bollinger Bands.
 
@@ -381,6 +402,9 @@ def bbands(
         Moving average mode to be used for the calculation, by default "sma".
     offset : int, optional
         Offset to be used for the calculation, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -426,6 +450,7 @@ def zlma(
     index: str = "date",
     length: int = 50,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the zero lag exponential moving average (ZLEMA).
 
@@ -448,6 +473,9 @@ def zlma(
         Number of periods to be used for the calculation, by default 50.
     offset : int, optional
         Offset to be used for the calculation, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -490,6 +518,7 @@ def aroon(
     index: str = "date",
     length: int = 25,
     scalar: int = 100,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Aroon Indicator.
 
@@ -515,6 +544,9 @@ def aroon(
         Number of periods to be used for the calculation, by default 25.
     scalar : int, optional
         Scalar to be used for the calculation, by default 100.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -551,6 +583,7 @@ def sma(
     index: str = "date",
     length: int = 50,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Simple Moving Average (SMA).
 
@@ -574,6 +607,9 @@ def sma(
         Number of periods to be used for the calculation, by default 50.
     offset : int, optional
         Offset from the current period, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -618,6 +654,7 @@ def demark(
     show_all: bool = True,
     asint: bool = True,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Demark sequential indicator.
 
@@ -641,6 +678,9 @@ def demark(
         If True, fill NAs with 0 and change type to int, by default True.
     offset : int, optional
         How many periods to offset the result
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -676,6 +716,7 @@ def vwap(
     index: str = "date",
     anchor: str = "D",
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Volume Weighted Average Price (VWAP).
 
@@ -696,6 +737,9 @@ def vwap(
         https://pandas.pydata.org/pandas-docs/stable/user_guide/timeseries.html#timeseries-offset-aliases
     offset : int, optional
         Offset from the current period, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -742,6 +786,7 @@ def macd(
     fast: int = 12,
     slow: int = 26,
     signal: int = 9,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Moving Average Convergence Divergence (MACD).
 
@@ -768,6 +813,9 @@ def macd(
         Number of periods for the slow EMA, by default 26.
     signal : int, optional
         Number of periods for the signal EMA, by default 9.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -810,6 +858,7 @@ def hma(
     index: str = "date",
     length: int = 50,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Hull Moving Average (HMA).
 
@@ -830,6 +879,9 @@ def hma(
         Number of periods for the HMA, by default 50.
     offset : int, optional
         Offset of the HMA, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -879,6 +931,7 @@ def donchian(
     lower_length: PositiveInt = 20,
     upper_length: PositiveInt = 20,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Donchian Channels.
 
@@ -900,6 +953,9 @@ def donchian(
         Number of periods for the upper band, by default 20.
     offset : int, optional
         Offset of the Donchian Channel, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -941,6 +997,7 @@ def ichimoku(
     lagging: PositiveInt = 52,
     offset: PositiveInt = 26,
     lookahead: bool = False,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Ichimoku Cloud.
 
@@ -966,6 +1023,9 @@ def ichimoku(
         Number of periods for the offset, by default 26.
     lookahead : bool, optional
         drops the Chikou Span Column to prevent potential data leak
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1009,6 +1069,7 @@ def clenow(
     index: str = "date",
     target: str = "close",
     period: PositiveInt = 90,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Clenow Volatility Adjusted Momentum.
 
@@ -1026,6 +1087,9 @@ def clenow(
         Target column name, by default "close".
     period : PositiveInt, optional
         Number of periods for the momentum, by default 90.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1066,7 +1130,12 @@ def clenow(
         APIEx(parameters={"data": APIEx.mock_data("timeseries")}),
     ],
 )
-def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[Data]]:
+def ad(
+    data: List[Data],
+    index: str = "date",
+    offset: int = 0,
+    **extra_params,
+) -> OBBject[List[Data]]:
     """Calculate the Accumulation/Distribution Line.
 
     Similar to the On Balance Volume (OBV).
@@ -1090,6 +1159,9 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
         Index column name to use with `data`, by default "date".
     offset : int, optional
         Offset of the AD, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1125,6 +1197,7 @@ def adx(
     length: int = 50,
     scalar: float = 100.0,
     drift: int = 1,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Average Directional Index (ADX).
 
@@ -1144,6 +1217,9 @@ def adx(
         Scalar value for the ADX, by default 100.0.
     drift : int, optional
         Drift value for the ADX, by default 1.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1182,6 +1258,7 @@ def wma(
     index: str = "date",
     length: int = 50,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Weighted Moving Average (WMA).
 
@@ -1202,6 +1279,9 @@ def wma(
         The length of the WMA, by default 50.
     offset : int, optional
         The offset of the WMA, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1244,6 +1324,7 @@ def cci(
     index: str = "date",
     length: PositiveInt = 14,
     scalar: PositiveFloat = 0.015,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Commodity Channel Index (CCI).
 
@@ -1263,6 +1344,9 @@ def cci(
         The length of the CCI, by default 14.
     scalar : PositiveFloat, optional
         The scalar of the CCI, by default 0.015.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1300,6 +1384,7 @@ def rsi(
     length: int = 14,
     scalar: float = 100.0,
     drift: int = 1,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Relative Strength Index (RSI).
 
@@ -1323,6 +1408,9 @@ def rsi(
         The scalar to use for the RSI, by default 100.0
     drift : int, optional
         The drift to use for the RSI, by default 1
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1366,6 +1454,7 @@ def stoch(
     fast_k_period: NonNegativeInt = 14,
     slow_d_period: NonNegativeInt = 3,
     slow_k_period: NonNegativeInt = 3,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Stochastic Oscillator.
 
@@ -1388,6 +1477,9 @@ def stoch(
         The slow %D period, by default 3.
     slow_k_period : NonNegativeInt, optional
         The slow %K period, by default 3.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1431,6 +1523,7 @@ def kc(
     scalar: PositiveFloat = 20,
     mamode: Literal["ema", "sma", "wma", "hma", "zlma"] = "ema",
     offset: NonNegativeInt = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Keltner Channels.
 
@@ -1454,6 +1547,9 @@ def kc(
         The moving average mode to use for the Keltner Channels, by default "ema"
     offset : NonNegativeInt, optional
         The offset to use for the Keltner Channels, by default 0
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1491,7 +1587,10 @@ def kc(
     ],
 )
 def cg(
-    data: List[Data], index: str = "date", length: PositiveInt = 14
+    data: List[Data],
+    index: str = "date",
+    length: PositiveInt = 14,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Center of Gravity.
 
@@ -1509,6 +1608,9 @@ def cg(
         Index column name to use with `data`, by default "date"
     length : PositiveInt, optional
         The length of the COG, by default 14
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1554,6 +1656,7 @@ def cones(
     ] = "std",
     is_crypto: bool = False,
     trading_periods: Optional[int] = None,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the realized volatility quantiles over rolling windows of time.
 
@@ -1607,6 +1710,9 @@ def cones(
         Whether the data is crypto or not. If True, volatility is calculated for 365 days instead of 252
     trading_periods : Optional[int] [default: 252]
         Number of trading periods in a year.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------
@@ -1650,6 +1756,7 @@ def ema(
     index: str = "date",
     length: int = 50,
     offset: int = 0,
+    **extra_params,
 ) -> OBBject[List[Data]]:
     """Calculate the Exponential Moving Average (EMA).
 
@@ -1670,6 +1777,9 @@ def ema(
         The length of the calculation, by default 50.
     offset : int, optional
         The offset of the calculation, by default 0.
+    **extra_params : Optional[Dict[str, Any]]
+        Extra parameters to be passed to the command execution.
+        API POST requests are sent in the body with data.
 
     Returns
     -------


### PR DESCRIPTION
Relies on this chain: #6250 

1. **Why**?:

    - The purpose is to prevent unexpected keyword argument errors from POST functions, and to facilitate extension development that might require additional parameters that are unknown - visualizations, etc. 

2. **What**?:

    - Add **extra_params to each router function.

    - This should provide the same type of behaviour as provider router functions.

3. **Impact** (1-2 sentences or a bullet point list):

    - Opens the functions to development/enhancement without needing to modify the router/extension directly.

4. **Testing Done**:

    - This is blocked by #6250 
