### PR TITLE
Fix build failing for router-only extensions with no standard models

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1154,7 +1154,7 @@ class DocstringGenerator:
                 results_type = (
                     cls._get_repr(
                         cls._get_generic_types(
-                            annotation.model_fields["results"].annotation,  # type: ignore[union-attr]
+                            annotation.model_fields["results"].annotation,  # type: ignore[arg-type]
                             [],
                         ),
                         model_name,
@@ -1673,10 +1673,10 @@ class ReferenceGenerator:
                 reference[path]["description"] = getattr(
                     route, "description", "No description available."
                 )
+
+                # TODO: The reference is not getting populated when a command does not use a standard model
                 # Access model map from the ProviderInterface
-                model_map = cls.pi.map[
-                    standard_model
-                ]  # pylint: disable=protected-access
+                model_map = cls.pi.map.get(standard_model, {})
 
                 for provider in model_map:
                     if provider == "openbb":


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

- Prevent package builder from failing when building a router-only extension that does not use standard models

## How has this been tested?

Ran commands from a router-only extension that have and haven't got query parameters
