### PR TITLE
[BugFix] Raise EmptyDataError When No Results Returned From `obb.economy.fred_search()`

### DIFF
--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -5160,16 +5160,16 @@
                     },
                     {
                         "name": "tag_names",
-                        "type": "str",
-                        "description": "A semicolon delimited list of tag names that series match all of. Example: 'japan;imports'",
+                        "type": "Union[str, List[str]]",
+                        "description": "A semicolon delimited list of tag names that series match all of. Example: 'japan;imports' Multiple items allowed for provider(s): fred.",
                         "default": null,
                         "optional": true,
                         "choices": null
                     },
                     {
                         "name": "exclude_tag_names",
-                        "type": "str",
-                        "description": "A semicolon delimited list of tag names that series match none of. Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series.",
+                        "type": "Union[str, List[str]]",
+                        "description": "A semicolon delimited list of tag names that series match none of. Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple items allowed for provider(s): fred.",
                         "default": null,
                         "optional": true,
                         "choices": null

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -1037,9 +1037,9 @@ class ROUTER_economy(Container):
         filter_value : Optional[str]
             String value to filter the variable by.  Used in conjunction with filter_variable. (provider: fred)
         tag_names : Optional[str]
-            A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' (provider: fred)
+            A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' Multiple comma separated items allowed. (provider: fred)
         exclude_tag_names : Optional[str]
-            A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. (provider: fred)
+            A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple comma separated items allowed. (provider: fred)
         series_id : Optional[str]
             A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas. (provider: fred)
 
@@ -1120,6 +1120,10 @@ class ROUTER_economy(Container):
                     "query": query,
                 },
                 extra_params=kwargs,
+                info={
+                    "tag_names": {"fred": {"multiple_items_allowed": True}},
+                    "exclude_tag_names": {"fred": {"multiple_items_allowed": True}},
+                },
             )
         )
 

--- a/openbb_platform/providers/fred/openbb_fred/models/search.py
+++ b/openbb_platform/providers/fred/openbb_fred/models/search.py
@@ -10,6 +10,7 @@ from openbb_core.provider.standard_models.fred_search import (
     SearchQueryParams,
 )
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
+from openbb_core.provider.utils.errors import EmptyDataError
 from pydantic import Field, NonNegativeInt
 
 
@@ -19,6 +20,11 @@ class FredSearchQueryParams(SearchQueryParams):
     __alias_dict__ = {
         "query": "search_text",
     }
+    __json_schema_extra__ = {
+        "tag_names": {"multiple_items_allowed": True},
+        "exclude_tag_names": {"multiple_items_allowed": True},
+    }
+
     is_release: Optional[bool] = Field(
         default=False,
         description="Is release?  If True, other search filter variables are ignored."
@@ -171,6 +177,8 @@ class FredSearchFetcher(
         query: FredSearchQueryParams, data: List[Dict], **kwargs: Any
     ) -> List[FredSearchData]:
         """Transform data."""
+        if not data:
+            raise EmptyDataError("No results were found with the supplied parameters.")
         if query.series_id is None:
             for observation in data:
                 id_column_name = (


### PR DESCRIPTION
1. **Why**?:

    - ^
    - API does not like an empty data response and will return a confusing 500 error.

2. **What**?:

    - `raise EmptyDataError()` when the search results return nothing.

3. **Impact**:

    - Will now `raise` instead of returning an empty list.

4. **Testing Done**:

    - Observed the error is being raised as expected.