### PR TITLE
[Feature] Remove Deprecated Fields From Equity Historical

### DIFF
--- a/openbb_platform/extensions/equity/integration/test_equity_api.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_api.py
@@ -1134,8 +1134,6 @@ def test_equity_compare_groups(params, headers):
                 "start_date": "2023-06-01",
                 "end_date": "2023-06-03",
                 "interval": "1h",
-                "adjusted": False,
-                "prepost": False,
             }
         ),
         (
@@ -1148,8 +1146,6 @@ def test_equity_compare_groups(params, headers):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "interval": "1d",
-                "adjusted": False,
-                "prepost": False,
             }
         ),
         (

--- a/openbb_platform/extensions/equity/integration/test_equity_python.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_python.py
@@ -1083,8 +1083,6 @@ def test_equity_compare_groups(params, obb):
                 "start_date": "2023-06-01",
                 "end_date": "2023-06-03",
                 "interval": "1h",
-                "adjusted": True,
-                "prepost": False,
             }
         ),
         (
@@ -1097,8 +1095,6 @@ def test_equity_compare_groups(params, obb):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "interval": "1d",
-                "adjusted": False,
-                "prepost": False,
             }
         ),
         (

--- a/openbb_platform/extensions/etf/integration/test_etf_api.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_api.py
@@ -161,8 +161,6 @@ def test_etf_search(params, headers):
                 "start_date": "2023-06-01",
                 "end_date": "2023-06-03",
                 "interval": "1h",
-                "adjusted": True,
-                "prepost": False,
             }
         ),
         (
@@ -175,8 +173,6 @@ def test_etf_search(params, headers):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "interval": "1d",
-                "adjusted": False,
-                "prepost": False,
             }
         ),
         (

--- a/openbb_platform/extensions/etf/integration/test_etf_python.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_python.py
@@ -156,8 +156,6 @@ def test_etf_search(params, obb):
                 "start_date": "2023-06-01",
                 "end_date": "2023-06-03",
                 "interval": "1h",
-                "adjusted": True,
-                "prepost": False,
             }
         ),
         (
@@ -170,8 +168,6 @@ def test_etf_search(params, obb):
                 "start_date": "2023-01-01",
                 "end_date": "2023-06-06",
                 "interval": "1d",
-                "adjusted": False,
-                "prepost": False,
             }
         ),
         (

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -5871,7 +5871,7 @@
                     {
                         "name": "symbol",
                         "type": "str",
-                        "description": "The date of the data.",
+                        "description": "Symbol representing the entity requested in the data.",
                         "default": null,
                         "optional": true,
                         "choices": null
@@ -25677,22 +25677,6 @@
                         "default": "splits_only",
                         "optional": true,
                         "choices": null
-                    },
-                    {
-                        "name": "adjusted",
-                        "type": "bool",
-                        "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead.",
-                        "default": false,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "prepost",
-                        "type": "bool",
-                        "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead.",
-                        "default": false,
-                        "optional": true,
-                        "choices": null
                     }
                 ]
             },
@@ -28333,22 +28317,6 @@
                         "type": "Literal['splits_only', 'splits_and_dividends']",
                         "description": "The adjustment factor to apply. Default is splits only.",
                         "default": "splits_only",
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "adjusted",
-                        "type": "bool",
-                        "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead.",
-                        "default": false,
-                        "optional": true,
-                        "choices": null
-                    },
-                    {
-                        "name": "prepost",
-                        "type": "bool",
-                        "description": "This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead.",
-                        "default": false,
                         "optional": true,
                         "choices": null
                     }

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -1072,7 +1072,7 @@ class ROUTER_economy(Container):
         children : Optional[str]
             The element_id of each child, as a comma-separated string.
         symbol : Optional[str]
-            The date of the data.
+            Symbol representing the entity requested in the data.
         name : Optional[str]
             The name of the series.
         value : Optional[float]

--- a/openbb_platform/openbb/package/equity_price.py
+++ b/openbb_platform/openbb/package/equity_price.py
@@ -84,10 +84,6 @@ class ROUTER_equity_price(Container):
             The number of data entries to return. (provider: polygon)
         include_actions : bool
             Include dividends and stock splits in results. (provider: yfinance)
-        adjusted : bool
-            This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead. (provider: yfinance)
-        prepost : bool
-            This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead. (provider: yfinance)
 
         Returns
         -------
@@ -188,9 +184,7 @@ class ROUTER_equity_price(Container):
                         "polygon": {"multiple_items_allowed": True},
                         "tiingo": {"multiple_items_allowed": True},
                         "yfinance": {"multiple_items_allowed": True},
-                    },
-                    "adjusted": {"deprecated": True},
-                    "prepost": {"deprecated": True},
+                    }
                 },
             )
         )

--- a/openbb_platform/openbb/package/etf.py
+++ b/openbb_platform/openbb/package/etf.py
@@ -239,10 +239,6 @@ class ROUTER_etf(Container):
             The number of data entries to return. (provider: polygon)
         include_actions : bool
             Include dividends and stock splits in results. (provider: yfinance)
-        adjusted : bool
-            This field is deprecated (4.1.5) and will be removed in a future version. Use 'adjustment' set as 'splits_and_dividends' instead. (provider: yfinance)
-        prepost : bool
-            This field is deprecated (4.1.5) and will be removed in a future version. Use 'extended_hours' as True instead. (provider: yfinance)
 
         Returns
         -------
@@ -345,9 +341,7 @@ class ROUTER_etf(Container):
                         "polygon": {"multiple_items_allowed": True},
                         "tiingo": {"multiple_items_allowed": True},
                         "yfinance": {"multiple_items_allowed": True},
-                    },
-                    "adjusted": {"deprecated": True},
-                    "prepost": {"deprecated": True},
+                    }
                 },
             )
         )

--- a/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
+++ b/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/models/equity_historical.py
@@ -19,7 +19,6 @@ from pydantic import (
     Field,
     NonNegativeFloat,
     PositiveFloat,
-    model_validator,
 )
 
 
@@ -39,29 +38,10 @@ class AVEquityHistoricalQueryParams(EquityHistoricalQueryParams):
         description="The adjustment factor to apply. 'splits_only' is not supported for intraday data.",
         default="splits_only",
     )
-    extended_hours: Optional[bool] = Field(
+    extended_hours: bool = Field(
         description="Include Pre and Post market data.",
         default=False,
     )
-    adjusted: bool = Field(
-        default=False,
-        exclude=True,
-        description="This field is deprecated (4.1.5) and will be removed in a future version."
-        + " Use 'adjustment' set as 'splits_and_dividends' instead.",
-        json_schema_extra={"deprecated": True},
-    )
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_deprecated_params(cls, values):
-        """Validate the deprecated parameters."""
-        for k, v in values.copy().items():
-            if k in ["adjusted"] and v is True:
-                warn(
-                    f"The '{k}' parameter is deprecated and will be removed in a future version."
-                )
-                values["adjustment"] = "splits_and_dividends"
-        return values
 
 
 class AVEquityHistoricalData(EquityHistoricalData):
@@ -287,7 +267,11 @@ class AVEquityHistoricalFetcher(
                         if len(query.symbol.split(",")) > 1:
                             data.loc[:, "symbol"] = symbol
 
-                        results.extend(data.reset_index().to_dict("records"))
+                        data = data.reset_index()
+                        if intraday is False:
+                            data["date"] = data["date"].dt.date
+
+                        results.extend(data.to_dict("records"))
 
             return results
 

--- a/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/utils/helpers.py
+++ b/openbb_platform/providers/alpha_vantage/openbb_alpha_vantage/utils/helpers.py
@@ -77,16 +77,20 @@ def calculate_adjusted_prices(
     # Reverse the DataFrame order, sorting by date in descending order
     df.sort_index(ascending=False, inplace=True)
 
-    price_col = df[column].values
-    split_col = df["volume_factor"] if column == "volume" else df["split_factor"].values
-    dividend_col = df["dividend"].values if dividends else zeros(len(price_col))
+    price_col = df[column]
+    split_col = df["volume_factor"] if column == "volume" else df["split_factor"]
+    dividend_col = df["dividend"] if dividends else zeros(len(price_col))
     adj_price_col = zeros(len(df.index))
-    adj_price_col[0] = price_col[0]
+    adj_price_col[0] = price_col.iloc[0]
 
     for i in range(1, len(price_col)):
         adj_price_col[i] = adj_price_col[i - 1] + adj_price_col[i - 1] * (
-            ((price_col[i] * split_col[i - 1]) - price_col[i - 1] - dividend_col[i - 1])
-            / price_col[i - 1]
+            (
+                (price_col.iloc[i] * split_col.iloc[i - 1])
+                - price_col.iloc[i - 1]
+                - dividend_col[i - 1]
+            )
+            / price_col.iloc[i - 1]
         )
     df[adj_column] = adj_price_col
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_historical.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_historical.py
@@ -14,7 +14,7 @@ from openbb_core.provider.standard_models.equity_historical import (
 from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 from openbb_core.provider.utils.errors import EmptyDataError
 from openbb_yfinance.utils.references import INTERVALS_DICT, PERIODS
-from pydantic import Field, PrivateAttr, model_validator
+from pydantic import Field, PrivateAttr
 
 if TYPE_CHECKING:
     from pandas import DataFrame
@@ -58,20 +58,6 @@ class YFinanceEquityHistoricalQueryParams(EquityHistoricalQueryParams):
         default="splits_only",
         description="The adjustment factor to apply. Default is splits only.",
     )
-    adjusted: bool = Field(
-        default=False,
-        exclude=True,
-        description="This field is deprecated (4.1.5) and will be removed in a future version."
-        + " Use 'adjustment' set as 'splits_and_dividends' instead.",
-        json_schema_extra={"deprecated": True},
-    )
-    prepost: bool = Field(
-        default=False,
-        exclude=True,
-        description="This field is deprecated (4.1.5) and will be removed in a future version."
-        + " Use 'extended_hours' as True instead.",
-        json_schema_extra={"deprecated": True},
-    )
 
     _ignore_tz: bool = PrivateAttr(default=True)
     _progress: bool = PrivateAttr(default=False)
@@ -80,23 +66,6 @@ class YFinanceEquityHistoricalQueryParams(EquityHistoricalQueryParams):
     _rounding: bool = PrivateAttr(default=False)
     _repair: bool = PrivateAttr(default=False)
     _group_by: Literal["ticker", "column"] = PrivateAttr(default="ticker")
-
-    @model_validator(mode="before")
-    @classmethod
-    def validate_deprecated_params(cls, values):
-        """Validate the deprecated parameters."""
-        for k, v in values.copy().items():
-            if k in ["adjusted"] and v is True:
-                warn(
-                    f"The '{k}' parameter is deprecated and will be removed in a future version."
-                )
-                values["adjustment"] = "splits_and_dividends"
-            if k in ["prepost"] and v is True:
-                warn(
-                    f"The '{k}' parameter is deprecated and will be removed in a future version."
-                )
-                values["extended_hours"] = True
-        return values
 
 
 class YFinanceEquityHistoricalData(EquityHistoricalData):
@@ -191,6 +160,14 @@ class YFinanceEquityHistoricalFetcher(
                 if query.include_actions is False
                 else data
             )
+        query_symbols = query.symbol.upper().split(",")
+
+        if len(query_symbols) > 1:
+            symbols = data.symbol.unique().tolist()
+            for symbol in query_symbols:
+                if symbol not in symbols:
+                    warn(f"Data for '{symbol}' was not found.")
+
         return [
             YFinanceEquityHistoricalData.model_validate(d)
             for d in data.to_dict("records")


### PR DESCRIPTION
1. **Why**?:

    - Fields have been deprecated since 4.1.5.

2. **What**?:

    In "yfinance" and "alpha_vantage":
      - "adjusted" -> "adjustment"
    In "yfinance": 
      - "prepost" -> "extended_hours"

3. **Impact**:

    - Old keys will no longer do anything except raise 'param not found' warning.
    - Should be no impact otherwise.

