### PR TITLE
[BugFix] Fix Yfinance Discovery Percent Values

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_performance.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_performance.py
@@ -1,6 +1,6 @@
 """Equity Performance Standard Model."""
 
-from typing import Literal, Optional
+from typing import Literal, Optional, Union
 
 from pydantic import Field, field_validator
 
@@ -30,18 +30,22 @@ class EquityPerformanceData(Data):
     symbol: str = Field(
         description=DATA_DESCRIPTIONS.get("symbol", ""),
     )
-    name: str = Field(
+    name: Optional[str] = Field(
+        default=None,
         description="Name of the entity.",
     )
     price: float = Field(
         description="Last price.",
+        json_schema_extra={"x-unit_measurement": "currency"},
     )
     change: float = Field(
-        description="Change in price value.",
+        description="Change in price.",
+        json_schema_extra={"x-unit_measurement": "currency"},
     )
     percent_change: float = Field(
         description="Percent change.",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    volume: float = Field(
+    volume: Union[int, float] = Field(
         description=DATA_DESCRIPTIONS.get("volume", ""),
     )

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -7855,7 +7855,57 @@
                         "description": "The country to get data. Multiple items allowed for provider(s): oecd.",
                         "default": "united_states",
                         "optional": true,
-                        "choices": null
+                        "choices": [
+                            "belgium",
+                            "bulgaria",
+                            "brazil",
+                            "ireland",
+                            "mexico",
+                            "indonesia",
+                            "new_zealand",
+                            "japan",
+                            "united_kingdom",
+                            "france",
+                            "chile",
+                            "canada",
+                            "netherlands",
+                            "united_states",
+                            "south_korea",
+                            "norway",
+                            "austria",
+                            "south_africa",
+                            "denmark",
+                            "switzerland",
+                            "hungary",
+                            "luxembourg",
+                            "australia",
+                            "germany",
+                            "sweden",
+                            "iceland",
+                            "turkey",
+                            "greece",
+                            "israel",
+                            "czech_republic",
+                            "latvia",
+                            "slovenia",
+                            "poland",
+                            "estonia",
+                            "lithuania",
+                            "portugal",
+                            "costa_rica",
+                            "slovakia",
+                            "finland",
+                            "spain",
+                            "romania",
+                            "russia",
+                            "euro_area19",
+                            "colombia",
+                            "italy",
+                            "india",
+                            "china",
+                            "croatia",
+                            "all"
+                        ]
                     },
                     {
                         "name": "start_date",
@@ -7872,13 +7922,6 @@
                         "default": null,
                         "optional": true,
                         "choices": null
-                    },
-                    {
-                        "name": "provider",
-                        "type": "Literal['oecd']",
-                        "description": "The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: oecd.",
-                        "default": null,
-                        "optional": true
                     }
                 ],
                 "oecd": [
@@ -7888,7 +7931,11 @@
                         "description": "Duration of the interest rate. 'immediate' is the overnight rate, 'short' is the 3-month rate, and 'long' is the 10-year rate.",
                         "default": "short",
                         "optional": true,
-                        "choices": null
+                        "choices": [
+                            "immediate",
+                            "short",
+                            "long"
+                        ]
                     },
                     {
                         "name": "frequency",
@@ -7896,7 +7943,11 @@
                         "description": "Frequency to get interest rate for for.",
                         "default": "monthly",
                         "optional": true,
-                        "choices": null
+                        "choices": [
+                            "monthly",
+                            "quarter",
+                            "annual"
+                        ]
                     }
                 ]
             },
@@ -7933,7 +7984,7 @@
                 "standard": [
                     {
                         "name": "date",
-                        "type": "date",
+                        "type": "Union[date, str]",
                         "description": "The date of the data.",
                         "default": null,
                         "optional": true,
@@ -12062,8 +12113,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12077,7 +12128,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12092,7 +12143,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12101,19 +12152,19 @@
                 ],
                 "yfinance": [
                     {
-                        "name": "market_cap",
-                        "type": "float",
-                        "description": "Market Cap.",
-                        "default": "",
-                        "optional": false,
-                        "choices": null
-                    },
-                    {
                         "name": "avg_volume_3_months",
                         "type": "float",
                         "description": "Average volume over the last 3 months in millions.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "market_cap",
+                        "type": "float",
+                        "description": "Market Cap.",
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12191,8 +12242,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12206,7 +12257,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12221,7 +12272,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12320,8 +12371,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12335,7 +12386,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12350,7 +12401,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12449,8 +12500,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12464,7 +12515,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12479,7 +12530,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12578,8 +12629,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12593,7 +12644,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12608,7 +12659,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12707,8 +12758,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12722,7 +12773,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12737,7 +12788,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -12836,8 +12887,8 @@
                         "name": "name",
                         "type": "str",
                         "description": "Name of the entity.",
-                        "default": "",
-                        "optional": false,
+                        "default": null,
+                        "optional": true,
                         "choices": null
                     },
                     {
@@ -12851,7 +12902,7 @@
                     {
                         "name": "change",
                         "type": "float",
-                        "description": "Change in price value.",
+                        "description": "Change in price.",
                         "default": "",
                         "optional": false,
                         "choices": null
@@ -12866,7 +12917,7 @@
                     },
                     {
                         "name": "volume",
-                        "type": "float",
+                        "type": "Union[int, float]",
                         "description": "The trading volume.",
                         "default": "",
                         "optional": false,
@@ -27192,13 +27243,6 @@
                         "default": null,
                         "optional": true,
                         "choices": null
-                    },
-                    {
-                        "name": "provider",
-                        "type": "Literal['fmp']",
-                        "description": "The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: fmp.",
-                        "default": null,
-                        "optional": true
                     }
                 ],
                 "fmp": []
@@ -27236,7 +27280,7 @@
                 "standard": [
                     {
                         "name": "date",
-                        "type": "date",
+                        "type": "Union[date, str]",
                         "description": "The date of the data.",
                         "default": "",
                         "optional": false,

--- a/openbb_platform/openbb/package/economy.py
+++ b/openbb_platform/openbb/package/economy.py
@@ -2270,9 +2270,9 @@ class ROUTER_economy(Container):
         ----------
         country : Union[str, List[str]]
             The country to get data. Multiple comma separated items allowed for provider(s): oecd.
-        start_date : Union[datetime.date, None, str]
+        start_date : Union[date, None, str]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Union[datetime.date, None, str]
+        end_date : Union[date, None, str]
             End date of the data, in YYYY-MM-DD format.
         provider : Optional[Literal['oecd']]
             The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: oecd.

--- a/openbb_platform/openbb/package/equity.py
+++ b/openbb_platform/openbb/package/equity.py
@@ -106,9 +106,9 @@ class ROUTER_equity(Container):
         ----------
         symbol : Union[str, List[str]]
             Symbol to get data for. Multiple comma separated items allowed for provider(s): fmp.
-        start_date : Union[datetime.date, None, str]
+        start_date : Union[date, None, str]
             Start date of the data, in YYYY-MM-DD format.
-        end_date : Union[datetime.date, None, str]
+        end_date : Union[date, None, str]
             End date of the data, in YYYY-MM-DD format.
         provider : Optional[Literal['fmp']]
             The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: fmp.
@@ -158,7 +158,9 @@ class ROUTER_equity(Container):
                     "end_date": end_date,
                 },
                 extra_params=kwargs,
-                info={"symbol": {"fmp": {"multiple_items_allowed": True}}},
+                info={
+                    "symbol": {"fmp": {"multiple_items_allowed": True, "choices": None}}
+                },
             )
         )
 

--- a/openbb_platform/openbb/package/equity_discovery.py
+++ b/openbb_platform/openbb/package/equity_discovery.py
@@ -71,15 +71,15 @@ class ROUTER_equity_discovery(Container):
         ------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap displayed in billions. (provider: yfinance)
@@ -157,15 +157,15 @@ class ROUTER_equity_discovery(Container):
         -------------------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap. (provider: yfinance)
@@ -352,20 +352,20 @@ class ROUTER_equity_discovery(Container):
         -------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
-        market_cap : Optional[float]
-            Market Cap. (provider: yfinance)
         avg_volume_3_months : Optional[float]
             Average volume over the last 3 months in millions. (provider: yfinance)
+        market_cap : Optional[float]
+            Market Cap. (provider: yfinance)
         pe_ratio_ttm : Optional[float]
             PE Ratio (TTM). (provider: yfinance)
 
@@ -438,15 +438,15 @@ class ROUTER_equity_discovery(Container):
         ------------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap. (provider: yfinance)
@@ -524,15 +524,15 @@ class ROUTER_equity_discovery(Container):
         ------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap. (provider: yfinance)
@@ -610,15 +610,15 @@ class ROUTER_equity_discovery(Container):
         -----------------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap. (provider: yfinance)
@@ -696,15 +696,15 @@ class ROUTER_equity_discovery(Container):
         --------------------------
         symbol : str
             Symbol representing the entity requested in the data.
-        name : str
+        name : Optional[str]
             Name of the entity.
         price : float
             Last price.
         change : float
-            Change in price value.
+            Change in price.
         percent_change : float
             Percent change.
-        volume : float
+        volume : Union[int, float]
             The trading volume.
         market_cap : Optional[float]
             Market Cap. (provider: yfinance)

--- a/openbb_platform/providers/tmx/openbb_tmx/models/gainers.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/gainers.py
@@ -44,6 +44,13 @@ STOCK_LISTS = Literal[
 class TmxGainersQueryParams(EquityPerformanceQueryParams):
     """TMX Gainers Query Params."""
 
+    __json_schema_extra__ = {
+        "category": {
+            "multiple_items_allowed": False,
+            "choices": list(STOCK_LISTS_DICT),
+        },
+    }
+
     category: STOCK_LISTS = Field(
         default="price_performer",
         description="The category of list to retrieve. Defaults to `price_performer`.",
@@ -63,6 +70,25 @@ class TmxGainersData(EquityPerformanceData):
         "avg_volume_10d": "10 Day Avg. Volume",
         "ninety_day_price_change": "90 Day Price Change",
     }
+    thirty_day_price_change: Optional[float] = Field(
+        default=None,
+        description="30 Day Price Change.",
+        json_schema_extra={"x-unit_measurement": "currency"},
+    )
+    ninety_day_price_change: Optional[float] = Field(
+        default=None,
+        description="90 Day Price Change.",
+        json_schema_extra={"x-unit_measurement": "currency"},
+    )
+    dividend_yield: Optional[float] = Field(
+        default=None,
+        description="Dividend Yield.",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
+    )
+    avg_volume_10d: Optional[float] = Field(
+        default=None,
+        description="10 Day Avg. Volume.",
+    )
     rank: int = Field(description="The rank of the stock in the list.")
 
     @field_validator("percent_change", mode="after", check_fields=False)

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/gainers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/gainers.py
@@ -37,15 +37,18 @@ class YFGainersData(EquityPerformanceData):
         "pe_ratio_ttm": "PE Ratio (TTM)",
     }
 
-    market_cap: Optional[float] = Field(
-        description="Market Cap.",
-    )
     avg_volume_3_months: Optional[float] = Field(
+        default=None,
         description="Average volume over the last 3 months in millions.",
     )
-    pe_ratio_ttm: Optional[float] = Field(
-        description="PE Ratio (TTM).",
+    market_cap: Optional[float] = Field(
         default=None,
+        description="Market Cap.",
+        json_schema_extra={"x-unit_measurement": "currency"},
+    )
+    pe_ratio_ttm: Optional[float] = Field(
+        default=None,
+        description="PE Ratio (TTM).",
     )
 
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -411,7 +411,7 @@ def df_transform_numbers(data: "DataFrame", columns: list) -> "DataFrame":
 
     for col in columns:
         if col == "% Change":
-            data[col] = data[col].astype(str).str.replace("%", "").astype(float)
+            data[col] = data[col].astype(str).str.replace("%", "").astype(float) / 100
         else:
             for suffix, multiplier in multipliers.items():
                 data[col] = data[col].apply(replace_suffix, args=(suffix, multiplier))

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
@@ -33,4 +33,4 @@ def test_df_transform_numbers():
     )
     transformed = df_transform_numbers(data, ["Value", "% Change"])
     assert transformed["Value"].equals(pd.Series([1e6, 2.5e9, 3e12]))
-    assert transformed["% Change"].equals(pd.Series([1.0, -2.0, 3.5]))
+    assert transformed["% Change"].equals(pd.Series([1/100, -2/100, 3.5/100]))


### PR DESCRIPTION
1. **Why**?:

    - Percent values not returned consistent with the rest of the Platform.

2. **What**?:

    - Fixes in the helper function.

    - Updates model definitions.

    - Rebuilt statics.

3. **Impact**:

    - More consistent output.

    - Increased clarity in the schemas.

4. **Testing Done**:

    - Before/after with "percent_change" field.
