### PR TITLE
[BugFix] VIX Curve - fixes `reset_index` erasing the name of the field.

### DIFF
--- a/openbb_platform/providers/cboe/openbb_cboe/utils/vix.py
+++ b/openbb_platform/providers/cboe/openbb_cboe/utils/vix.py
@@ -146,6 +146,7 @@ async def get_vx_current(
         ]
         df = df.set_index("symbol")
         df = df.filter(items=current_symbols, axis=0).reset_index()
+        df = df.rename(columns={"index": "symbol"})
 
     expirations: List = []
     for month in current_months:


### PR DESCRIPTION
1. **Why**?:

   - In, `obb.derivatives.futures.curve("VX", provider="cboe")`, a column was unexpectedly being renamed as "index" after being reset.

2. **What**?:

    - Renames the "index" column where it should already have been "symbol". 

3. **Impact**:

    - Unclear if this is actually the expected behavior from Pandas. 

4. **Testing Done**:

    - Before/After: `obb.derivatives.futures.curve("VX", provider="cboe")`
