### PR TITLE
[BugFix] Fix Pandas FutureWarning In `derivatives.futures.curve` Chart

### DIFF
--- a/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
@@ -107,9 +107,7 @@ class DerivativesViews:
 
         provider = kwargs.get("provider", "")
 
-        df["expiration"] = df["expiration"].apply(to_datetime).dt.strftime(
-            "%b-%Y"
-        )
+        df["expiration"] = df["expiration"].apply(to_datetime).dt.strftime("%b-%Y")
 
         if (
             provider == "cboe"

--- a/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
@@ -107,7 +107,7 @@ class DerivativesViews:
 
         provider = kwargs.get("provider", "")
 
-        df["expiration"] = to_datetime(df["expiration"], errors="ignore").dt.strftime(
+        df["expiration"] = df["expiration"].apply(to_datetime).dt.strftime(
             "%b-%Y"
         )
 


### PR DESCRIPTION
1. **Why**?:

```
obb.derivatives.futures.curve("vx", chart=True)

/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py:110: FutureWarning:

errors='ignore' is deprecated and will raise in a future version. Use to_datetime without passing `errors` and catch exceptions explicitly instead
```

2. **What**?:

    - Use `col.apply(to_datetime)` instead.
