### PR TITLE
[BugFix] Replace `Optional[bool]` with `bool` as type in Equity Search

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/equity_search.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/equity_search.py
@@ -16,10 +16,6 @@ class EquitySearchQueryParams(QueryParams):
     is_symbol: bool = Field(
         description="Whether to search by ticker symbol.", default=False
     )
-    use_cache: Optional[bool] = Field(
-        default=True,
-        description="Whether to use the cache or not.",
-    )
 
 
 class EquitySearchData(Data):

--- a/openbb_platform/extensions/equity/integration/test_equity_api.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_api.py
@@ -1391,7 +1391,7 @@ def test_equity_fundamental_latest_attributes(params, headers):
     [
         ({"query": "AAPl", "is_symbol": True, "provider": "cboe", "use_cache": False}),
         ({"query": "Apple", "provider": "sec", "use_cache": False, "is_fund": False}),
-        ({"query": "", "provider": "nasdaq", "use_cache": False, "is_etf": True}),
+        ({"query": "", "provider": "nasdaq", "is_etf": True}),
         ({"query": "gold", "provider": "tmx", "use_cache": False}),
         ({"query": "gold", "provider": "tradier", "is_symbol": False}),
         (
@@ -1400,7 +1400,6 @@ def test_equity_fundamental_latest_attributes(params, headers):
                 "provider": "intrinio",
                 "active": True,
                 "limit": 100,
-                "use_cache": None,
             }
         ),
     ],

--- a/openbb_platform/extensions/equity/integration/test_equity_python.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_python.py
@@ -1329,7 +1329,7 @@ def test_equity_fundamental_latest_attributes(params, obb):
     [
         ({"query": "AAPL", "is_symbol": True, "provider": "cboe", "use_cache": False}),
         ({"query": "Apple", "provider": "sec", "use_cache": False, "is_fund": False}),
-        ({"query": "", "provider": "nasdaq", "use_cache": False, "is_etf": True}),
+        ({"query": "", "provider": "nasdaq", "is_etf": True}),
         ({"query": "gold", "provider": "tmx", "use_cache": False}),
         ({"query": "gold", "provider": "tradier", "is_symbol": False}),
         (
@@ -1338,7 +1338,6 @@ def test_equity_fundamental_latest_attributes(params, obb):
                 "provider": "intrinio",
                 "active": True,
                 "limit": 100,
-                "use_cache": None,
             }
         ),
     ],

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -25749,14 +25749,6 @@
                         "default": false,
                         "optional": true,
                         "choices": null
-                    },
-                    {
-                        "name": "use_cache",
-                        "type": "bool",
-                        "description": "Whether to use the cache or not.",
-                        "default": true,
-                        "optional": true,
-                        "choices": null
                     }
                 ],
                 "intrinio": [
@@ -25778,6 +25770,14 @@
                     }
                 ],
                 "sec": [
+                    {
+                        "name": "use_cache",
+                        "type": "bool",
+                        "description": "Whether to use the cache or not.",
+                        "default": true,
+                        "optional": true,
+                        "choices": null
+                    },
                     {
                         "name": "is_fund",
                         "type": "bool",

--- a/openbb_platform/openbb/package/equity.py
+++ b/openbb_platform/openbb/package/equity.py
@@ -662,9 +662,6 @@ class ROUTER_equity(Container):
         is_symbol: Annotated[
             bool, OpenBBField(description="Whether to search by ticker symbol.")
         ] = False,
-        use_cache: Annotated[
-            Optional[bool], OpenBBField(description="Whether to use the cache or not.")
-        ] = True,
         provider: Annotated[
             Optional[Literal["intrinio", "sec"]],
             OpenBBField(
@@ -681,14 +678,14 @@ class ROUTER_equity(Container):
             Search query.
         is_symbol : bool
             Whether to search by ticker symbol.
-        use_cache : Optional[bool]
-            Whether to use the cache or not.
         provider : Optional[Literal['intrinio', 'sec']]
             The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: intrinio, sec.
-        active : Optional[bool]
+        active : bool
             When true, return companies that are actively traded (having stock prices within the past 14 days). When false, return companies that are not actively traded or never have been traded. (provider: intrinio)
         limit : Optional[int]
             The number of data entries to return. (provider: intrinio)
+        use_cache : bool
+            Whether to use the cache or not. (provider: sec)
         is_fund : bool
             Whether to direct the search to the list of mutual funds and ETFs. (provider: sec)
 
@@ -739,7 +736,6 @@ class ROUTER_equity(Container):
                 standard_params={
                     "query": query,
                     "is_symbol": is_symbol,
-                    "use_cache": use_cache,
                 },
                 extra_params=kwargs,
             )

--- a/openbb_platform/providers/cboe/openbb_cboe/models/equity_search.py
+++ b/openbb_platform/providers/cboe/openbb_cboe/models/equity_search.py
@@ -18,6 +18,11 @@ class CboeEquitySearchQueryParams(EquitySearchQueryParams):
     Source: https://www.cboe.com/
     """
 
+    use_cache: bool = Field(
+        default=True,
+        description="Whether to use the cache or not.",
+    )
+
 
 class CboeEquitySearchData(EquitySearchData):
     """CBOE Equity Search Data."""

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_search.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_search.py
@@ -26,7 +26,7 @@ class IntrinioEquitySearchQueryParams(EquitySearchQueryParams):
         "limit": "page_size",
     }
 
-    active: Optional[bool] = Field(
+    active: bool = Field(
         default=True,
         description="When true, return companies that are actively traded (having stock prices within the past 14 days)."
         + " When false, return companies that are not actively traded or never have been traded.",

--- a/openbb_platform/providers/intrinio/tests/record/http/test_intrinio_fetchers/test_intrinio_equity_search_fetcher_urllib3_v1.yaml
+++ b/openbb_platform/providers/intrinio/tests/record/http/test_intrinio_fetchers/test_intrinio_equity_search_fetcher_urllib3_v1.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://api-v2.intrinio.com/companies/search?active=True&api_key=MOCK_API_KEY&page_size=100&query=gold&use_cache=True
+    uri: https://api-v2.intrinio.com/companies/search?active=True&api_key=MOCK_API_KEY&page_size=100&query=gold
   response:
     body:
       string: !!binary |

--- a/openbb_platform/providers/intrinio/tests/record/http/test_intrinio_fetchers/test_intrinio_equity_search_fetcher_urllib3_v2.yaml
+++ b/openbb_platform/providers/intrinio/tests/record/http/test_intrinio_fetchers/test_intrinio_equity_search_fetcher_urllib3_v2.yaml
@@ -9,7 +9,7 @@ interactions:
       Connection:
       - keep-alive
     method: GET
-    uri: https://api-v2.intrinio.com/companies/search?active=True&api_key=MOCK_API_KEY&page_size=100&query=gold&use_cache=True
+    uri: https://api-v2.intrinio.com/companies/search?active=True&api_key=MOCK_API_KEY&page_size=100&query=gold
   response:
     body:
       string: !!binary |

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=unused-argument
 
-from typing import Any, Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 
 from openbb_core.app.model.abstract.error import OpenBBError
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -19,7 +19,7 @@ class NasdaqEquitySearchQueryParams(EquitySearchQueryParams):
     Source: https://www.nasdaqtrader.com/dynamic/SymDir/nasdaqtraded.txt
     """
 
-    is_etf: Optional[bool] = Field(
+    is_etf: Union[bool, None] = Field(
         default=None,
         description="If True, returns ETFs.",
     )

--- a/openbb_platform/providers/sec/openbb_sec/models/equity_search.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/equity_search.py
@@ -18,6 +18,10 @@ class SecEquitySearchQueryParams(EquitySearchQueryParams):
     Source: https://sec.gov/
     """
 
+    use_cache: bool = Field(
+        default=True,
+        description="Whether to use the cache or not.",
+    )
     is_fund: bool = Field(
         default=False,
         description="Whether to direct the search to the list of mutual funds and ETFs.",


### PR DESCRIPTION
1. **Why**?:

    - OpenAPI prefers `bool` when it is not an `Optional[bool]`.
    - `use_cache` shouldn't be a standard param.

2. **What**?:

    - Move `use_cache` to the provider models.

    - Remove Optional from the boolean arguments

3. **Impact**:

    - More consistent schema.
    - Should have no impact real impact other than better `openapi.json` representations.
