### PR TITLE
[BugFix] Allow lowercase `symbol` for EconDB EconomicIndicators

### DIFF
--- a/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
+++ b/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
@@ -201,7 +201,7 @@ class EconDbEconomicIndicatorsFetcher(
         new_symbols: List = []
         # We need to join country, symbol, and transformation
         # for every combination of country and symbol.
-        for symbol in symbols:
+        for s in symbols:
             # We will assume that if the symbol has a '~' in it,
             # the user knows what they are doing. We don't want to
             # match this defined symbol with any supplied country, and we need to
@@ -210,9 +210,10 @@ class EconDbEconomicIndicatorsFetcher(
             # and return the symbol as 'level' if it is not.
             # We will also check if the symbol should have a country,
             # and if one was supplied.
+            symbol = s.upper()
             if "~" in symbol:
-                _symbol = symbol.split("~")[0].upper()
-                _transform = symbol.split("~")[1].upper()
+                _symbol = symbol.split("~")[0]
+                _transform = symbol.split("~")[1]
                 if (
                     helpers.HAS_COUNTRIES.get(_symbol) is True
                     and _symbol in helpers.SYMBOL_TO_INDICATOR.values()
@@ -275,7 +276,9 @@ class EconDbEconomicIndicatorsFetcher(
             ):
                 new_symbols.append(symbol)
         if not new_symbols:
-            symbol_message = helpers.INDICATOR_COUNTRIES.get(query.symbol, "None")
+            symbol_message = helpers.INDICATOR_COUNTRIES.get(
+                query.symbol.upper(), "None"
+            )
             error_message = (
                 "No valid combination of indicator symbols and countries were supplied."
                 + f"\nValid countries for '{query.symbol}' are: {symbol_message}"


### PR DESCRIPTION
1. **Why**?:

    - Allows lowercase symbols through - i.e, 'gdp'.

2. **What**?:

    - Ensure that a lowercase symbol is not scoped into the actual symbol formation stage.

3. **Impact**:

    - Allows lowercase symbols - `gdp` - to be entered.
    - Other behavior remains the same.

4. **Testing Done**:

Before:

```python
obb.economy.indicators(symbol="gdp")
```

```
OpenBBError: No valid combination of indicator symbols and countries were supplied.
Valid countries for 'gdp' are: None
If the symbol - gdp - is missing a country code. Please add the two-letter country code or use the country parameter.
If already included, add '~' to the end of the symbol.
```

After:

![Screenshot 2024-08-26 at 5 32 06 PM](https://github.com/user-attachments/assets/77fbf56e-6497-4349-a143-5ba73793708e)
