### PR TITLE
[BugFix] Fix Date In Output Of `yfinance.download` For Google Colab

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -355,6 +355,9 @@ def yf_download(
             threads=False,
             **kwargs,
         )
+        if hasattr(data.index, "tz") and data.index.tz is not None:
+            data = data.tz_convert(None)
+
     except ValueError as exc:
         raise EmptyDataError() from exc
 


### PR DESCRIPTION
1. **Why**?:

    - This fixes an edge case where something in the Google Colabs environment is inserting UTC TZ to the output of `yfinance.download` which is raising errors because of unexpected formatting.
    - This behavior seems to be specific to Colab.

2. **What**?:

    - At the direct output of `yfinance.download`, adds a check for the index to remove the TZ, if it is there.

3. **Impact**:

    - Historical prices from `openbb-yfinance` in Colab environment works.

4. **Testing Done**:

    - This can only be tested directly in Colab, by editing the files - use OPENBB_DEBUG_MODE='true' - to enable traceback.

This screenshot demonstrates the difference in dType between expected and Colab. Note the "x" in the Colab cell that fails because of unexpected TZ information when filtering for date ranges.

![Screenshot 2024-08-27 at 5 01 09 PM](https://github.com/user-attachments/assets/85da2e9b-e874-403a-ad93-486e4857f48e)

This screenshot is the repair in action.

<img width="1660" alt="Screenshot 2024-08-27 at 6 55 20 PM" src="https://github.com/user-attachments/assets/3020ec3c-391c-4f5b-ba6d-765cd6e07e66">

