### PR TITLE
Adding example on how to urn OpenBB in Apache Beam pipelineadding beam sample

### DIFF
--- a/examples/openbb-apachebeam/README.txt
+++ b/examples/openbb-apachebeam/README.txt
@@ -1,0 +1,12 @@
+#### Obb Dataflow sample
+
+
+This is a sample how to  invoke OBB fetchers in an Apache Beam pipeline. (GCP dataflow is build on Apache Beam)
+-- Pre-requisite
+# You need to create a Conda environment (or a virtual env) using requirements.txt in this directory
+# The script exercise 3 OBB endpoints, all of which require no credentials
+# Run the test from the main directory
+  (obb-dataflow) C:\Users\Marco And Sofia\tmp\OBBDataflowSample>python -m unittest discover
+
+# The script will run a pipeline consisting of 3 task which will fetch AAPL quote, profile and news
+# This is just a very basic sample which can be used as building block to create more complex scenarios

--- a/examples/openbb-apachebeam/requirements.txt
+++ b/examples/openbb-apachebeam/requirements.txt
@@ -1,0 +1,2 @@
+apache-beam
+openbb==4.3.1

--- a/examples/openbb-apachebeam/tests/test_obb_pipeline.py
+++ b/examples/openbb-apachebeam/tests/test_obb_pipeline.py
@@ -1,0 +1,49 @@
+import unittest
+import os
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.options.pipeline_options import PipelineOptions
+import asyncio
+import apache_beam as beam
+from openbb_yfinance.models.equity_quote import YFinanceEquityQuoteFetcher as quote_fetcher
+from openbb_yfinance.models.equity_profile import YFinanceEquityProfileFetcher as profile_fetcher
+from openbb_yfinance.models.company_news import YFinanceCompanyNewsFetcher as news_fetcher
+
+
+class AsyncProcess(beam.DoFn):
+
+    def __init__(self, credentials, fetcher):
+        self.credentials = credentials
+        self.fetcher = fetcher
+
+    async def fetch_data(self, element: str):
+        params = dict(symbol=element)
+        data = await self.fetcher.fetch_data(params, self.credentials)
+        return [d.model_dump(exclude_none=True) for d in data]
+
+    def process(self, element: str):
+        return asyncio.run(self.fetch_data(element))
+
+class MyTestCase(unittest.TestCase):
+
+
+    def test_sample_pipeline(self):
+        credentials = {} # Running OBB endpoints which do not require credentials
+        debug_sink = beam.Map(print)
+        ticker = 'AAPL'
+
+        with TestPipeline(options=PipelineOptions()) as p:
+            quote = (p | 'Start Quote' >> beam.Create([ticker])
+                     | 'Run Quote' >> beam.ParDo(AsyncProcess(credentials, quote_fetcher))
+                     | 'Print quote' >> debug_sink)
+
+            profile = (p | 'Start Profile' >> beam.Create([ticker])
+                     | 'Run Profile' >> beam.ParDo(AsyncProcess(credentials, profile_fetcher))
+                     | 'Print profile' >> debug_sink)
+
+            news = (p | 'Start News' >> beam.Create([ticker])
+                       | 'Run News' >> beam.ParDo(AsyncProcess(credentials, news_fetcher))
+                       | 'Print nes' >> debug_sink)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/openbb_platform/providers/government_us/openbb_government_us/models/senate_disclosures.py
+++ b/openbb_platform/providers/government_us/openbb_government_us/models/senate_disclosures.py
@@ -1,0 +1,95 @@
+from typing import Any, Dict, List, Literal, Optional
+
+from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.abstract.query_params import QueryParams
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.utils.errors import EmptyDataError
+from pydantic import Field
+import asyncio
+from warnings import warn
+class USSenateDisclosuresQueryParams(QueryParams):
+    """US Senate Disclosures."""
+    num_reports: Optional[int] = Field(description="Number of disclosures to fetch.", default=30)
+
+class USSenateDisclosuresData(Data):
+    """US Senate Disclosures Data."""
+    __alias_dict__ = {
+        "tx_date": "transaction_date",
+        "tx_amount": "transaction_amount"
+    }
+
+class USSenateDisclosuresFetcher(
+    Fetcher[
+        USSenateDisclosuresQueryParams,
+        List[USSenateDisclosuresData],
+    ]
+):
+    """US Government Treasury Prices Fetcher."""
+
+    @staticmethod
+    def transform_query(
+        params: Dict[str, Any]
+    ) -> USSenateDisclosuresQueryParams:
+        """Transform query params."""
+        # pylint: disable=import-outside-toplevel
+        from datetime import date, timedelta
+
+        today = date.today()
+        last_bd = (
+            today - timedelta(today.weekday() - 4) if today.weekday() > 4 else today
+        )
+        if params.get("date") is None:
+            params["date"] = last_bd
+        return USSenateDisclosuresQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: USSenateDisclosuresQueryParams,
+        credentials: Optional[Dict[str, str]],
+        **kwargs: Any,
+    ) -> str:
+        """Extract the raw data from US Treasury website."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_government_us.utils.senate_helpers import get_transactions
+
+        num_reports = query.num_reports
+        results = []
+
+        async def get_one(num_records):
+            """Get data for one symbol."""
+            result = await get_transactions(num_reports)
+            if not result:
+                warn(f"Symbol Error: No data found for Senate Disclosures")
+
+            if result:
+                for r in result:
+                    results.append(r)
+
+        await asyncio.gather(get_one(num_reports))
+
+        if not results:
+            raise EmptyDataError("No data found for the given symbols.")
+
+
+    @staticmethod
+    def transform_data(
+        query: USSenateDisclosuresQueryParams,
+        data :List[Dict],
+        **kwargs: Any,
+    ) -> List[USSenateDisclosuresData]:
+        """Transform the data."""
+        # pylint: disable=import-outside-toplevel
+        from io import StringIO  # noqa
+        from pandas import Index, read_csv, to_datetime  # noqa
+
+        try:
+            if not data:
+                raise EmptyDataError("Data not found")
+        except Exception as e:
+            raise OpenBBError(e) from e
+
+        return [
+            USSenateDisclosuresData.model_validate(d)
+            for d in data
+        ]

--- a/openbb_platform/providers/government_us/openbb_government_us/utils/runner.py
+++ b/openbb_platform/providers/government_us/openbb_government_us/utils/runner.py
@@ -1,0 +1,10 @@
+
+from openbb_government_us.models.senate_disclosures import USSenateDisclosuresFetcher, USSenateDisclosuresQueryParams
+import asyncio
+
+
+def run_fetcher():
+    params = USSenateDisclosuresQueryParams()
+    params.num_reports = 5
+    return USSenateDisclosuresFetcher.extract_data(params, {})
+

--- a/openbb_platform/providers/government_us/openbb_government_us/utils/senate_constants.py
+++ b/openbb_platform/providers/government_us/openbb_government_us/utils/senate_constants.py
@@ -1,0 +1,22 @@
+ROOT = "https://efdsearch.senate.gov"
+LANDING_PAGE_URL = "{}/search/home/".format(ROOT)
+SEARCH_PAGE_URL = "{}/search/".format(ROOT)
+REPORTS_URL = "{}/search/report/data/".format(ROOT)
+
+PDF_PREFIX = "/search/view/paper/"
+LANDING_PAGE_FAIL = "Failed to fetch filings landing page"
+
+BATCH_SIZE = 100
+
+REPORT_COL_NAMES = [
+    "tx_date",
+    "file_date",
+    "last_name",
+    "first_name",
+    "order_type",
+    "ticker",
+    "asset_name",
+    "asset_type",
+    "tx_amount",
+    "notes",
+]

--- a/openbb_platform/providers/government_us/openbb_government_us/utils/senate_helpers.py
+++ b/openbb_platform/providers/government_us/openbb_government_us/utils/senate_helpers.py
@@ -1,0 +1,185 @@
+import aiohttp
+import asyncio
+
+import pandas as pd
+from bs4 import BeautifulSoup
+from typing import Any, List, Optional
+from openbb_government_us.utils.senate_constants import LANDING_PAGE_URL, LANDING_PAGE_FAIL, SEARCH_PAGE_URL, REPORTS_URL,\
+                ROOT, REPORT_COL_NAMES, PDF_PREFIX, BATCH_SIZE
+
+async def _csrf(client: aiohttp.ClientSession) -> str:
+    """Set the session ID and return the CSRF token for this session."""
+    async with client.get(LANDING_PAGE_URL) as landing_page_response:
+        landing_page_text = await landing_page_response.text()
+        landing_page = BeautifulSoup(landing_page_text, "lxml")
+        form_csrf = landing_page.find(attrs={"name": "csrfmiddlewaretoken"})["value"]
+        form_payload = {"csrfmiddlewaretoken": form_csrf, "prohibition_agreement": "1"}
+        await client.post(
+            LANDING_PAGE_URL, data=form_payload, headers={"Referer": LANDING_PAGE_URL}
+        )
+
+    cookies = client.cookie_jar.filter_cookies(LANDING_PAGE_URL)
+    csrftoken = cookies.get("csrftoken") or cookies.get("csrf")
+    return csrftoken.value if csrftoken else None
+
+
+async def get_total_reports(client: aiohttp.ClientSession, token: str) -> int:
+    """Fetch the total number of reports to determine the number of batches."""
+    login_data = {
+        "start": "0",
+        "length": "100",
+        "report_types": "[11]",
+        "filer_types": "[]",
+        "submitted_start_date": "01/01/2012 00:00:00",
+        "submitted_end_date": "",
+        "candidate_state": "",
+        "senator_state": "",
+        "office_id": "",
+        "first_name": "",
+        "last_name": "",
+        "csrfmiddlewaretoken": token,
+    }
+    async with client.post(
+        REPORTS_URL, data=login_data, headers={"Referer": SEARCH_PAGE_URL}
+    ) as response:
+        response_json = await response.json()
+    return response_json["recordsTotal"]
+
+
+async def senator_reports(client: aiohttp.ClientSession) -> List[List[str]]:
+    """Return all results from the periodic transaction reports API."""
+    token = await _csrf(client)
+    total_reports = await get_total_reports(client, token)
+    num_batches = (
+        total_reports + BATCH_SIZE - 1
+    ) // BATCH_SIZE  # Calculate the number of batches
+
+    tasks = [reports_api(client, idx * BATCH_SIZE, token) for idx in range(num_batches)]
+
+    # Gather all tasks and collect results
+    results = await asyncio.gather(*tasks)
+    all_reports = [report for batch in results for report in batch]
+
+    return all_reports
+
+
+async def reports_api(
+    client: aiohttp.ClientSession, offset: int, token: str
+) -> List[List[str]]:
+    """Query the periodic transaction reports API."""
+    login_data = {
+        "start": str(offset),
+        "length": str(BATCH_SIZE),
+        "report_types": "[11]",
+        "filer_types": "[]",
+        "submitted_start_date": "01/01/2012 00:00:00",
+        "submitted_end_date": "",
+        "candidate_state": "",
+        "senator_state": "",
+        "office_id": "",
+        "first_name": "",
+        "last_name": "",
+        "csrfmiddlewaretoken": token,
+    }
+    async with client.post(
+        REPORTS_URL, data=login_data, headers={"Referer": SEARCH_PAGE_URL}
+    ) as response:
+        response_json = await response.json()
+    return response_json["data"]
+
+
+async def _tbody_from_link(
+    client: aiohttp.ClientSession, link: str, token: str
+) -> Optional[Any]:
+    """
+    Return the tbody element containing transactions for this senator.
+    Return None if no such tbody element exists.
+    """
+    report_url = "{0}{1}".format(ROOT, link)
+    async with client.get(report_url) as report_response:
+        # If the page is redirected, then the session ID has expired
+        if report_response.url == LANDING_PAGE_URL:
+            token = await _csrf(client)  # pylint: disable=unused-variable # noqa
+            async with client.get(report_url) as report_response:
+                report_text = await report_response.text()
+        else:
+            report_text = await report_response.text()
+
+    report = BeautifulSoup(report_text, "lxml")
+    tbodies = report.find_all("tbody")
+    if len(tbodies) == 0:
+        return None
+    return tbodies[0]
+
+
+async def txs_for_report(
+    client: aiohttp.ClientSession, row: List[str], token: str
+) -> pd.DataFrame:
+    """
+    Convert a row from the periodic transaction reports API to a DataFrame
+    of transactions.
+    """
+    first, last, _, link_html, date_received = row
+    link = BeautifulSoup(link_html, "lxml").a.get("href")
+    # We cannot parse PDFs
+    if link[: len(PDF_PREFIX)] == PDF_PREFIX:
+        return pd.DataFrame()
+
+    tbody = await _tbody_from_link(client, link, token)
+    if not tbody:
+        return pd.DataFrame()
+
+    stocks = []
+    for table_row in tbody.find_all("tr"):
+        cols = [c.get_text() for c in table_row.find_all("td")]
+        tx_date, ticker, asset_name, asset_type, order_type, tx_amount, description = (
+            cols[1],
+            cols[3],
+            cols[4],
+            cols[5],
+            cols[6],
+            cols[7],
+            cols[8],
+        )
+        stocks.append(
+            [
+                tx_date,
+                date_received,
+                last,
+                first,
+                order_type,
+                ticker,
+                asset_name,
+                asset_type,
+                tx_amount,
+                description,
+            ]
+        )
+    df = pd.DataFrame(stocks, columns=REPORT_COL_NAMES)
+    for col in df:
+        df[col] = df[col].apply(lambda x: x.replace("\n", "").replace(",", "").strip())
+
+    return df
+
+
+async def fetch_all_txs(
+    client: aiohttp.ClientSession, reports: List[List[str]], token: str
+) -> pd.DataFrame:
+    """Fetch all transactions concurrently."""
+    tasks = [txs_for_report(client, row, token) for row in reports]
+    all_transactions = await asyncio.gather(*tasks)
+    all_transactions_df = pd.concat(all_transactions, ignore_index=True)
+    return all_transactions_df.to_dict('records')
+
+
+async def get_transactions(num_reports:int):
+    session = aiohttp.ClientSession()
+    token = await _csrf(session)
+    reports = await senator_reports(session)
+
+    return await fetch_all_txs(session, reports[:num_reports], token)
+
+def senate_runner(num_reports:int = 10):
+    with asyncio.Runner() as runner:
+        print(runner.run(get_transactions(num_reports=num_reports)))
+


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

- Example on running OpenBB codebase on Apache Beam
- OpenBB can be leveraged to run in an automated mode by running on Apache Beam in 
  a series of pipelines so that the same data you would retrieve via Terminal or OpenBB GUI can be fetched
  automatically by running the same code in an Apache Beam pipeline.
  GCP dataflow currently supports Apache Beam so the entire code could theoretically be run on cloud.
  There will be  limitations, of course, such as the fact that Beam runs pipeline in parallel and perhaps not all the underlying
 APIs used by OBB accepts parallel requests,but it is an useful proof of concept on what can be done
- The application is self contained, and uses  a requirements.txt file to install dependencies

## How has this been tested?

- The application runs an unit test
</details>
