### PR TITLE
[BugFix] Improve Warning For Invalid Defaults Key In `user_settings.json`

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/defaults.py
+++ b/openbb_platform/core/openbb_core/app/model/defaults.py
@@ -30,11 +30,17 @@ class Defaults(BaseModel):
         """Validate model (before)."""
         key = "commands"
         if "routes" in values:
-            warn(
-                message="'routes' is deprecated. Use 'commands' instead.",
-                category=OpenBBWarning,
-            )
-            key = "routes"
+            if not values.get("routes"):
+                del values["routes"]
+            else:
+                warn(
+                    message="The 'routes' key is deprecated within 'defaults' of 'user_settings.json'."
+                    + " Suppress this warning by updating the key to 'commands'."
+                    + " Prevent all warnings from displaying in the console by setting 'show_warnings' to 'false' in"
+                    + " the 'preferences' section of 'user_settings.json'.",
+                    category=OpenBBWarning,
+                )
+                key = "routes"
 
         new_values: Dict[str, Dict[str, Optional[List[str]]]] = {"commands": {}}
         for k, v in values.get(key, {}).items():

--- a/openbb_platform/core/openbb_core/app/model/defaults.py
+++ b/openbb_platform/core/openbb_core/app/model/defaults.py
@@ -32,12 +32,11 @@ class Defaults(BaseModel):
         if "routes" in values:
             if not values.get("routes"):
                 del values["routes"]
-            else:
+            show_warnings = values.get("preferences", {}).get("show_warnings")
+            if show_warnings is False or show_warnings in ["False", "false"]:
                 warn(
                     message="The 'routes' key is deprecated within 'defaults' of 'user_settings.json'."
-                    + " Suppress this warning by updating the key to 'commands'."
-                    + " Prevent all warnings from displaying in the console by setting 'show_warnings' to 'false' in"
-                    + " the 'preferences' section of 'user_settings.json'.",
+                    + " Suppress this warning by updating the key to 'commands'.",
                     category=OpenBBWarning,
                 )
                 key = "routes"


### PR DESCRIPTION
1. **Why**?:

    - Adds clarity and actionable information to the warning.

2. **What**? (1-3 sentences or a bullet point list):

    - Suppressed if "routes" is actually empty and/or when `show_warnings` is set to `false`.

3. **Impact**:

    - Annoying warning will no longer display if the user happens to have a legacy `user_settings.json` file with this key.
    - The warning will be broadcast only when `routes` is actually populated

4. **Testing Done**:

    - Play around with `user_settings.json` to show and suppress the warning.
