### PR TITLE
[BugFix] Enforce User Preference For Dark/Light Mode In Chart Output To API

### DIFF
--- a/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/derivatives_views.py
@@ -128,6 +128,7 @@ class DerivativesViews:
 
         figure = OpenBBFigure().create_subplots(shared_xaxes=True)
         figure.update_layout(ChartStyle().plotly_template.get("layout", {}))
+        text_color = "white" if ChartStyle().plt_style == "dark" else "black"
 
         def create_fig(figure, df, dates, color_count):
             """Create a scatter for each date in the data."""
@@ -184,7 +185,12 @@ class DerivativesViews:
         # Update the layout of the figure.
         figure.update_layout(
             title=dict(text=title, x=0.5, font=dict(size=20)),
-            plot_bgcolor="rgba(255,255,255,0)",
+            plot_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
             xaxis=dict(
                 title="",
                 ticklen=0,
@@ -207,7 +213,9 @@ class DerivativesViews:
                 x=0,
                 xref="paper",
                 font=dict(size=12),
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             ),
             margin=dict(
                 b=10,

--- a/openbb_platform/extensions/economy/openbb_economy/economy_views.py
+++ b/openbb_platform/extensions/economy/openbb_economy/economy_views.py
@@ -25,6 +25,7 @@ class EconomyViews:
         from openbb_charting.charts.helpers import (
             z_score_standardization,
         )
+        from openbb_charting.core.chart_style import ChartStyle
         from openbb_charting.core.openbb_figure import OpenBBFigure
         from openbb_charting.styles.colors import LARGE_CYCLER
         from openbb_core.app.utils import basemodel_to_df
@@ -177,7 +178,8 @@ class EconomyViews:
         fig = OpenBBFigure().create_subplots(
             rows=1, cols=1, shared_xaxes=True, shared_yaxes=False
         )
-
+        fig.update_layout(ChartStyle().plotly_template.get("layout", {}))
+        text_color = "white" if ChartStyle().plt_style == "dark" else "black"
         # For each series in the DataFrame, add a scatter plot.
         for i, col in enumerate(df_ta.columns):
 
@@ -227,15 +229,21 @@ class EconomyViews:
         # Now update the layout of the complete figure.
         fig.update_layout(
             title=dict(text=title, x=0.5, font=dict(size=16)),
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor="rgba(0,0,0,0)",
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
+            plot_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
             legend=dict(
                 orientation="h",
                 yanchor="bottom",
                 xanchor="right",
                 y=1.02,
                 x=0.95,
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
                 font=dict(size=12),
             ),
             yaxis=(
@@ -304,6 +312,7 @@ class EconomyViews:
             margin=(
                 dict(r=25, l=25, b=75 if xtitle else 30) if normalize is False else None
             ),
+            font=dict(color=text_color),
             autosize=True,
             dragmode="pan",
         )
@@ -311,6 +320,7 @@ class EconomyViews:
             fig.update_layout(kwargs.get("layout_kwargs"))
         if kwargs.get("title"):
             fig.set_title(str(kwargs.get("title")))
+
         content = fig.to_plotly_json()
 
         return fig, content

--- a/openbb_platform/extensions/fixedincome/openbb_fixedincome/fixedincome_views.py
+++ b/openbb_platform/extensions/fixedincome/openbb_fixedincome/fixedincome_views.py
@@ -64,6 +64,7 @@ class FixedIncomeViews:
 
         figure = OpenBBFigure().create_subplots(shared_xaxes=True)
         figure.update_layout(ChartStyle().plotly_template.get("layout", {}))
+        text_color = "white" if ChartStyle().plt_style == "dark" else "black"
 
         def create_fig(figure, df, dates, color_count, country: Optional[str] = None):
             """Create a scatter for each date in the data."""
@@ -90,7 +91,6 @@ class FixedIncomeViews:
                 figure.add_scatter(
                     x=plot_df["Maturity"],
                     y=plot_df["Yield"],
-                    # fill=fill,
                     mode="lines+markers",
                     name=f"{country} - {date}" if country else date,
                     line=dict(width=3, color=color),
@@ -142,7 +142,12 @@ class FixedIncomeViews:
         # Update the layout of the figure.
         figure.update_layout(
             title=dict(text=title, x=0.5, font=dict(size=20)),
-            plot_bgcolor="rgba(255,255,255,0)",
+            plot_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
             xaxis=dict(
                 title="Maturity",
                 ticklen=0,
@@ -174,7 +179,9 @@ class FixedIncomeViews:
                 x=0,
                 xref="paper",
                 font=dict(size=12),
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             ),
             margin=dict(
                 b=25,

--- a/openbb_platform/extensions/technical/openbb_technical/technical_views.py
+++ b/openbb_platform/extensions/technical/openbb_technical/technical_views.py
@@ -289,8 +289,12 @@ class TechnicalViews:
         fig.set_title(title)
 
         fig.update_layout(
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor="rgba(0,0,0,0)",
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
+            plot_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
             font=dict(color=text_color),
             legend=dict(
                 orientation="h",
@@ -298,7 +302,9 @@ class TechnicalViews:
                 xanchor="right",
                 y=1.02,
                 x=1,
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             ),
             yaxis=dict(
                 ticklen=0,
@@ -366,7 +372,9 @@ class TechnicalViews:
         figure = OpenBBFigure(fig)  # pylint: disable=E0606
         font_color = "black" if ChartStyle().plt_style == "light" else "white"
         figure.update_layout(
-            paper_bgcolor="rgba(0,0,0,0)",
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if font_color == "white" else "rgba(255,255,255,255)"
+            ),
             plot_bgcolor="rgba(255,255,255,1)",
             font=dict(color=font_color),
             yaxis=dict(
@@ -473,7 +481,7 @@ def _ta_ma(**kwargs):
         specs=[[{"secondary_y": True}]],
     )
     fig.update_layout(ChartStyle().plotly_template.get("layout", {}))
-
+    font_color = "black" if ChartStyle().plt_style == "light" else "white"
     ma_df = DataFrame()
     window = [window] if isinstance(window, int) else window
     for w in window:
@@ -511,8 +519,12 @@ def _ta_ma(**kwargs):
 
     fig.update_layout(
         title=dict(text=title, x=0.5, font=dict(size=16)),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor=(
+            "rgba(0,0,0,0)" if font_color == "white" else "rgba(255,255,255,255)"
+        ),
+        plot_bgcolor=(
+            "rgba(0,0,0,0)" if font_color == "white" else "rgba(255,255,255,0)"
+        ),
         showlegend=True,
         legend=dict(
             orientation="h",
@@ -520,7 +532,7 @@ def _ta_ma(**kwargs):
             xanchor="right",
             y=1.02,
             x=0.95,
-            bgcolor="rgba(0,0,0,0)",
+            bgcolor="rgba(0,0,0,0)" if font_color == "white" else "rgba(255,255,255,0)",
         ),
         xaxis=dict(
             ticklen=0,
@@ -537,6 +549,7 @@ def _ta_ma(**kwargs):
             mirror=True,
             autorange=True,
         ),
+        font=dict(color=font_color),
     )
 
     content = fig.show(external=True).to_plotly_json()

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/generic_charts.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/generic_charts.py
@@ -52,7 +52,7 @@ def line_chart(  # noqa: PLR0912
     """Create a line chart."""
     # pylint: disable=import-outside-toplevel
     from pandas import DataFrame, Series, to_datetime  # noqa
-    from openbb_charting.core.openbb_figure import OpenBBFigure  # noqa
+    from openbb_charting.core.openbb_figure import OpenBBFigure
 
     if data is None:
         raise ValueError("Error: Data is a required field.")
@@ -122,6 +122,8 @@ def line_chart(  # noqa: PLR0912
     except Exception as _:
         fig = OpenBBFigure(create_backend=True)
 
+    fig.update_layout(ChartStyle().plotly_template.get("layout", {}))
+    text_color = "white" if ChartStyle().plt_style == "dark" else "black"
     title = f"{title}" if title else ""
     xtitle = xtitle if xtitle else ""
     y1title = ytitle if ytitle else ""
@@ -242,15 +244,24 @@ def line_chart(  # noqa: PLR0912
 
     fig.update_layout(
         title=dict(text=title if title else None, x=0.5, font=dict(size=16)),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
+        font=dict(color=text_color),
+        paper_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
+        plot_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
         legend=dict(
-            orientation="h",
-            yanchor="bottom",
+            orientation="v",
+            yanchor="top",
             xanchor="right",
-            y=1.02,
-            x=0.95,
-            bgcolor="rgba(0,0,0,0)",
+            y=0.95,
+            x=-0.01,
+            xref="paper",
+            font=dict(size=12),
+            bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
         ),
         yaxis=(
             dict(
@@ -405,6 +416,7 @@ def bar_chart(  # noqa: PLR0912
     )
 
     figure.update_layout(ChartStyle().plotly_template.get("layout", {}))
+    text_color = "white" if ChartStyle().plt_style == "dark" else "black"
     if colors is not None:
         figure.update_layout(colorway=colors)
     if bar_kwargs is None:
@@ -434,15 +446,23 @@ def bar_chart(  # noqa: PLR0912
 
     figure.update_layout(
         title=dict(text=title if title else None, x=0.5, font=dict(size=16)),
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
+        plot_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rbga(255,255,255,0)"
+        ),
         legend=dict(
-            orientation="h",
-            yanchor="bottom",
+            orientation="v",
+            yanchor="top",
             xanchor="right",
-            y=1.02,
-            x=0.98,
-            bgcolor="rgba(0,0,0,0)",
+            y=0.95,
+            x=-0.01 if orientation == "v" else 1.01,
+            xref="paper",
+            font=dict(size=12),
+            bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
         ),
         xaxis=dict(
             type=xtype,
@@ -469,6 +489,7 @@ def bar_chart(  # noqa: PLR0912
         ),
         margin=dict(pad=5),
         barmode=barmode,
+        font=dict(color=text_color),
     )
     if orientation == "h":
         figure.update_layout(
@@ -483,6 +504,7 @@ def bar_chart(  # noqa: PLR0912
             hoverlabel=dict(
                 font=dict(size=12),
             ),
+            hovermode="y unified",
         )
     if layout_kwargs:
         figure.update_layout(
@@ -532,7 +554,7 @@ def bar_increasing_decreasing(  # pylint: disable=W0102
     """
     # pylint: disable=import-outside-toplevel
     from openbb_charting.core.openbb_figure import OpenBBFigure  # noqa
-    from pandas import Series  # noqa
+    from pandas import Series
 
     try:
         figure = OpenBBFigure()
@@ -548,7 +570,8 @@ def bar_increasing_decreasing(  # pylint: disable=W0102
         row_width=[1],
         specs=[[{"secondary_y": True}]],
     )
-    # figure.update_layout(ChartStyle().plotly_template.get("layout", {}))
+    figure.update_layout(ChartStyle().plotly_template.get("layout", {}))
+    text_color = "white" if ChartStyle().plt_style == "dark" else "black"
 
     try:
         data = Series(data=values, index=keys)
@@ -605,6 +628,13 @@ def bar_increasing_decreasing(  # pylint: disable=W0102
             categoryorder="array" if orientation == "v" else None,
             categoryarray=keys if orientation == "v" else None,
         ),
+        paper_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
+        plot_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
+        font=dict(color="white" if text_color == "white" else "black"),
         margin=dict(pad=5),
     )
 

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
@@ -120,8 +120,12 @@ def price_historical(  # noqa: PLR0912
         if _volume is True and "atr" in indicators:  # type: ignore
             fig.add_inchart_volume(data)
         fig.update_layout(
-            paper_bgcolor="rgba(0,0,0,0)",
-            plot_bgcolor="rgba(0,0,0,0)",
+            paper_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
+            plot_bgcolor=(
+                "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+            ),
             font=dict(color=text_color),
             showlegend=True,
             legend=dict(
@@ -132,7 +136,9 @@ def price_historical(  # noqa: PLR0912
                 x=-0.01,
                 xref="paper",
                 font=dict(size=12),
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             ),
             xaxis=dict(
                 ticklen=0,
@@ -207,6 +213,8 @@ def price_historical(  # noqa: PLR0912
                 y2title = None  # type: ignore
 
         fig = OpenBBFigure()
+        fig.update_layout(ChartStyle().plotly_template.get("layout", {}))
+        text_color = "white" if ChartStyle().plt_style == "dark" else "black"
 
         for i, col in enumerate(data.columns):
 
@@ -246,10 +254,14 @@ def price_historical(  # noqa: PLR0912
     if same_axis is True:
         y1title = None  # type: ignore
         y2title = None  # type: ignore
-
+)
     fig.update_layout(
-        paper_bgcolor="rgba(0,0,0,0)",
-        plot_bgcolor="rgba(0,0,0,0)",
+        paper_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
+        plot_bgcolor=(
+            "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+        ),
         legend=(
             dict(
                 orientation="v",
@@ -257,7 +269,9 @@ def price_historical(  # noqa: PLR0912
                 xanchor="right",
                 y=0.95,
                 x=-0.01,
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             )
             if len(data.columns) > 2
             else dict(
@@ -266,7 +280,9 @@ def price_historical(  # noqa: PLR0912
                 xanchor="right",
                 y=1.02,
                 x=0.98,
-                bgcolor="rgba(0,0,0,0)",
+                bgcolor=(
+                    "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"
+                ),
             )
         ),
         yaxis1=(

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
@@ -254,7 +254,7 @@ def price_historical(  # noqa: PLR0912
     if same_axis is True:
         y1title = None  # type: ignore
         y2title = None  # type: ignore
-)
+
     fig.update_layout(
         paper_bgcolor=(
             "rgba(0,0,0,0)" if text_color == "white" else "rgba(255,255,255,0)"


### PR DESCRIPTION
1. **Why**?:

    - The charting extension is relying on the output at runtime to set the user preference theme, this was excluding the API from being set by this preference.

2. **What**?:

    - Sets `plot_bgcolor`, `paper_bgcolor` and `font_color` as white/black according to the user-defined preference in `user_settings.json`, "chart_style".
    - This is done at the chart function level, prior to the `layout_kwargs` entry at output, and remains settable at runtime.

3. **Impact**:

    - Charts output from the API should now be consistent with the Python output.

4. **Testing Done**:

    - Define the preference in `user_settings.json` and created the different charts from endpoints.
   