### PR TITLE
[BugFix] Fix BLS Error and API Exception Handling - Resolves #6661 and #6662

### DIFF
--- a/openbb_platform/core/openbb_core/api/exception_handlers.py
+++ b/openbb_platform/core/openbb_core/api/exception_handlers.py
@@ -31,6 +31,16 @@ class ExceptionHandlers:
     @staticmethod
     async def exception(_: Request, error: Exception) -> JSONResponse:
         """Exception handler for Base Exception."""
+        # Required parameters are missing and is not handled by ValidationError.
+        errors = error.errors(include_url=False) if hasattr(error, "errors") else error
+        if errors:
+            for err in errors:
+                if err.get("type") == "missing":
+                    return await ExceptionHandlers._handle(
+                        exception=error,
+                        status_code=422,
+                        detail={**err},
+                    )
         return await ExceptionHandlers._handle(
             exception=error,
             status_code=500,

--- a/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
+++ b/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
@@ -81,6 +81,17 @@ async def get_bls_timeseries(  # pylint: disable=too-many-branches  # noqa: PLR0
     res = await amake_request(url=url, method="POST", headers=headers, data=payload)
     results = res.get("Results", {}).get("series", [])  # type: ignore
     messages = res.get("message", [])  # type: ignore
+    if messages:
+        messages = [
+            (
+                f"The key provided by the User is invalid. {m.split(' provided by the User is invalid.')[1].strip()}"
+                if m.startswith("The key:")
+                else m
+            )
+            for m in messages
+            if m
+        ]
+
     metadata: Dict = {}
     data: List = []
     for result in results:


### PR DESCRIPTION
1. **Why**?:

    - Resolves #6661, #6662

2. **What**?:

    - Sanitize the invalid API key error message from BLS.
    - Handle `Field required` error in the API as 422.

3. **Impact**:

    - Better privacy handling and improved exception handling for required fields in the API.

4. **Testing Done**:

Resolves #6661:

![Screenshot 2024-09-09 at 6 33 12 PM](https://github.com/user-attachments/assets/4ad7c422-4e8c-4105-a8c4-9f4cffe973c1)

Resolves #6662:

![Screenshot 2024-09-09 at 4 54 50 PM](https://github.com/user-attachments/assets/86265c21-ee4b-445f-930b-04b6dff1663c)
