### PR TITLE
[BugFix] Bar Chart Fixes

### DIFF
--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/generic_charts.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/generic_charts.py
@@ -426,7 +426,8 @@ def bar_chart(  # noqa: PLR0912
 
     bar_df = data.copy().set_index(x)  # type: ignore
     y = y.split(",") if isinstance(y, str) else y
-
+    hovertemplate = bar_kwargs.pop("hovertemplate", None)
+    width = bar_kwargs.pop("width", None)
     for item in y:
         figure.add_bar(
             x=bar_df.index if orientation == "v" else bar_df[item],
@@ -436,11 +437,19 @@ def bar_chart(  # noqa: PLR0912
             legendgroup=bar_df[item].name,
             orientation=orientation,
             hovertemplate=(
-                "%{fullData.name}:%{y}<extra></extra>"
-                if orientation == "v"
-                else "%{fullData.name}:%{x}<extra></extra>"
+                hovertemplate
+                if hovertemplate
+                else (
+                    "%{fullData.name}:%{y}<extra></extra>"
+                    if orientation == "v"
+                    else "%{fullData.name}:%{x}<extra></extra>"
+                )
             ),
-            width=0.95 / len(y) * 0.75 if barmode == "group" and len(y) > 1 else 0.95,
+            width=(
+                width
+                if width
+                else 0.95 / len(y) * 0.75 if barmode == "group" and len(y) > 1 else 0.95
+            ),
             **bar_kwargs,
         )
 

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
@@ -925,19 +925,6 @@ class OpenBBFigure(go.Figure):
                     if data.get("layout", {}):
                         pio.show(data, *args, **kwargs)
 
-        self.update_layout(
-            legend=dict(
-                orientation=(
-                    "v"
-                    if not self.layout.legend.orientation
-                    else self.layout.legend.orientation
-                ),
-            ),
-            barmode="overlay",
-            bargap=0,
-            bargroupgap=0,
-        )
-
         return pio.show(self, *args, **kwargs)
 
     def _xaxis_tickformatstops(self) -> None:


### PR DESCRIPTION
1. **Why**?:

    - Bar charts in Jupyter were always being set as "overlay" every time `figure.show()` was run.

    - `hovertemplate` and `width` were inaccessible from the `bar_kwargs` entry in the Generic Charts because those values were defined by default.

2. **What**?:

    - Removes the lines that updated the figure layout as "overlay" when `isatty` was False.
    - Prioritizes the user-supplied `hovertemplate` and `width` in `openbb_charting.charts.generic_charts.bar_chart` so that multiple values are not sent to the params.

3. **Impact**:

    - More better.

4. **Testing Done**:

Before:
<img width="1547" alt="Screenshot 2024-09-10 at 8 07 53 PM" src="https://github.com/user-attachments/assets/51784004-32ad-47bf-9167-ede9dab66bdb">

After:
<img width="1519" alt="Screenshot 2024-09-10 at 8 09 07 PM" src="https://github.com/user-attachments/assets/1fc4fe82-813d-4128-9cdf-e389d19eac20">
