### PR TITLE
[BugFix] Use `__alias_dict__` instead of Field(alias) for data fields.

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/treasury_auctions.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/treasury_auctions.py
@@ -17,10 +17,17 @@ from openbb_core.provider.utils.descriptions import QUERY_DESCRIPTIONS
 class USTreasuryAuctionsQueryParams(QueryParams):
     """US Treasury Auctions Query."""
 
-    security_type: Literal["Bill", "Note", "Bond", "CMB", "TIPS", "FRN", None] = Field(
-        default=None,
-        description="Used to only return securities of a particular type.",
-        alias="type",
+    __json_schema_extra__ = {
+        "security_type": {
+            "choices": ["bill", "note", "bond", "cmb", "tips", "frn"],
+        }
+    }
+
+    security_type: Optional[Literal["bill", "note", "bond", "cmb", "tips", "frn"]] = (
+        Field(
+            default=None,
+            description="Used to only return securities of a particular type.",
+        )
     )
     cusip: Optional[str] = Field(
         default=None,
@@ -29,12 +36,10 @@ class USTreasuryAuctionsQueryParams(QueryParams):
     page_size: Optional[int] = Field(
         default=None,
         description="Maximum number of results to return; you must also include pagenum when using pagesize.",
-        alias="pagesize",
     )
     page_num: Optional[int] = Field(
         default=None,
         description="The first page number to display results for; used in combination with page size.",
-        alias="pagenum",
     )
     start_date: Optional[dateType] = Field(
         default=None,
@@ -67,265 +72,224 @@ class USTreasuryAuctionsData(Data):
 
     cusip: str = Field(description="CUSIP of the Security.")
     issue_date: dateType = Field(
-        description="The issue date of the security.", alias="issueDate"
+        description="The issue date of the security.",
     )
     security_type: Literal["Bill", "Note", "Bond", "CMB", "TIPS", "FRN"] = Field(
-        description="The type of security.", alias="securityType"
+        description="The type of security.",
     )
     security_term: str = Field(
-        description="The term of the security.", alias="securityTerm"
+        description="The term of the security.",
     )
     maturity_date: dateType = Field(
-        description="The maturity date of the security.", alias="maturityDate"
+        description="The maturity date of the security.",
     )
     interest_rate: Optional[float] = Field(
         default=None,
         description="The interest rate of the security.",
-        alias="interestRate",
     )
     cpi_on_issue_date: Optional[float] = Field(
         default=None,
         description="Reference CPI rate on the issue date of the security.",
-        alias="refCpiOnIssueDate",
     )
     cpi_on_dated_date: Optional[float] = Field(
         default=None,
         description="Reference CPI rate on the dated date of the security.",
-        alias="refCpiOnDatedDate",
     )
     announcement_date: Optional[dateType] = Field(
         default=None,
         description="The announcement date of the security.",
-        alias="announcementDate",
     )
     auction_date: Optional[dateType] = Field(
         default=None,
         description="The auction date of the security.",
-        alias="auctionDate",
     )
     auction_date_year: Optional[int] = Field(
         default=None,
         description="The auction date year of the security.",
-        alias="auctionDateYear",
     )
     dated_date: Optional[dateType] = Field(
-        default=None, description="The dated date of the security.", alias="datedDate"
+        default=None,
+        description="The dated date of the security.",
     )
     first_payment_date: Optional[dateType] = Field(
         default=None,
         description="The first payment date of the security.",
-        alias="firstInterestPaymentDate",
     )
     accrued_interest_per_100: Optional[float] = Field(
         default=None,
         description="Accrued interest per $100.",
-        alias="accruedInterestPer100",
     )
     accrued_interest_per_1000: Optional[float] = Field(
         default=None,
         description="Accrued interest per $1000.",
-        alias="accruedInterestPer1000",
     )
     adjusted_accrued_interest_per_100: Optional[float] = Field(
         default=None,
         description="Adjusted accrued interest per $100.",
-        alias="adjustedAccruedInterestPer100",
     )
     adjusted_accrued_interest_per_1000: Optional[float] = Field(
         default=None,
         description="Adjusted accrued interest per $1000.",
-        alias="adjustedAccruedInterestPer1000",
     )
     adjusted_price: Optional[float] = Field(
-        default=None, description="Adjusted price.", alias="adjustedPrice"
+        default=None,
+        description="Adjusted price.",
     )
     allocation_percentage: Optional[float] = Field(
         default=None,
         description="Allocation percentage, as normalized percentage points.",
-        alias="allocationPercentage",
     )
     allocation_percentage_decimals: Optional[float] = Field(
         default=None,
         description="The number of decimals in the Allocation percentage.",
-        alias="allocationPercentageDecimals",
     )
     announced_cusip: Optional[str] = Field(
         default=None,
         description="The announced CUSIP of the security.",
-        alias="announcedCusip",
     )
     auction_format: Optional[str] = Field(
         default=None,
         description="The auction format of the security.",
-        alias="auctionFormat",
     )
     avg_median_discount_rate: Optional[float] = Field(
         default=None,
         description="The average median discount rate of the security.",
-        alias="averageMedianDiscountRate",
     )
     avg_median_investment_rate: Optional[float] = Field(
         default=None,
         description="The average median investment rate of the security.",
-        alias="averageMedianInvestmentRate",
     )
     avg_median_price: Optional[float] = Field(
         default=None,
         description="The average median price paid for the security.",
-        alias="averageMedianPrice",
     )
     avg_median_discount_margin: Optional[float] = Field(
         default=None,
         description="The average median discount margin of the security.",
-        alias="averageMedianDiscountMargin",
     )
     avg_median_yield: Optional[float] = Field(
         default=None,
         description="The average median yield of the security.",
-        alias="averageMedianYield",
     )
     back_dated: Literal["Yes", "No", None] = Field(
         default=None,
         description="Whether the security is back dated.",
-        alias="backDated",
     )
     back_dated_date: Optional[dateType] = Field(
         default=None,
         description="The back dated date of the security.",
-        alias="backDatedDate",
     )
     bid_to_cover_ratio: Optional[float] = Field(
         default=None,
         description="The bid to cover ratio of the security.",
-        alias="bidToCoverRatio",
     )
     call_date: Optional[dateType] = Field(
-        default=None, description="The call date of the security.", alias="callDate"
+        default=None,
+        description="The call date of the security.",
     )
     callable: Literal["Yes", "No", None] = Field(
         default=None,
         description="Whether the security is callable.",
     )
     called_date: Optional[dateType] = Field(
-        default=None, description="The called date of the security.", alias="calledDate"
+        default=None,
+        description="The called date of the security.",
     )
     cash_management_bill: Literal["Yes", "No", None] = Field(
         default=None,
         description="Whether the security is a cash management bill.",
-        alias="cashManagementBillCMB",
     )
     closing_time_competitive: Optional[str] = Field(
         default=None,
         description="The closing time for competitive bids on the security.",
-        alias="closingTimeCompetitive",
     )
     closing_time_non_competitive: Optional[str] = Field(
         default=None,
         description="The closing time for non-competitive bids on the security.",
-        alias="closingTimeNoncompetitive",
     )
     competitive_accepted: Optional[int] = Field(
         default=None,
         description="The accepted value for competitive bids on the security.",
-        alias="competitiveAccepted",
     )
     competitive_accepted_decimals: Optional[int] = Field(
         default=None,
         description="The number of decimals in the Competitive Accepted.",
-        alias="competitiveBidDecimals",
     )
     competitive_tendered: Optional[int] = Field(
         default=None,
         description="The tendered value for competitive bids on the security.",
-        alias="competitiveTendered",
     )
     competitive_tenders_accepted: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
         description="Whether competitive tenders are accepted on the security.",
-        alias="competitiveTendersAccepted",
     )
     corp_us_cusip: Optional[str] = Field(
-        default=None, description="The CUSIP of the security.", alias="corpusCusip"
+        default=None,
+        description="The CUSIP of the security.",
     )
     cpi_base_reference_period: Optional[str] = Field(
         default=None,
         description="The CPI base reference period of the security.",
-        alias="cpiBaseReferencePeriod",
     )
     currently_outstanding: Optional[int] = Field(
         default=None,
         description="The currently outstanding value on the security.",
-        alias="currentlyOutstanding",
     )
     direct_bidder_accepted: Optional[int] = Field(
         default=None,
         description="The accepted value from direct bidders on the security.",
-        alias="directBidderAccepted",
     )
     direct_bidder_tendered: Optional[int] = Field(
         default=None,
         description="The tendered value from direct bidders on the security.",
-        alias="directBidderTendered",
     )
     est_amount_of_publicly_held_maturing_security: Optional[int] = Field(
         default=None,
         description="The estimated amount of publicly held maturing securities on the security.",
-        alias="estimatedAmountOfPubliclyHeldMaturingSecuritiesByType",
     )
     fima_included: Literal["Yes", "No", None] = Field(
         default=None,
         description="Whether the security is included in the FIMA (Foreign and International Money Authorities).",
-        alias="fimaIncluded",
     )
     fima_non_competitive_accepted: Optional[int] = Field(
         default=None,
         description="The non-competitive accepted value on the security from FIMAs.",
-        alias="fimaNoncompetitiveAccepted",
     )
     fima_non_competitive_tendered: Optional[int] = Field(
         default=None,
         description="The non-competitive tendered value on the security from FIMAs.",
-        alias="fimaNoncompetitiveTendered",
     )
     first_interest_period: Optional[str] = Field(
         default=None,
         description="The first interest period of the security.",
-        alias="firstInterestPeriod",
     )
     first_interest_payment_date: Optional[dateType] = Field(
         default=None,
         description="The first interest payment date of the security.",
-        alias="firstInterestPaymentDate",
     )
     floating_rate: Literal["Yes", "No", None] = Field(
         default=None,
         description="Whether the security is a floating rate.",
-        alias="floatingRate",
     )
     frn_index_determination_date: Optional[dateType] = Field(
         default=None,
         description="The FRN index determination date of the security.",
-        alias="frnIndexDeterminationDate",
     )
     frn_index_determination_rate: Optional[float] = Field(
         default=None,
         description="The FRN index determination rate of the security.",
-        alias="frnIndexDeterminationRate",
     )
     high_discount_rate: Optional[float] = Field(
         default=None,
         description="The high discount rate of the security.",
-        alias="highDiscountRate",
     )
     high_investment_rate: Optional[float] = Field(
         default=None,
         description="The high investment rate of the security.",
-        alias="highInvestmentRate",
     )
     high_price: Optional[float] = Field(
         default=None,
         description="The high price of the security at auction.",
-        alias="highPrice",
     )
     high_discount_margin: Optional[float] = Field(
         default=None,
@@ -334,102 +298,82 @@ class USTreasuryAuctionsData(Data):
     high_yield: Optional[float] = Field(
         default=None,
         description="The high yield of the security at auction.",
-        alias="highYield",
     )
     index_ratio_on_issue_date: Optional[float] = Field(
         default=None,
         description="The index ratio on the issue date of the security.",
-        alias="indexRatioOnIssueDate",
     )
     indirect_bidder_accepted: Optional[int] = Field(
         default=None,
         description="The accepted value from indirect bidders on the security.",
-        alias="indirectBidderAccepted",
     )
     indirect_bidder_tendered: Optional[int] = Field(
         default=None,
         description="The tendered value from indirect bidders on the security.",
-        alias="indirectBidderTendered",
     )
     interest_payment_frequency: Optional[str] = Field(
         default=None,
         description="The interest payment frequency of the security.",
-        alias="interestPaymentFrequency",
     )
     low_discount_rate: Optional[float] = Field(
         default=None,
         description="The low discount rate of the security.",
-        alias="lowDiscountRate",
     )
     low_investment_rate: Optional[float] = Field(
         default=None,
         description="The low investment rate of the security.",
-        alias="lowInvestmentRate",
     )
     low_price: Optional[float] = Field(
         default=None,
         description="The low price of the security at auction.",
-        alias="lowPrice",
     )
     low_discount_margin: Optional[float] = Field(
         default=None,
         description="The low discount margin of the security.",
-        alias="lowDiscountMargin",
     )
     low_yield: Optional[float] = Field(
         default=None,
         description="The low yield of the security at auction.",
-        alias="lowYield",
     )
     maturing_date: Optional[dateType] = Field(
         default=None,
         description="The maturing date of the security.",
-        alias="maturingDate",
     )
     max_competitive_award: Optional[int] = Field(
         default=None,
         description="The maximum competitive award at auction.",
-        alias="maximumCompetitiveAward",
     )
     max_non_competitive_award: Optional[int] = Field(
         default=None,
         description="The maximum non-competitive award at auction.",
-        alias="maximumNoncompetitiveAward",
     )
     max_single_bid: Optional[int] = Field(
         default=None,
         description="The maximum single bid at auction.",
-        alias="maximumSingleBid",
     )
     min_bid_amount: Optional[int] = Field(
         default=None,
         description="The minimum bid amount at auction.",
-        alias="minimumBidAmount",
     )
     min_strip_amount: Optional[int] = Field(
         default=None,
         description="The minimum strip amount at auction.",
-        alias="minimumStripAmount",
     )
     min_to_issue: Optional[int] = Field(
         default=None,
         description="The minimum to issue at auction.",
-        alias="minimumToIssue",
     )
     multiples_to_bid: Optional[int] = Field(
         default=None,
         description="The multiples to bid at auction.",
-        alias="multiplesToBid",
     )
     multiples_to_issue: Optional[int] = Field(
         default=None,
         description="The multiples to issue at auction.",
-        alias="multiplesToIssue",
     )
     nlp_exclusion_amount: Optional[int] = Field(
         default=None,
         description="The NLP exclusion amount at auction.",
-        alias="nlpExclusionAmount",
     )
     nlp_reporting_threshold: Optional[int] = Field(
         default=None,
@@ -438,72 +382,58 @@ class USTreasuryAuctionsData(Data):
     non_competitive_accepted: Optional[int] = Field(
         default=None,
         description="The accepted value from non-competitive bidders on the security.",
-        alias="noncompetitiveAccepted",
     )
     non_competitive_tenders_accepted: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
         description="Whether or not the auction accepted non-competitive tenders.",
-        alias="noncompetitiveTendersAccepted",
     )
     offering_amount: Optional[int] = Field(
         default=None,
         description="The offering amount at auction.",
-        alias="offeringAmount",
     )
     original_cusip: Optional[str] = Field(
         default=None,
         description="The original CUSIP of the security.",
-        alias="originalCusip",
     )
     original_dated_date: Optional[dateType] = Field(
         default=None,
         description="The original dated date of the security.",
-        alias="originalDatedDate",
     )
     original_issue_date: Optional[dateType] = Field(
         default=None,
         description="The original issue date of the security.",
-        alias="originalIssueDate",
     )
     original_security_term: Optional[str] = Field(
         default=None,
         description="The original term of the security.",
-        alias="originalSecurityTerm",
     )
     pdf_announcement: Optional[str] = Field(
         default=None,
         description="The PDF filename for the announcement of the security.",
-        alias="pdfFilenameAnnouncement",
     )
     pdf_competitive_results: Optional[str] = Field(
         default=None,
         description="The PDF filename for the competitive results of the security.",
-        alias="pdfFilenameCompetitiveResults",
     )
     pdf_non_competitive_results: Optional[str] = Field(
         default=None,
         description="The PDF filename for the non-competitive results of the security.",
-        alias="pdfFilenameNoncompetitiveResults",
     )
     pdf_special_announcement: Optional[str] = Field(
         default=None,
         description="The PDF filename for the special announcements.",
-        alias="pdfFilenameSpecialAnnouncement",
     )
     price_per_100: Optional[float] = Field(
         default=None,
         description="The price per 100 of the security.",
-        alias="pricePer100",
     )
     primary_dealer_accepted: Optional[int] = Field(
         default=None,
         description="The primary dealer accepted value on the security.",
-        alias="primaryDealerAccepted",
     )
     primary_dealer_tendered: Optional[int] = Field(
         default=None,
         description="The primary dealer tendered value on the security.",
-        alias="primaryDealerTendered",
     )
     reopening: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
@@ -512,12 +442,10 @@ class USTreasuryAuctionsData(Data):
     security_term_day_month: Optional[str] = Field(
         default=None,
         description="The security term in days or months.",
-        alias="securityTermDayMonth",
     )
     security_term_week_year: Optional[str] = Field(
         default=None,
         description="The security term in weeks or years.",
-        alias="securityTermWeekYear",
     )
     series: Optional[str] = Field(
         default=None,
@@ -526,22 +454,18 @@ class USTreasuryAuctionsData(Data):
     soma_accepted: Optional[int] = Field(
         default=None,
         description="The SOMA accepted value on the security.",
-        alias="somaAccepted",
     )
     soma_holdings: Optional[int] = Field(
         default=None,
         description="The SOMA holdings on the security.",
-        alias="somaHoldings",
     )
     soma_included: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
         description="Whether or not the SOMA (System Open Market Account) was included on the security.",
-        alias="somaIncluded",
     )
     soma_tendered: Optional[int] = Field(
         default=None,
         description="The SOMA tendered value on the security.",
-        alias="somaTendered",
     )
     spread: Optional[float] = Field(
         default=None,
@@ -550,7 +474,6 @@ class USTreasuryAuctionsData(Data):
     standard_payment_per_1000: Optional[float] = Field(
         default=None,
         description="The standard payment per 1000 of the security.",
-        alias="standardInterestPaymentPer1000",
     )
     strippable: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
@@ -563,7 +486,6 @@ class USTreasuryAuctionsData(Data):
     tiin_conversion_factor_per_1000: Optional[float] = Field(
         default=None,
         description="The TIIN conversion factor per 1000 of the security.",
-        alias="tiinConversionFactorPer1000",
     )
     tips: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
@@ -572,22 +494,18 @@ class USTreasuryAuctionsData(Data):
     total_accepted: Optional[int] = Field(
         default=None,
         description="The total accepted value at auction.",
-        alias="totalAccepted",
     )
     total_tendered: Optional[int] = Field(
         default=None,
         description="The total tendered value at auction.",
-        alias="totalTendered",
     )
     treasury_retail_accepted: Optional[int] = Field(
         default=None,
         description="The accepted value on the security from retail.",
-        alias="treasuryRetailAccepted",
     )
     treasury_retail_tenders_accepted: Optional[Literal["Yes", "No", None]] = Field(
         default=None,
         description="Whether or not the tender offers from retail are accepted",
-        alias="treasuryRetailTendersAccepted",
     )
     type: Optional[str] = Field(
         default=None,
@@ -596,35 +514,30 @@ class USTreasuryAuctionsData(Data):
     unadjusted_accrued_interest_per_1000: Optional[float] = Field(
         default=None,
         description="The unadjusted accrued interest per 1000 of the security.",
-        alias="unadjustedAccruedInterestPer1000",
     )
     unadjusted_price: Optional[float] = Field(
         default=None,
         description="The unadjusted price of the security.",
-        alias="unadjustedPrice",
     )
     updated_timestamp: Optional[datetime] = Field(
         default=None,
         description="The updated timestamp of the security.",
-        alias="updatedTimestamp",
     )
     xml_announcement: Optional[str] = Field(
         default=None,
         description="The XML filename for the announcement of the security.",
-        alias="xmlFilenameAnnouncement",
     )
     xml_competitive_results: Optional[str] = Field(
         default=None,
         description="The XML filename for the competitive results of the security.",
-        alias="xmlFilenameCompetitiveResults",
     )
     xml_special_announcement: Optional[str] = Field(
         default=None,
         description="The XML filename for special announcements.",
-        alias="xmlFilenameSpecialAnnouncement",
     )
     tint_cusip1: Optional[str] = Field(
-        default=None, description="Tint CUSIP 1.", alias="tintCusip1"
+        default=None,
+        description="Tint CUSIP 1.",
     )
     tint_cusip2: Optional[str] = Field(
         default=None,

--- a/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
+++ b/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
@@ -113,7 +113,7 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         "average_return_3y": "3y_average_return",
         "std_dev_3y": "3y_stdev",
         "smart_score_3y": "3y_smart_score",
-        "success_rate_3y": "3y_success",
+        "success_rate_3y": "3y_success_rate",
     }
 
     analyst_id: Optional[str] = Field(

--- a/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
+++ b/openbb_platform/providers/benzinga/openbb_benzinga/models/analyst_search.py
@@ -73,7 +73,49 @@ class BenzingaAnalystSearchData(AnalystSearchData):
     __alias_dict__ = {
         "analyst_id": "id",
         "last_updated": "updated",
+        "overall_std_dev": "overall_stdev",
+        "gain_count_1m": "1m_gain_count",
+        "loss_count_1m": "1m_loss_count",
+        "average_return_1m": "1m_average_return",
+        "std_dev_1m": "1m_stdev",
+        "smart_score_1m": "1m_smart_score",
+        "success_rate_1m": "1m_success_rate",
+        "gain_count_3m": "3m_gain_count",
+        "loss_count_3m": "3m_loss_count",
+        "average_return_3m": "3m_average_return",
+        "std_dev_3m": "3m_stdev",
+        "smart_score_3m": "3m_smart_score",
+        "success_rate_3m": "3m_success_rate",
+        "gain_count_6m": "6m_gain_count",
+        "loss_count_6m": "6m_loss_count",
+        "average_return_6m": "6m_average_return",
+        "std_dev_6m": "6m_stdev",
+        "gain_count_9m": "9m_gain_count",
+        "loss_count_9m": "9m_loss_count",
+        "average_return_9m": "9m_average_return",
+        "std_dev_9m": "9m_stdev",
+        "smart_score_9m": "9m_smart_score",
+        "success_rate_9m": "9m_success_rate",
+        "gain_count_1y": "1y_gain_count",
+        "loss_count_1y": "1y_loss_count",
+        "average_return_1y": "1y_average_return",
+        "std_dev_1y": "1y_stdev",
+        "smart_score_1y": "1y_smart_score",
+        "success_rate_1y": "1y_success_rate",
+        "gain_count_2y": "2y_gain_count",
+        "loss_count_2y": "2y_loss_count",
+        "average_return_2y": "2y_average_return",
+        "std_dev_2y": "2y_stdev",
+        "smart_score_2y": "2y_smart_score",
+        "success_rate_2y": "2y_success_rate",
+        "gain_count_3y": "3y_gain_count",
+        "loss_count_3y": "3y_loss_count",
+        "average_return_3y": "3y_average_return",
+        "std_dev_3y": "3y_stdev",
+        "smart_score_3y": "3y_smart_score",
+        "success_rate_3y": "3y_success",
     }
+
     analyst_id: Optional[str] = Field(
         default=None,
         description="ID of the analyst.",
@@ -126,240 +168,199 @@ class BenzingaAnalystSearchData(AnalystSearchData):
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings since the date of recommendation",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="overall_stdev",
     )
     gain_count_1m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last month",
-        alias="1m_gain_count",
     )
     loss_count_1m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last month",
-        alias="1m_loss_count",
     )
     average_return_1m: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over the last month",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1m_average_return",
     )
     std_dev_1m: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last month",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1m_stdev",
     )
     smart_score_1m: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last month.",
-        alias="1m_smart_score",
     )
     success_rate_1m: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last month",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1m_success_rate",
     )
     gain_count_3m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 3 months",
-        alias="3m_gain_count",
     )
     loss_count_3m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 3 months",
-        alias="3m_loss_count",
     )
     average_return_3m: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 3 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3m_average_return",
     )
     std_dev_3m: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 3 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3m_stdev",
     )
     smart_score_3m: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last 3 months.",
-        alias="3m_smart_score",
     )
     success_rate_3m: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3m_success_rate",
     )
     gain_count_6m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 6 months",
-        alias="6m_gain_count",
     )
     loss_count_6m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 6 months",
-        alias="6m_loss_count",
     )
     average_return_6m: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 6 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="6m_average_return",
     )
     std_dev_6m: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 6 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="6m_stdev",
     )
     gain_count_9m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 9 months",
-        alias="9m_gain_count",
     )
     loss_count_9m: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 9 months",
-        alias="9m_loss_count",
     )
     average_return_9m: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 9 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="9m_average_return",
     )
     std_dev_9m: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 9 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="9m_stdev",
     )
     smart_score_9m: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last 9 months.",
-        alias="9m_smart_score",
     )
     success_rate_9m: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 9 months",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="9m_success_rate",
     )
     gain_count_1y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 1 year",
-        alias="1y_gain_count",
     )
     loss_count_1y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 1 year",
-        alias="1y_loss_count",
     )
     average_return_1y: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 1 year",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1y_average_return",
     )
     std_dev_1y: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 1 year",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1y_stdev",
     )
     smart_score_1y: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last 1 year.",
-        alias="1y_smart_score",
     )
     success_rate_1y: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 1 year",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="1y_success_rate",
     )
     gain_count_2y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 2 years",
-        alias="2y_gain_count",
     )
     loss_count_2y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 2 years",
-        alias="2y_loss_count",
     )
     average_return_2y: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 2 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="2y_average_return",
     )
     std_dev_2y: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 2 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="2y_stdev",
     )
     smart_score_2y: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last 3 years.",
-        alias="2y_smart_score",
     )
     success_rate_2y: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 2 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="2y_success_rate",
     )
     gain_count_3y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have gained value over the last 3 years",
-        alias="3y_gain_count",
     )
     loss_count_3y: Optional[int] = Field(
         default=None,
         description="The number of ratings that have lost value over the last 3 years",
-        alias="3y_loss_count",
     )
     average_return_3y: Optional[float] = Field(
         default=None,
         description="The average percent (normalized) price difference per rating over"
         + " the last 3 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3y_average_return",
     )
     std_dev_3y: Optional[float] = Field(
         default=None,
         description="The standard deviation in percent (normalized) price difference in the"
         + " analyst's ratings over the last 3 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3y_stdev",
     )
     smart_score_3y: Optional[float] = Field(
         default=None,
         description="A weighted average smart score over the last 3 years.",
-        alias="3y_smart_score",
     )
     success_rate_3y: Optional[float] = Field(
         default=None,
         description="The percentage (normalized) of gain/loss ratings that resulted in a gain over the last 3 years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="3y_success_rate",
     )
 
     @field_validator("last_updated", mode="before", check_fields=False)

--- a/openbb_platform/providers/benzinga/openbb_benzinga/models/price_target.py
+++ b/openbb_platform/providers/benzinga/openbb_benzinga/models/price_target.py
@@ -171,6 +171,9 @@ class BenzingaPriceTargetData(PriceTargetData):
         "company_name": "name",
         "rating_previous": "rating_prior",
         "url_analyst": "url",
+        "action": "action_company",
+        "action_change": "action_pt",
+        "last_updated": "updated",
     }
 
     action: Optional[
@@ -191,14 +194,12 @@ class BenzingaPriceTargetData(PriceTargetData):
         default=None,
         description="Description of the change in rating from firm's last rating."
         "Note that all of these terms are precisely defined.",
-        alias="action_company",
     )
     action_change: Optional[
         Literal["Announces", "Maintains", "Lowers", "Raises", "Removes", "Adjusts"]
     ] = Field(
         default=None,
         description="Description of the change in price target from firm's last price target.",
-        alias="action_pt",
     )
     importance: Optional[Literal[0, 1, 2, 3, 4, 5]] = Field(
         default=None,
@@ -218,7 +219,6 @@ class BenzingaPriceTargetData(PriceTargetData):
     last_updated: Optional[datetime] = Field(
         default=None,
         description="Last updated timestamp, UTC.",
-        alias="updated",
     )
 
     @field_validator("published_date", mode="before", check_fields=False)

--- a/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
+++ b/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
@@ -37,7 +37,7 @@ class BiztocWorldNewsData(WorldNewsData):
     }
 
     images: Optional[List[Dict[str, str]]] = Field(
-        description="Images for the article.", alias="images", default=None
+        description="Images for the article.", default=None
     )
     tags: Optional[List[str]] = Field(description="Tags for the article.", default=None)
     score: Optional[float] = Field(

--- a/openbb_platform/providers/cboe/openbb_cboe/models/equity_search.py
+++ b/openbb_platform/providers/cboe/openbb_cboe/models/equity_search.py
@@ -27,10 +27,13 @@ class CboeEquitySearchQueryParams(EquitySearchQueryParams):
 class CboeEquitySearchData(EquitySearchData):
     """CBOE Equity Search Data."""
 
+    __alias_dict__ = {
+        "dpm_name": "DPM Name",
+    }
+
     dpm_name: Optional[str] = Field(
         default=None,
         description="Name of the primary market maker.",
-        alias="DPM Name",
     )
     post_station: Optional[str] = Field(
         default=None, description="Post and station location on the CBOE trading floor."

--- a/openbb_platform/providers/cboe/openbb_cboe/models/index_constituents.py
+++ b/openbb_platform/providers/cboe/openbb_cboe/models/index_constituents.py
@@ -98,6 +98,7 @@ class CboeIndexConstituentsData(IndexConstituentsData):
         "change": "price_change",
         "change_percent": "price_change_percent",
         "last_price": "current_price",
+        "asset_type": "type",
     }
 
     security_type: Optional[str] = Field(
@@ -135,7 +136,8 @@ class CboeIndexConstituentsData(IndexConstituentsData):
         default=None, description="Last trade timestamp for the symbol."
     )
     asset_type: Optional[str] = Field(
-        default=None, description="Type of asset.", alias="type"
+        default=None,
+        description="Type of asset.",
     )
 
     @field_validator("last_trade_time", mode="before", check_fields=False)

--- a/openbb_platform/providers/finviz/openbb_finviz/models/compare_groups.py
+++ b/openbb_platform/providers/finviz/openbb_finviz/models/compare_groups.py
@@ -42,21 +42,21 @@ class FinvizCompareGroupsData(CompareGroupsData):
         "name": "Name",
         "stocks": "Number of Stocks",
         "market_cap": "Market Cap",
-        "performance_1D": "Change",
-        "performance_1W": "Perf Week",
-        "performance_1M": "Perf Month",
-        "performance_3M": "Perf Quart",
-        "performance_6M": "Perf Half",
-        "performance_1Y": "Perf Year",
-        "performance_YTD": "Perf YTD",
+        "performance_1d": "Change",
+        "performance_1w": "Perf Week",
+        "performance_1m": "Perf Month",
+        "performance_3m": "Perf Quart",
+        "performance_6m": "Perf Half",
+        "performance_1y": "Perf Year",
+        "performance_ytd": "Perf YTD",
         "volume": "Volume",
         "volume_average": "Avg Volume",
         "volume_relative": "Rel Volume",
         "pe": "P/E",
         "forward_pe": "Fwd P/E",
-        "pe_growth": "PEG",
-        "eps_growth_past_5_years": "EPS past 5Y",
-        "eps_growth_next_5_years": "EPS next 5Y",
+        "peg": "PEG",
+        "eps_growth_past_5y": "EPS past 5Y",
+        "eps_growth_next_5y": "EPS next 5Y",
         "sales_growth_past_5_years": "Sales past 5Y",
         "price_to_sales": "P/S",
         "price_to_book": "P/B",
@@ -70,43 +70,42 @@ class FinvizCompareGroupsData(CompareGroupsData):
     stocks: Optional[int] = Field(
         default=None,
         description="The number of stocks in the group.",
-        alias="Stocks",
     )
     market_cap: Optional[ForceInt] = Field(
         default=None,
         description="The market cap of the group.",
     )
-    performance_1D: Optional[float] = Field(
+    performance_1d: Optional[float] = Field(
         default=None,
         description="The performance in the last day, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_1W: Optional[float] = Field(
+    performance_1w: Optional[float] = Field(
         default=None,
         description="The performance in the last week, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_1M: Optional[float] = Field(
+    performance_1m: Optional[float] = Field(
         default=None,
         description="The performance in the last month, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_3M: Optional[float] = Field(
+    performance_3m: Optional[float] = Field(
         default=None,
         description="The performance in the last quarter, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_6M: Optional[float] = Field(
+    performance_6m: Optional[float] = Field(
         default=None,
         description="The performance in the last half year, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_1Y: Optional[float] = Field(
+    performance_1y: Optional[float] = Field(
         default=None,
         description="The performance in the last year, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    performance_YTD: Optional[float] = Field(
+    performance_ytd: Optional[float] = Field(
         default=None,
         description="The performance in the year to date, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
@@ -127,20 +126,19 @@ class FinvizCompareGroupsData(CompareGroupsData):
     peg: Optional[float] = Field(
         default=None,
         description="The PEG ratio of the group.",
-        alias="pe_growth",
     )
-    eps_growth_past_5_years: Optional[float] = Field(
+    eps_growth_past_5y: Optional[float] = Field(
         default=None,
         description="The EPS growth of the group for the past 5 years, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    eps_growth_next_5_years: Optional[float] = Field(
+    eps_growth_next_5y: Optional[float] = Field(
         default=None,
         description="The estimated EPS growth of the groupo for the next 5 years,"
         + " as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    sales_growth_past_5_years: Optional[float] = Field(
+    sales_growth_past_5y: Optional[float] = Field(
         default=None,
         description="The sales growth of the group for the past 5 years, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
@@ -167,16 +165,16 @@ class FinvizCompareGroupsData(CompareGroupsData):
     )
 
     @field_validator(
-        "performance_1W",
-        "performance_1M",
-        "performance_3M",
-        "performance_6M",
-        "performance_1Y",
-        "performance_YTD",
+        "performance_1w",
+        "performance_1m",
+        "performance_3m",
+        "performance_6m",
+        "performance_1y",
+        "performance_ytd",
         "dividend_yield",
-        "eps_growth_past_5_years",
-        "eps_growth_next_5_years",
-        "sales_growth_past_5_years",
+        "eps_growth_past_5y",
+        "eps_growth_next_5y",
+        "sales_growth_past_5y",
         "float_short",
         mode="before",
         check_fields=False,

--- a/openbb_platform/providers/finviz/openbb_finviz/models/equity_screener.py
+++ b/openbb_platform/providers/finviz/openbb_finviz/models/equity_screener.py
@@ -207,14 +207,14 @@ class FinvizEquityScreenerData(EquityScreenerData):
         "volume_avg": "Avg Volume",
         "volume_relative": "Rel Volume",
         "average_true_range": "ATR",
-        "price_change_1W": "Perf Week",
-        "price_change_1M": "Perf Month",
-        "price_change_3M": "Perf Quart",
-        "price_change_6M": "Perf Half",
-        "price_change_1Y": "Perf Year",
-        "price_change_YTD": "Perf YTD",
-        "volatility_1W": "Volatility W",
-        "volatility_1M": "Volatility M",
+        "price_change_1w": "Perf Week",
+        "price_change_1m": "Perf Month",
+        "price_change_3m": "Perf Quart",
+        "price_change_6m": "Perf Half",
+        "price_change_1y": "Perf Year",
+        "price_change_ytd": "Perf YTD",
+        "volatility_1w": "Volatility W",
+        "volatility_1m": "Volatility M",
         "price_to_earnings": "P/E",
         "forward_pe": "Fwd P/E",
         "peg_ratio": "PEG",
@@ -222,11 +222,11 @@ class FinvizEquityScreenerData(EquityScreenerData):
         "price_to_book": "P/B",
         "price_to_cash": "P/C",
         "price_to_free_cash_flow": "P/FCF",
-        "eps_growth_past_1Y": "EPS this Y",
-        "eps_growth_next_1Y": "EPS next Y",
-        "eps_growth_past_5Y": "EPS past 5Y",
-        "eps_growth_next_5Y": "EPS next 5Y",
-        "sales_growth_past_5Y": "Sales past 5Y",
+        "eps_growth_past_1y": "EPS this Y",
+        "eps_growth_next_1y": "EPS next Y",
+        "eps_growth_past_5y": "EPS past 5Y",
+        "eps_growth_next_5y": "EPS next 5Y",
+        "sales_growth_past_5y": "Sales past 5Y",
         "dividend_yield": "Dividend",
         "return_on_assets": "ROA",
         "return_on_equity": "ROE",
@@ -306,42 +306,42 @@ class FinvizEquityScreenerData(EquityScreenerData):
         description="Average true range (14).",
         json_schema_extra={"x-unit_measurement:": "currency"},
     )
-    price_change_1W: Optional[float] = Field(
+    price_change_1w: Optional[float] = Field(
         default=None,
         description="One-week price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    price_change_1M: Optional[float] = Field(
+    price_change_1m: Optional[float] = Field(
         default=None,
         description="One-month price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    price_change_3M: Optional[float] = Field(
+    price_change_3m: Optional[float] = Field(
         default=None,
         description="Three-month price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    price_change_6M: Optional[float] = Field(
+    price_change_6m: Optional[float] = Field(
         default=None,
         description="Six-month price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    price_change_1Y: Optional[float] = Field(
+    price_change_1y: Optional[float] = Field(
         default=None,
         description="One-year price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    price_change_YTD: Optional[float] = Field(
+    price_change_ytd: Optional[float] = Field(
         default=None,
         description="Year-to-date price return.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    volatility_1W: Optional[float] = Field(
+    volatility_1w: Optional[float] = Field(
         default=None,
         description="One-week volatility.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    volatility_1M: Optional[float] = Field(
+    volatility_1m: Optional[float] = Field(
         default=None,
         description="One-month volatility.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
@@ -440,27 +440,27 @@ class FinvizEquityScreenerData(EquityScreenerData):
         default=None,
         description="Price to free cash flow ratio.",
     )
-    eps_growth_past_1Y: Optional[float] = Field(
+    eps_growth_past_1y: Optional[float] = Field(
         default=None,
         description="EPS growth for this year.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    eps_growth_next_1Y: Optional[float] = Field(
+    eps_growth_next_1y: Optional[float] = Field(
         default=None,
         description="EPS growth next year.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    eps_growth_past_5Y: Optional[float] = Field(
+    eps_growth_past_5y: Optional[float] = Field(
         default=None,
         description="EPS growth for the previous 5 years.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    eps_growth_next_5Y: Optional[float] = Field(
+    eps_growth_next_5y: Optional[float] = Field(
         default=None,
         description="EPS growth for the next 5 years.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
-    sales_growth_past_5Y: Optional[float] = Field(
+    sales_growth_past_5y: Optional[float] = Field(
         default=None,
         description="Sales growth for the previous 5 years.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},

--- a/openbb_platform/providers/fmp/openbb_fmp/models/available_indices.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/available_indices.py
@@ -21,12 +21,16 @@ class FMPAvailableIndicesQueryParams(AvailableIndicesQueryParams):
 class FMPAvailableIndicesData(AvailableIndicesData):
     """FMP Available Indices Data."""
 
+    __alias_dict__ = {
+        "stock_exchange": "stockExchange",
+        "exchange_short_name": "exchangeShortName",
+    }
+
     stock_exchange: str = Field(
-        description="Stock exchange where the index is listed.", alias="stockExchange"
+        description="Stock exchange where the index is listed.",
     )
     exchange_short_name: str = Field(
         description="Short name of the stock exchange where the index is listed.",
-        alias="exchangeShortName",
     )
 
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/calendar_dividend.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/calendar_dividend.py
@@ -34,12 +34,12 @@ class FMPCalendarDividendData(CalendarDividendData):
         "record_date": "recordDate",
         "payment_date": "paymentDate",
         "declaration_date": "declarationDate",
+        "adjusted_amount": "adjDividend",
     }
 
     adjusted_amount: Optional[float] = Field(
         default=None,
         description="The adjusted-dividend amount.",
-        alias="adjDividend",
     )
     label: Optional[str] = Field(
         default=None, description="Ex-dividend date formatted for display."

--- a/openbb_platform/providers/fmp/openbb_fmp/models/calendar_earnings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/calendar_earnings.py
@@ -34,37 +34,37 @@ class FMPCalendarEarningsData(CalendarEarningsData):
     __alias_dict__ = {
         "report_date": "date",
         "eps_consensus": "epsEstimated",
+        "eps_actual": "eps",
+        "revenue_actual": "revenue",
+        "revenue_consensus": "revenueEstimated",
+        "period_ending": "fiscalDateEnding",
+        "reporting_time": "time",
+        "updated_date": "updatedFromDate",
     }
 
     eps_actual: Optional[float] = Field(
         default=None,
         description="The actual earnings per share announced.",
-        alias="eps",
     )
     revenue_actual: Optional[float] = Field(
         default=None,
         description="The actual reported revenue.",
-        alias="revenue",
     )
     revenue_consensus: Optional[float] = Field(
         default=None,
         description="The revenue forecast consensus.",
-        alias="revenueEstimated",
     )
     period_ending: Optional[dateType] = Field(
         default=None,
         description="The fiscal period end date.",
-        alias="fiscalDateEnding",
     )
     reporting_time: Optional[str] = Field(
         default=None,
         description="The reporting time - e.g. after market close.",
-        alias="time",
     )
     updated_date: Optional[dateType] = Field(
         default=None,
         description="The date the data was updated last.",
-        alias="updatedFromDate",
     )
 
     @field_validator(

--- a/openbb_platform/providers/fmp/openbb_fmp/models/crypto_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/crypto_historical.py
@@ -48,6 +48,10 @@ class FMPCryptoHistoricalQueryParams(CryptoHistoricalQueryParams):
 class FMPCryptoHistoricalData(CryptoHistoricalData):
     """FMP Crypto Historical Price Data."""
 
+    __alias_dict__ = {
+        "change_percent": "changeOverTime",
+    }
+
     adj_close: Optional[float] = Field(
         default=None, description=DATA_DESCRIPTIONS.get("adj_close", "")
     )
@@ -58,7 +62,6 @@ class FMPCryptoHistoricalData(CryptoHistoricalData):
     change_percent: Optional[float] = Field(
         default=None,
         description="Change in the price from the previous close, as a normalized percent.",
-        alias="changeOverTime",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/crypto_search.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/crypto_search.py
@@ -29,17 +29,20 @@ class FMPCryptoSearchQueryParams(CryptoSearchQueryParams):
 class FMPCryptoSearchData(CryptoSearchData):
     """FMP Crypto Search Data."""
 
+    __alias_dict__ = {
+        "exchange": "stockExchange",
+        "exchange_name": "exchangeShortName",
+    }
+
     currency: Optional[str] = Field(
         description="The currency the crypto trades for.", default=None
     )
     exchange: Optional[str] = Field(
         description="The exchange code the crypto trades on.",
-        alias="stockExchange",
         default=None,
     )
     exchange_name: Optional[str] = Field(
         description="The short name of the exchange the crypto trades on.",
-        alias="exchangeShortName",
         default=None,
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/currency_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/currency_historical.py
@@ -46,6 +46,10 @@ class FMPCurrencyHistoricalQueryParams(CurrencyHistoricalQueryParams):
 class FMPCurrencyHistoricalData(CurrencyHistoricalData):
     """FMP Currency Historical Price Data."""
 
+    __alias_dict__ = {
+        "change_percent": "changeOverTime",
+    }
+
     adj_close: Optional[float] = Field(
         default=None, description=DATA_DESCRIPTIONS.get("adj_close", "")
     )
@@ -56,7 +60,6 @@ class FMPCurrencyHistoricalData(CurrencyHistoricalData):
     change_percent: Optional[float] = Field(
         default=None,
         description="Change in the price from the previous close, as a normalized percent.",
-        alias="changeOverTime",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/discovery_filings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/discovery_filings.py
@@ -22,12 +22,12 @@ class FMPDiscoveryFilingsQueryParams(DiscoveryFilingsQueryParams):
         "start_date": "from",
         "end_date": "to",
         "form_type": "type",
+        "is_done": "isDone",
     }
 
     is_done: Optional[bool] = Field(
         default=None,
         description="Flag for whether or not the filing is done.",
-        alias="isDone",
     )
 
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_historical.py
@@ -46,6 +46,10 @@ class FMPEquityHistoricalQueryParams(EquityHistoricalQueryParams):
 class FMPEquityHistoricalData(EquityHistoricalData):
     """FMP Equity Historical Price Data."""
 
+    __alias_dict__ = {
+        "change_percent": "changeOverTime",
+    }
+
     adj_close: Optional[float] = Field(
         default=None, description=DATA_DESCRIPTIONS.get("adj_close", "")
     )
@@ -59,7 +63,6 @@ class FMPEquityHistoricalData(EquityHistoricalData):
     change_percent: Optional[float] = Field(
         default=None,
         description="Change in the price from the previous close, as a normalized percent.",
-        alias="changeOverTime",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_profile.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_profile.py
@@ -47,6 +47,10 @@ class FMPEquityProfileData(EquityInfoData):
         "employees": "fullTimeEmployees",
         "long_description": "description",
         "first_stock_price_date": "ipoDate",
+        "market_cap": "mktCap",
+        "last_price": "price",
+        "volume_avg": "volAvg",
+        "annualized_dividend_amount": "lastDiv",
     }
     __json_schema_extra__ = {"symbol": {"multiple_items_allowed": True}}
 
@@ -61,12 +65,10 @@ class FMPEquityProfileData(EquityInfoData):
     market_cap: Optional[ForceInt] = Field(
         default=None,
         description="Market capitalization of the company.",
-        alias="mktCap",
     )
     last_price: Optional[float] = Field(
         default=None,
         description="The last traded price.",
-        alias="price",
     )
     year_high: Optional[float] = Field(
         default=None, description="The one-year high of the price."
@@ -77,12 +79,10 @@ class FMPEquityProfileData(EquityInfoData):
     volume_avg: Optional[ForceInt] = Field(
         default=None,
         description="Average daily trading volume.",
-        alias="volAvg",
     )
     annualized_dividend_amount: Optional[float] = Field(
         default=None,
         description="The annualized dividend payment based on the most recent regular dividend payment.",
-        alias="lastDiv",
     )
     beta: Optional[float] = Field(
         default=None, description="Beta of the stock relative to the market."

--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_screener.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_screener.py
@@ -97,10 +97,16 @@ class FMPEquityScreenerData(EquityScreenerData):
 
     __alias_dict__ = {
         "name": "companyName",
+        "market_cap": "marketCap",
+        "last_annual_dividend": "lastAnnualDividend",
+        "exchange": "exchangeShortName",
+        "exchange_name": "exchange",
+        "is_etf": "isEtf",
+        "actively_trading": "isActivelyTrading",
     }
 
     market_cap: Optional[int] = Field(
-        description="The market cap of ticker.", alias="marketCap", default=None
+        description="The market cap of ticker.", default=None
     )
     sector: Optional[str] = Field(
         description="The sector the ticker belongs to.", default=None
@@ -112,7 +118,6 @@ class FMPEquityScreenerData(EquityScreenerData):
     price: Optional[float] = Field(description="The current price.", default=None)
     last_annual_dividend: Optional[float] = Field(
         description="The last annual amount dividend paid.",
-        alias="lastAnnualDividend",
         default=None,
     )
     volume: Optional[int] = Field(
@@ -120,12 +125,10 @@ class FMPEquityScreenerData(EquityScreenerData):
     )
     exchange: Optional[str] = Field(
         description="The exchange code the asset trades on.",
-        alias="exchangeShortName",
         default=None,
     )
     exchange_name: Optional[str] = Field(
         description="The full name of the primary exchange.",
-        alias="exchange",
         default=None,
     )
     country: Optional[str] = Field(
@@ -133,11 +136,10 @@ class FMPEquityScreenerData(EquityScreenerData):
         default=None,
     )
     is_etf: Optional[Literal[True, False]] = Field(
-        description="Whether the ticker is an ETF.", alias="isEtf", default=None
+        description="Whether the ticker is an ETF.", default=None
     )
     actively_trading: Optional[Literal[True, False]] = Field(
         description="Whether the ETF is actively trading.",
-        alias="isActivelyTrading",
         default=None,
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_holdings.py
@@ -49,6 +49,17 @@ class FMPEtfHoldingsData(EtfHoldingsData):
         "value": "marketValue",
         "symbol": "asset",
         "balance": "sharesNumber",
+        "acceptance_datetime": "acceptanceTime",
+        "is_restricted": "isRestrictedSec",
+        "is_loan_by_fund": "isLoanByFund",
+        "is_cash_collateral": "isCashCollateral",
+        "is_non_cash_collateral": "isNonCashCollateral",
+        "fair_value_level": "fairValLevel",
+        "payoff_profile": "payoffProfile",
+        "asset_category": "assetCat",
+        "issuer_category": "issuerCat",
+        "country": "invCountry",
+        "currency": "cur_cd",
     }
 
     lei: Optional[str] = Field(description="The LEI of the holding.", default=None)
@@ -62,64 +73,54 @@ class FMPEtfHoldingsData(EtfHoldingsData):
         description="The type of units.", default=None
     )
     currency: Optional[str] = Field(
-        description="The currency of the holding.", alias="cur_cd", default=None
+        description="The currency of the holding.", default=None
     )
     value: Optional[float] = Field(
         description="The value of the holding, in dollars.",
-        alias="valUsd",
         default=None,
     )
     weight: Optional[float] = Field(
         description="The weight of the holding, as a normalized percent.",
-        alias="pctVal",
         default=None,
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     payoff_profile: Optional[str] = Field(
         description="The payoff profile of the holding.",
-        alias="payoffProfile",
         default=None,
     )
     asset_category: Optional[str] = Field(
-        description="The asset category of the holding.", alias="assetCat", default=None
+        description="The asset category of the holding.", default=None
     )
     issuer_category: Optional[str] = Field(
         description="The issuer category of the holding.",
-        alias="issuerCat",
         default=None,
     )
     country: Optional[str] = Field(
-        description="The country of the holding.", alias="invCountry", default=None
+        description="The country of the holding.", default=None
     )
     is_restricted: Optional[str] = Field(
         description="Whether the holding is restricted.",
-        alias="isRestrictedSec",
         default=None,
     )
     fair_value_level: Optional[int] = Field(
         description="The fair value level of the holding.",
-        alias="fairValLevel",
         default=None,
     )
     is_cash_collateral: Optional[str] = Field(
         description="Whether the holding is cash collateral.",
-        alias="isCashCollateral",
         default=None,
     )
     is_non_cash_collateral: Optional[str] = Field(
         description="Whether the holding is non-cash collateral.",
-        alias="isNonCashCollateral",
         default=None,
     )
     is_loan_by_fund: Optional[str] = Field(
         description="Whether the holding is loan by fund.",
-        alias="isLoanByFund",
         default=None,
     )
     cik: Optional[str] = Field(description="The CIK of the filing.", default=None)
     acceptance_datetime: Optional[str] = Field(
         description="The acceptance datetime of the filing.",
-        alias="acceptanceTime",
         default=None,
     )
     updated: Optional[Union[dateType, datetime]] = Field(
@@ -188,4 +189,13 @@ class FMPEtfHoldingsFetcher(
         **kwargs: Any,
     ) -> List[FMPEtfHoldingsData]:
         """Return the transformed data."""
-        return [FMPEtfHoldingsData.model_validate(d) for d in data]
+        results: list[FMPEtfHoldingsData] = []
+        # Limited to one alias per field, so we need to do these here.
+        for d in data:
+            new_d = {
+                k.replace("valUsd", "value").replace("pctVal", "weight"): v
+                for k, v in d.items()
+            }
+            results.append(FMPEtfHoldingsData.model_validate(new_d))
+
+        return results

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_info.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_info.py
@@ -24,8 +24,13 @@ class FMPEtfInfoQueryParams(EtfInfoQueryParams):
 class FMPEtfInfoData(EtfInfoData):
     """FMP ETF Info Data."""
 
+    __alias_dict__ = {
+        "issuer": "etfCompany",
+    }
+
     issuer: Optional[str] = Field(
-        default=None, description="Company of the ETF.", alias="etfCompany"
+        default=None,
+        description="Company of the ETF.",
     )
     cusip: Optional[str] = Field(default=None, description="CUSIP of the ETF.")
     isin: Optional[str] = Field(default=None, description="ISIN of the ETF.")

--- a/openbb_platform/providers/fmp/openbb_fmp/models/etf_search.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/etf_search.py
@@ -30,10 +30,15 @@ class FMPEtfSearchData(EtfSearchData):
 
     __alias_dict__ = {
         "name": "companyName",
+        "market_cap": "marketCap",
+        "last_annual_dividend": "lastAnnualDividend",
+        "exchange": "exchangeShortName",
+        "exchange_name": "exchange",
+        "actively_trading": "isActivelyTrading",
     }
 
     market_cap: Optional[float] = Field(
-        description="The market cap of the ETF.", alias="marketCap", default=None
+        description="The market cap of the ETF.", default=None
     )
     sector: Optional[str] = Field(description="The sector of the ETF.", default=None)
     industry: Optional[str] = Field(
@@ -45,7 +50,6 @@ class FMPEtfSearchData(EtfSearchData):
     )
     last_annual_dividend: Optional[float] = Field(
         description="The last annual dividend paid.",
-        alias="lastAnnualDividend",
         default=None,
     )
     volume: Optional[float] = Field(
@@ -53,12 +57,10 @@ class FMPEtfSearchData(EtfSearchData):
     )
     exchange: Optional[str] = Field(
         description="The exchange code the ETF trades on.",
-        alias="exchangeShortName",
         default=None,
     )
     exchange_name: Optional[str] = Field(
         description="The full name of the exchange the ETF trades on.",
-        alias="exchange",
         default=None,
     )
     country: Optional[str] = Field(
@@ -66,7 +68,6 @@ class FMPEtfSearchData(EtfSearchData):
     )
     actively_trading: Optional[Literal[True, False]] = Field(
         description="Whether the ETF is actively trading.",
-        alias="isActivelyTrading",
         default=None,
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/historical_eps.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/historical_eps.py
@@ -31,32 +31,34 @@ class FMPHistoricalEpsQueryParams(HistoricalEpsQueryParams):
 class FMPHistoricalEpsData(HistoricalEpsData):
     """FMP Historical EPS Data."""
 
-    __alias_dict__ = {"eps_actual": "eps"}
+    __alias_dict__ = {
+        "eps_actual": "eps",
+        "revenue_estimated": "revenueEstimated",
+        "revenue_actual": "revenue",
+        "reporting_time": "time",
+        "updated_at": "updatedFromDate",
+        "period_ending": "fiscalDateEnding",
+    }
 
     revenue_estimated: Optional[float] = Field(
         default=None,
         description="Estimated consensus revenue for the reporting period.",
-        alias="revenueEstimated",
     )
     revenue_actual: Optional[float] = Field(
         default=None,
         description="The actual reported revenue.",
-        alias="revenue",
     )
     reporting_time: Optional[str] = Field(
         default=None,
         description="The reporting time - e.g. after market close.",
-        alias="time",
     )
     updated_at: Optional[dateType] = Field(
         default=None,
         description="The date when the data was last updated.",
-        alias="updatedFromDate",
     )
     period_ending: Optional[dateType] = Field(
         default=None,
         description="The fiscal period end date.",
-        alias="fiscalDateEnding",
     )
 
     @field_validator(

--- a/openbb_platform/providers/fmp/openbb_fmp/models/index_historical.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/index_historical.py
@@ -46,6 +46,10 @@ class FMPIndexHistoricalQueryParams(IndexHistoricalQueryParams):
 class FMPIndexHistoricalData(IndexHistoricalData):
     """FMP Index Historical Data."""
 
+    __alias_dict__ = {
+        "change_percent": "changeOverTime",
+    }
+
     vwap: Optional[float] = Field(
         default=None, description=DATA_DESCRIPTIONS.get("vwap", "")
     )
@@ -56,7 +60,6 @@ class FMPIndexHistoricalData(IndexHistoricalData):
     change_percent: Optional[float] = Field(
         default=None,
         description="Change in the price from the previous close, as a normalized percent.",
-        alias="changeOverTime",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
 

--- a/openbb_platform/providers/fmp/openbb_fmp/models/insider_trading.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/insider_trading.py
@@ -21,10 +21,19 @@ class FMPInsiderTradingQueryParams(InsiderTradingQueryParams):
     Source: https://site.financialmodelingprep.com/developer/docs/#Stock-Insider-Trading
     """
 
+    __json_schema_extra__ = {
+        "transaction_type": {
+            "multiple_items_allowed": False,
+            "choices": list(TRANSACTION_TYPES_DICT),
+        }
+    }
+    __alias_dict__ = {
+        "transaction_type": "transactionType",
+    }
+
     transaction_type: Optional[TRANSACTION_TYPES] = Field(
         default=None,
         description="Type of the transaction.",
-        alias="transactionType",
     )
 
     @model_validator(mode="after")

--- a/openbb_platform/providers/fmp/openbb_fmp/models/institutional_ownership.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/institutional_ownership.py
@@ -30,6 +30,12 @@ class FMPInstitutionalOwnershipQueryParams(InstitutionalOwnershipQueryParams):
 class FMPInstitutionalOwnershipData(InstitutionalOwnershipData):
     """FMP Institutional Ownership Data."""
 
+    __alias_dict__ = {
+        "number_of_13f_shares": "numberOf13Fshares",
+        "last_number_of_13f_shares": "lastNumberOf13Fshares",
+        "number_of_13f_shares_change": "numberOf13FsharesChange",
+    }
+
     investors_holding: int = Field(description="Number of investors holding the stock.")
     last_investors_holding: int = Field(
         description="Number of investors holding the stock in the last quarter."
@@ -40,17 +46,14 @@ class FMPInstitutionalOwnershipData(InstitutionalOwnershipData):
     number_of_13f_shares: int = Field(
         default=None,
         description="Number of 13F shares.",
-        alias="numberOf13Fshares",
     )
     last_number_of_13f_shares: int = Field(
         default=None,
         description="Number of 13F shares in the last quarter.",
-        alias="lastNumberOf13Fshares",
     )
     number_of_13f_shares_change: int = Field(
         default=None,
         description="Change in the number of 13F shares.",
-        alias="numberOf13FsharesChange",
     )
     total_invested: float = Field(description="Total amount invested.")
     last_total_invested: float = Field(

--- a/openbb_platform/providers/fmp/openbb_fmp/models/key_metrics.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/key_metrics.py
@@ -51,9 +51,19 @@ class FMPKeyMetricsData(KeyMetricsData):
     __alias_dict__ = {
         "dividend_yield": "dividend_yiel",
         "market_cap": "marketCap",
-        "research_and_development_to_revenue": "researchAndDevelopementToRevenue",
+        "research_and_development_to_revenue": "researchAndDdevelopementToRevenue",
         "fiscal_period": "period",
         "period_ending": "date",
+        "price_to_sales": "priceToSalesRatio",
+        "price_to_operating_cash_flow": "pocfratio",
+        "price_to_free_cash_flow": "pfcfRatio",
+        "price_to_book": "pbRatio",
+        "price_to_tangible_book": "ptbRatio",
+        "ev_to_sales": "evToSales",
+        "ev_to_ebitda": "enterpriseValueOverEBITDA",
+        "net_debt_to_ebitda": "netDebtToEBITDA",
+        "return_on_equity": "roe",
+        "return_on_invested_capital": "roic",
     }
     period_ending: dateType = Field(description="Period ending date.")
     fiscal_period: str = Field(description="Period of the data.")
@@ -91,37 +101,30 @@ class FMPKeyMetricsData(KeyMetricsData):
     price_to_sales: Optional[float] = Field(
         default=None,
         description="Price-to-sales ratio",
-        alias="priceToSalesRatio",
     )
     price_to_operating_cash_flow: Optional[float] = Field(
         default=None,
         description="Price-to-operating cash flow ratio",
-        alias="pocfratio",
     )
     price_to_free_cash_flow: Optional[float] = Field(
         default=None,
         description="Price-to-free cash flow ratio",
-        alias="pfcfRatio",
     )
     price_to_book: Optional[float] = Field(
         default=None,
         description="Price-to-book ratio",
-        alias="pbRatio",
     )
     price_to_tangible_book: Optional[float] = Field(
         default=None,
         description="Price-to-tangible book ratio",
-        alias="ptbRatio",
     )
     ev_to_sales: Optional[float] = Field(
         default=None,
         description="Enterprise value-to-sales ratio",
-        alias="evToSales",
     )
     ev_to_ebitda: Optional[float] = Field(
         default=None,
         description="Enterprise value-to-EBITDA ratio",
-        alias="enterpriseValueOverEBITDA",
     )
     ev_to_operating_cash_flow: Optional[float] = Field(
         default=None, description="Enterprise value-to-operating cash flow ratio"
@@ -151,7 +154,6 @@ class FMPKeyMetricsData(KeyMetricsData):
     net_debt_to_ebitda: Optional[float] = Field(
         default=None,
         description="Net debt-to-EBITDA ratio",
-        alias="netDebtToEBITDA",
     )
     current_ratio: Optional[float] = Field(default=None, description="Current ratio")
     interest_coverage: Optional[float] = Field(
@@ -166,7 +168,7 @@ class FMPKeyMetricsData(KeyMetricsData):
     research_and_development_to_revenue: Optional[float] = Field(
         default=None,
         description="Research and development expenses-to-revenue ratio",
-        alias="researchAndDdevelopementToRevenue",
+        alias="researchAndDevelopementToRevenue",
     )
     intangibles_to_total_assets: Optional[float] = Field(
         default=None, description="Intangibles-to-total assets ratio"
@@ -229,13 +231,11 @@ class FMPKeyMetricsData(KeyMetricsData):
         default=None,
         description="Return on equity",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="roe",
     )
     return_on_invested_capital: Optional[float] = Field(
         default=None,
         description="Return on invested capital",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="roic",
     )
     return_on_tangible_assets: Optional[float] = Field(
         default=None,

--- a/openbb_platform/providers/fmp/openbb_fmp/models/market_snapshots.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/market_snapshots.py
@@ -45,6 +45,12 @@ class FMPMarketSnapshotsData(MarketSnapshotsData):
         "last_price_timestamp": "timestamp",
         "shares_outstanding": "sharesOutstanding",
         "volume_avg": "avgVolume",
+        "ma50": "priceAvg50",
+        "ma200": "priceAvg200",
+        "year_high": "yearHigh",
+        "year_low": "yearLow",
+        "market_cap": "marketCap",
+        "earnings_date": "earningsAnnouncement",
     }
 
     last_price: Optional[float] = Field(
@@ -54,22 +60,18 @@ class FMPMarketSnapshotsData(MarketSnapshotsData):
         description="The timestamp of the last price.", default=None
     )
     ma50: Optional[float] = Field(
-        description="The 50-day moving average.", alias="priceAvg50", default=None
+        description="The 50-day moving average.", default=None
     )
     ma200: Optional[float] = Field(
-        description="The 200-day moving average.", alias="priceAvg200", default=None
+        description="The 200-day moving average.", default=None
     )
-    year_high: Optional[float] = Field(
-        description="The 52-week high.", alias="yearHigh", default=None
-    )
-    year_low: Optional[float] = Field(
-        description="The 52-week low.", alias="yearLow", default=None
-    )
+    year_high: Optional[float] = Field(description="The 52-week high.", default=None)
+    year_low: Optional[float] = Field(description="The 52-week low.", default=None)
     volume_avg: Optional[ForceInt] = Field(
         description="Average daily trading volume.", default=None
     )
     market_cap: Optional[ForceInt] = Field(
-        description="Market cap of the stock.", alias="marketCap", default=None
+        description="Market cap of the stock.", default=None
     )
     eps: Optional[float] = Field(description="Earnings per share.", default=None)
     pe: Optional[float] = Field(description="Price to earnings ratio.", default=None)
@@ -85,7 +87,6 @@ class FMPMarketSnapshotsData(MarketSnapshotsData):
     )
     earnings_date: Optional[Union[datetime, dateType]] = Field(
         description="The upcoming earnings announcement date.",
-        alias="earningsAnnouncement",
         default=None,
     )
 

--- a/openbb_platform/providers/government_us/openbb_government_us/models/treasury_auctions.py
+++ b/openbb_platform/providers/government_us/openbb_government_us/models/treasury_auctions.py
@@ -19,16 +19,130 @@ class GovernmentUSTreasuryAuctionsQueryParams(USTreasuryAuctionsQueryParams):
     """
 
     __alias_dict__ = {
-        "start_date": "startDate",
-        "end_date": "endDate",
         "security_type": "type",
         "page_size": "pagesize",
         "page_num": "pagenum",
+        "start_date": "startDate",
+        "end_date": "endDate",
     }
 
 
 class GovernementUSTreasuryAuctionsData(USTreasuryAuctionsData):
     """US Government Treasury Auctions Data."""
+
+    __alias_dict__ = {
+        "issue_date": "issueDate",
+        "security_type": "securityType",
+        "security_term": "securityTerm",
+        "maturity_date": "maturityDate",
+        "interest_rate": "interestRate",
+        "cpi_on_issue_date": "refCpiOnIssueDate",
+        "cpi_on_dated_date": "refCpiOnDatedDate",
+        "announcement_date": "announcementDate",
+        "auction_date": "auctionDate",
+        "auction_date_year": "auctionDateYear",
+        "dated_date": "datedDate",
+        "first_payment_date": "firstInterestPaymentDate",
+        "accrued_interest_per_100": "accruedInterestPer100",
+        "accrued_interest_per_1000": "accruedInterestPer1000",
+        "adjusted_accrued_interest_per_100": "adjustedAccruedInterestPer100",
+        "adjusted_accrued_interest_per_1000": "adjustedAccruedInterestPer1000",
+        "adjusted_price": "adjustedPrice",
+        "allocation_percentage": "allocationPercentage",
+        "allocation_percentage_decimals": "allocationPercentageDecimals",
+        "announced_cusip": "announcedCusip",
+        "auction_format": "auctionFormat",
+        "avg_median_discount_rate": "averageMedianDiscountRate",
+        "avg_median_investment_rate": "averageMedianInvestmentRate",
+        "avg_median_price": "averageMedianPrice",
+        "avg_median_discount_margin": "averageMedianDiscountMargin",
+        "avg_median_yield": "averageMedianYield",
+        "back_dated": "backDated",
+        "back_dated_date": "backDatedDate",
+        "bid_to_cover_ratio": "bidToCoverRatio",
+        "call_date": "callDate",
+        "called_date": "calledDate",
+        "cash_management_bill": "cashManagementBillCMB",
+        "closing_time_competitive": "closingTimeCompetitive",
+        "closing_time_non_competitive": "closingTimeNoncompetitive",
+        "competitive_accepted": "competitiveAccepted",
+        "competitive_accepted_decimals": "competitiveBidDecimals",
+        "competitive_tendered": "competitiveTendered",
+        "competitive_tenders_accepted": "competitiveTendersAccepted",
+        "corp_us_cusip": "corpusCusip",
+        "cpi_base_reference_period": "cpiBaseReferencePeriod",
+        "currently_outstanding": "currentlyOutstanding",
+        "direct_bidder_accepted": "directBidderAccepted",
+        "direct_bidder_tendered": "directBidderTendered",
+        "est_amount_of_publicly_held_maturing_security": "estimatedAmountOfPubliclyHeldMaturingSecuritiesByType",
+        "fima_included": "fimaIncluded",
+        "fima_non_competitive_accepted": "fimaNoncompetitiveAccepted",
+        "fima_non_competitive_tendered": "fimaNoncompetitiveTendered",
+        "first_interest_period": "firstInterestPeriod",
+        "first_interest_payment_date": "firstInterestPaymentDate",
+        "floating_rate": "floatingRate",
+        "frn_index_determination_date": "frnIndexDeterminationDate",
+        "frn_index_determination_rate": "frnIndexDeterminationRate",
+        "high_discount_rate": "highDiscountRate",
+        "high_investment_rate": "highInvestmentRate",
+        "high_price": "highPrice",
+        "high_discount_margin": "highDiscountMargin",
+        "high_yield": "highYield",
+        "index_ratio_on_issue_date": "indexRatioOnIssueDate",
+        "indirect_bidder_accepted": "indirectBidderAccepted",
+        "indirect_bidder_tendered": "indirectBidderTendered",
+        "interest_payment_frequency": "interestPaymentFrequency",
+        "low_discount_rate": "lowDiscountRate",
+        "low_investment_rate": "lowInvestmentRate",
+        "low_price": "lowPrice",
+        "low_discount_margin": "lowDiscountMargin",
+        "low_yield": "lowYield",
+        "maturing_date": "maturingDate",
+        "max_competitive_award": "maximumCompetitiveAward",
+        "max_non_competitive_award": "maximumNoncompetitiveAward",
+        "max_single_bid": "maximumSingleBid",
+        "min_bid_amount": "minimumBidAmount",
+        "min_strip_amount": "minimumStripAmount",
+        "min_to_issue": "minimumToIssue",
+        "multiples_to_bid": "multiplesToBid",
+        "multiples_to_issue": "multiplesToIssue",
+        "nlp_exclusion_amount": "nlpExclusionAmount",
+        "nlp_reporting_threshold": "nlpReportingThreshold",
+        "non_competitive_accepted": "noncompetitiveAccepted",
+        "non_competitive_tenders_accepted": "noncompetitiveTendersAccepted",
+        "offering_amount": "offeringAmount",
+        "original_cusip": "originalCusip",
+        "original_dated_date": "originalDatedDate",
+        "original_issue_date": "originalIssueDate",
+        "original_security_term": "originalSecurityTerm",
+        "pdf_announcement": "pdfFilenameAnnouncement",
+        "pdf_competitive_results": "pdfFilenameCompetitiveResults",
+        "pdf_non_competitive_results": "pdfFilenameNoncompetitiveResults",
+        "pdf_special_announcement": "pdfFilenameSpecialAnnouncement",
+        "price_per_100": "pricePer100",
+        "primary_dealer_accepted": "primaryDealerAccepted",
+        "primary_dealer_tendered": "primaryDealerTendered",
+        "security_term_day_month": "securityTermDayMonth",
+        "security_term_week_year": "securityTermWeekYear",
+        "soma_accepted": "somaAccepted",
+        "soma_holdings": "somaHoldings",
+        "soma_included": "somaIncluded",
+        "soma_tendered": "somaTendered",
+        "standard_payment_per_1000": "standardInterestPaymentPer1000",
+        "tiin_conversion_factor_per_1000": "tiinConversionFactorPer1000",
+        "total_accepted": "totalAccepted",
+        "total_tendered": "totalTendered",
+        "treasury_retail_accepted": "treasuryRetailAccepted",
+        "treasury_retail_tenders_accepted": "treasuryRetailTendersAccepted",
+        "unadjusted_accrued_interest_per_1000": "unadjustedAccruedInterestPer1000",
+        "unadjusted_price": "unadjustedPrice",
+        "updated_timestamp": "updatedTimestamp",
+        "xml_announcement": "xmlFilenameAnnouncement",
+        "xml_competitive_results": "xmlFilenameCompetitiveResults",
+        "xml_special_announcement": "xmlFilenameSpecialAnnouncement",
+        "tint_cusip1": "tintCusip1",
+        "tint_cusip2": "tintCusip2",
+    }
 
 
 class GovernmentUSTreasuryAuctionsFetcher(
@@ -62,6 +176,15 @@ class GovernmentUSTreasuryAuctionsFetcher(
 
         base_url = "https://www.treasurydirect.gov/TA_WS/securities/search?"
 
+        security_dict = {
+            "bill": "Bill",
+            "note": "Note",
+            "bond": "Bond",
+            "cmb": "CMB",
+            "tips": "TIPS",
+            "frn": "FRN",
+        }
+
         _query = query.model_dump()
         _query["startDate"] = (
             _query["startDate"].strftime("%m/%d/%Y") if query.start_date else None
@@ -69,6 +192,7 @@ class GovernmentUSTreasuryAuctionsFetcher(
         _query["endDate"] = (
             _query["endDate"].strftime("%m/%d/%Y") if _query["endDate"] else None
         )
+        _query["type"] = security_dict.get(_query["type"], _query["type"])
         query_string = get_querystring(_query, [])
 
         url = base_url + query_string + "&format=json"

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/calendar_ipo.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/calendar_ipo.py
@@ -25,6 +25,8 @@ class IntrinioCalendarIpoQueryParams(CalendarIpoQueryParams):
     __alias_dict__ = {
         "symbol": "ticker",
         "limit": "page_size",
+        "min_value": "offer_amount_greater_than",
+        "max_value": "offer_amount_less_than",
     }
 
     status: Optional[Literal["upcoming", "priced", "withdrawn"]] = Field(
@@ -33,12 +35,10 @@ class IntrinioCalendarIpoQueryParams(CalendarIpoQueryParams):
     min_value: Optional[int] = Field(
         description="Return IPOs with an offer dollar amount greater than the given amount.",
         default=None,
-        alias="offer_amount_greater_than",
     )
     max_value: Optional[int] = Field(
         description="Return IPOs with an offer dollar amount less than the given amount.",
         default=None,
-        alias="offer_amount_less_than",
     )
 
 

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/equity_historical.py
@@ -103,7 +103,12 @@ class IntrinioEquityHistoricalQueryParams(EquityHistoricalQueryParams):
 class IntrinioEquityHistoricalData(EquityHistoricalData):
     """Intrinio Equity Historical Price Data."""
 
-    __alias_dict__ = {"date": "time"}
+    __alias_dict__ = {
+        "date": "time",
+        "change_percent": "percent_change",
+        "interval": "frequency",
+        "intra_period": "intraperiod",
+    }
 
     average: Optional[float] = Field(
         default=None,
@@ -116,7 +121,6 @@ class IntrinioEquityHistoricalData(EquityHistoricalData):
     change_percent: Optional[float] = Field(
         default=None,
         description="Percent change in the price of the symbol from the previous day.",
-        alias="percent_change",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     adj_open: Optional[float] = Field(
@@ -167,7 +171,6 @@ class IntrinioEquityHistoricalData(EquityHistoricalData):
     interval: Optional[str] = Field(
         default=None,
         description="The data time frequency.",
-        alias="frequency",
     )
     intra_period: Optional[bool] = Field(
         default=None,
@@ -175,7 +178,6 @@ class IntrinioEquityHistoricalData(EquityHistoricalData):
         "(be it day, week, quarter, month, or year), meaning that the close "
         "price is the latest price available, not the official close price "
         "for the period",
-        alias="intraperiod",
     )
 
 

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/institutional_ownership.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/institutional_ownership.py
@@ -21,8 +21,13 @@ class IntrinioInstitutionalOwnershipQueryParams(InstitutionalOwnershipQueryParam
             https://docs.intrinio.com/documentation/web_api/get_owner_by_id_v2
     """
 
+    __alias_dict__ = {
+        "limit": "page_size",
+    }
+
     limit: Optional[int] = Field(
-        default=100, description=QUERY_DESCRIPTIONS.get("limit", ""), alias="page_size"
+        default=100,
+        description=QUERY_DESCRIPTIONS.get("limit", ""),
     )
 
 
@@ -32,10 +37,11 @@ class IntrinioInstitutionalOwnershipData(InstitutionalOwnershipData):
     __alias_dict__ = {
         "cik": "owner_cik",
         "date": "period_ended",
+        "name": "owner_name",
     }
 
     name: str = Field(
-        description="Name of the institutional owner.", alias="owner_name"
+        description="Name of the institutional owner.",
     )
     value: float = Field(description="Value of the institutional owner.")
     amount: float = Field(description="Amount of the institutional owner.")

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/institutional_ownership.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/institutional_ownership.py
@@ -117,7 +117,7 @@ class IntrinioInstitutionalOwnershipFetcher(
         for item in results:
             if isinstance(item, Exception):
                 continue
-            data.append(item)
+            data.append(item)  # type: ignore
 
         return data
 

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/share_statistics.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/share_statistics.py
@@ -29,12 +29,12 @@ class IntrinioShareStatisticsData(ShareStatisticsData):
 
     __alias_dict__ = {
         "outstanding_shares": "weightedavebasicdilutedsharesos",
+        "adjusted_outstanding_shares": "adjweightedavebasicdilutedsharesos",
     }
 
     adjusted_outstanding_shares: Optional[float] = Field(
         default=None,
         description="Total number of shares of a publicly-traded company, adjusted for splits.",
-        alias="adjweightedavebasicdilutedsharesos",
     )
     public_float: Optional[float] = Field(
         default=None,

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_dividend.py
@@ -31,12 +31,12 @@ class NasdaqCalendarDividendData(CalendarDividendData):
         "record_date": "record_Date",
         "declaration_date": "announcement_Date",
         "amount": "dividend_Rate",
+        "annualized_amount": "indicated_Annual_Dividend",
     }
 
     annualized_amount: Optional[float] = Field(
         default=None,
         description="The indicated annualized dividend amount.",
-        alias="indicated_Annual_Dividend",
     )
 
     @field_validator(

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_earnings.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_earnings.py
@@ -31,41 +31,42 @@ class NasdaqCalendarEarningsData(CalendarEarningsData):
         "report_date": "date",
         "eps_previous": "lastYearEPS",
         "eps_consensus": "epsForecast",
+        "eps_actual": "eps",
+        "surprise_percent": "surprise",
+        "num_estimates": "noOfEsts",
+        "period_ending": "fiscalQuarterEnding",
+        "previous_report_date": "lastYearRptDt",
+        "reporting_time": "time",
+        "market_cap": "marketCap",
     }
+
     eps_actual: Optional[float] = Field(
         default=None,
         description="The actual earnings per share (USD) announced.",
-        alias="eps",
     )
     surprise_percent: Optional[float] = Field(
         default=None,
         description="The earnings surprise as normalized percentage points.",
-        alias="surprise",
     )
     num_estimates: Optional[int] = Field(
         default=None,
         description="The number of analysts providing estimates for the consensus.",
-        alias="noOfEsts",
     )
     period_ending: Optional[str] = Field(
         default=None,
         description="The fiscal period end date.",
-        alias="fiscalQuarterEnding",
     )
     previous_report_date: Optional[dateType] = Field(
         default=None,
         description="The previous report date for the same period last year.",
-        alias="lastYearRptDt",
     )
     reporting_time: Optional[str] = Field(
         default=None,
         description="The reporting time - e.g. after market close.",
-        alias="time",
     )
     market_cap: Optional[int] = Field(
         default=None,
         description="The market cap (USD) of the reporting entity.",
-        alias="marketCap",
     )
 
     @field_validator(

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_ipo.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/calendar_ipo.py
@@ -42,38 +42,42 @@ class NasdaqCalendarIpoData(CalendarIpoData):
         "share_price": "proposedSharePrice",
         "exchange": "proposedExchange",
         "id": "dealID",
+        "name": "companyName",
+        "offer_amount": "dollarValueOfSharesOffered",
+        "share_count": "sharesOffered",
+        "expected_price_date": "expectedPriceDate",
+        "filed_date": "filedDate",
+        "withdraw_date": "withdrawDate",
+        "deal_status": "dealStatus",
     }
 
     name: Optional[str] = Field(
         default=None,
         description="The name of the company.",
-        alias="companyName",
     )
     offer_amount: Optional[float] = Field(
         default=None,
         description="The dollar value of the shares offered.",
-        alias="dollarValueOfSharesOffered",
     )
     share_count: Optional[int] = Field(
         default=None,
         description="The number of shares offered.",
-        alias="sharesOffered",
     )
     expected_price_date: Optional[dateType] = Field(
         default=None,
         description="The date the pricing is expected.",
-        alias="expectedPriceDate",
     )
     filed_date: Optional[dateType] = Field(
-        default=None, description="The date the IPO was filed.", alias="filedDate"
+        default=None,
+        description="The date the IPO was filed.",
     )
     withdraw_date: Optional[dateType] = Field(
         default=None,
         description="The date the IPO was withdrawn.",
-        alias="withdrawDate",
     )
     deal_status: Optional[str] = Field(
-        default=None, description="The status of the deal.", alias="dealStatus"
+        default=None,
+        description="The status of the deal.",
     )
 
     @field_validator(

--- a/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/crypto_historical.py
@@ -84,12 +84,12 @@ class PolygonCryptoHistoricalData(CryptoHistoricalData):
         "close": "c",
         "volume": "v",
         "vwap": "vw",
+        "transactions": "n",
     }
 
     transactions: Optional[PositiveInt] = Field(
         default=None,
         description="Number of transactions for the symbol in the time period.",
-        alias="n",
     )
 
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_historical.py
@@ -88,12 +88,12 @@ class PolygonEquityHistoricalData(EquityHistoricalData):
         "close": "c",
         "volume": "v",
         "vwap": "vw",
+        "transactions": "n",
     }
 
     transactions: Optional[PositiveInt] = Field(
         default=None,
         description="Number of transactions for the symbol in the time period.",
-        alias="n",
     )
 
 

--- a/openbb_platform/providers/polygon/openbb_polygon/models/equity_nbbo.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/equity_nbbo.py
@@ -21,6 +21,8 @@ class PolygonEquityNBBOQueryParams(EquityNBBOQueryParams):
     Source: https://polygon.io/docs/stocks/get_v3_quotes__stockticker
     """
 
+    __alias_dict__ = {"date": "timestamp"}
+
     limit: int = Field(
         default=50000,
         description=(
@@ -38,7 +40,6 @@ class PolygonEquityNBBOQueryParams(EquityNBBOQueryParams):
             QUERY_DESCRIPTIONS.get("date", "")
             + " Use bracketed the timestamp parameters to specify exact time ranges."
         ),
-        alias="timestamp",
     )
     timestamp_lt: Optional[Union[datetime, str]] = Field(
         default=None,
@@ -81,16 +82,24 @@ class PolygonEquityNBBOQueryParams(EquityNBBOQueryParams):
 class PolygonEquityNBBOData(EquityNBBOData):
     """Polygon Equity NBBO data."""
 
-    __alias_dict__ = {"ask": "ask_price", "bid": "bid_price"}
+    __alias_dict__ = {
+        "ask": "ask_price",
+        "bid": "bid_price",
+        "tape": "tape_integer",
+        "sequence_num": "sequence_number",
+    }
 
     tape: Optional[str] = Field(
-        default=None, description="The exchange tape.", alias="tape_integer"
+        default=None,
+        description="The exchange tape.",
     )
     conditions: Optional[Union[str, List[int], List[str]]] = Field(
-        default=None, description="A list of condition codes.", alias="conditions"
+        default=None,
+        description="A list of condition codes.",
     )
     indicators: Optional[List[int]] = Field(
-        default=None, description="A list of indicator codes.", alias="indicators"
+        default=None,
+        description="A list of indicator codes.",
     )
     sequence_num: Optional[int] = Field(
         default=None,
@@ -99,7 +108,6 @@ class PolygonEquityNBBOData(EquityNBBOData):
             "These are increasing and unique per ticker symbol, but will not always be sequential "
             "(e.g., 1, 2, 6, 9, 10, 11)"
         ),
-        alias="sequence_number",
     )
     participant_timestamp: Optional[datetime] = Field(
         default=None,

--- a/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
+++ b/openbb_platform/providers/polygon/openbb_polygon/models/index_historical.py
@@ -83,12 +83,12 @@ class PolygonIndexHistoricalData(IndexHistoricalData):
         "close": "c",
         "volume": "v",
         "vwap": "vw",
+        "transactions": "n",
     }
 
     transactions: Optional[PositiveInt] = Field(
         default=None,
         description="Number of transactions for the symbol in the time period.",
-        alias="n",
     )
 
 

--- a/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
@@ -53,12 +53,21 @@ class SecCompanyFilingsData(CompanyFilingsData):
         "filing_url": "filingDetailUrl",
         "report_url": "primaryDocumentUrl",
         "report_type": "form",
+        "report_date": "reportDate",
+        "primary_doc_description": "primaryDocDescription",
+        "primary_doc": "primaryDocument",
+        "accession_number": "accessionNumber",
+        "file_number": "fileNumber",
+        "film_number": "filmNumber",
+        "is_inline_xbrl": "isInlineXBRL",
+        "is_xbrl": "isXBRL",
+        "complete_submission_url": "completeSubmissionUrl",
+        "filing_detail_url": "filingDetailUrl",
     }
 
     report_date: Optional[dateType] = Field(
         description="The date of the filing.",
         default=None,
-        alias="reportDate",
     )
     act: Optional[Union[str, int]] = Field(
         description="The SEC Act number.", default=None
@@ -69,37 +78,30 @@ class SecCompanyFilingsData(CompanyFilingsData):
     primary_doc_description: Optional[str] = Field(
         description="The description of the primary document.",
         default=None,
-        alias="primaryDocDescription",
     )
     primary_doc: Optional[str] = Field(
         description="The filename of the primary document.",
         default=None,
-        alias="primaryDocument",
     )
     accession_number: Optional[Union[str, int]] = Field(
         description="The accession number.",
         default=None,
-        alias="accessionNumber",
     )
     file_number: Optional[Union[str, int]] = Field(
         description="The file number.",
         default=None,
-        alias="fileNumber",
     )
     film_number: Optional[Union[str, int]] = Field(
         description="The film number.",
         default=None,
-        alias="filmNumber",
     )
     is_inline_xbrl: Optional[Union[str, int]] = Field(
         description="Whether the filing is an inline XBRL filing.",
         default=None,
-        alias="isInlineXBRL",
     )
     is_xbrl: Optional[Union[str, int]] = Field(
         description="Whether the filing is an XBRL filing.",
         default=None,
-        alias="isXBRL",
     )
     size: Optional[Union[str, int]] = Field(
         description="The size of the filing.", default=None
@@ -107,12 +109,10 @@ class SecCompanyFilingsData(CompanyFilingsData):
     complete_submission_url: Optional[str] = Field(
         description="The URL to the complete filing submission.",
         default=None,
-        alias="completeSubmissionUrl",
     )
     filing_detail_url: Optional[str] = Field(
         description="The URL to the filing details.",
         default=None,
-        alias="filingDetailUrl",
     )
 
     @field_validator("report_date", mode="before", check_fields=False)

--- a/openbb_platform/providers/sec/openbb_sec/models/compare_company_facts.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/compare_company_facts.py
@@ -36,6 +36,11 @@ class SecCompareCompanyFactsQueryParams(CompareCompanyFactsQueryParams):
 
     __json_schema_extra__ = {
         "symbol": {"multiple_items_allowed": True},
+        "fact": {"multiple_items_allowed": False, "choices": sorted(FACTS)},
+        "fiscal_period": {
+            "multiple_items_allowed": False,
+            "choices": ["fy", "q1", "q2", "q3", "q4"],
+        },
     }
 
     fact: FACT_CHOICES = Field(
@@ -43,7 +48,6 @@ class SecCompareCompanyFactsQueryParams(CompareCompanyFactsQueryParams):
         description="Fact or concept from the SEC taxonomy, in UpperCamelCase. Defaults to, 'Revenues'."
         + " AAPL, MSFT, GOOG, BRK-A currently report revenue as, 'RevenueFromContractWithCustomerExcludingAssessedTax'."
         + " In previous years, they have reported as 'Revenues'.",
-        json_schema_extra={"choices": sorted(FACTS)},
     )
     year: Optional[int] = Field(
         default=None,

--- a/openbb_platform/providers/sec/openbb_sec/models/etf_holdings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/etf_holdings.py
@@ -39,7 +39,22 @@ class SecEtfHoldingsQueryParams(EtfHoldingsQueryParams):
 class SecEtfHoldingsData(EtfHoldingsData):
     """SEC ETF Holdings Data."""
 
-    __alias_dict__ = {"name": "title"}
+    __alias_dict__ = {
+        "name": "title",
+        "weight": "pctVal",
+        "value": "valUSD",
+        "payoff_profile": "payoffProfile",
+        "currency": "curCd",
+        "asset_category": "assetCat",
+        "issuer_category": "issuerCat",
+        "country": "invCountry",
+        "is_restricted": "isRestrictedSec",
+        "fair_value_level": "fairValLevel",
+        "is_cash_collateral": "isCashCollateral",
+        "is_non_cash_collateral": "isNonCashCollateral",
+        "is_loan_by_fund": "isLoanByFund",
+        "loan_value": "loanVal",
+    }
 
     lei: Optional[str] = Field(description="The LEI of the holding.", default=None)
     cusip: Optional[str] = Field(description="The CUSIP of the holding.", default=None)
@@ -52,63 +67,54 @@ class SecEtfHoldingsData(EtfHoldingsData):
     )
     weight: Optional[float] = Field(
         description="The weight of the holding in ETF in %.",
-        alias="pctVal",
         default=None,
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     value: Optional[float] = Field(
-        description="The value of the holding in USD.", alias="valUSD", default=None
+        description="The value of the holding in USD.", default=None
     )
     payoff_profile: Optional[str] = Field(
         description="The payoff profile of the holding.",
-        alias="payoffProfile",
         default=None,
     )
     units: Optional[Union[float, str]] = Field(
         description="The units of the holding.", default=None
     )
     currency: Optional[str] = Field(
-        description="The currency of the holding.", alias="curCd", default=None
+        description="The currency of the holding.", default=None
     )
     asset_category: Optional[str] = Field(
-        description="The asset category of the holding.", alias="assetCat", default=None
+        description="The asset category of the holding.", default=None
     )
     issuer_category: Optional[str] = Field(
         description="The issuer category of the holding.",
-        alias="issuerCat",
         default=None,
     )
     country: Optional[str] = Field(
-        description="The country of the holding.", alias="invCountry", default=None
+        description="The country of the holding.", default=None
     )
     is_restricted: Optional[str] = Field(
         description="Whether the holding is restricted.",
-        alias="isRestrictedSec",
         default=None,
     )
     fair_value_level: Optional[int] = Field(
         description="The fair value level of the holding.",
-        alias="fairValLevel",
         default=None,
     )
     is_cash_collateral: Optional[str] = Field(
         description="Whether the holding is cash collateral.",
-        alias="isCashCollateral",
         default=None,
     )
     is_non_cash_collateral: Optional[str] = Field(
         description="Whether the holding is non-cash collateral.",
-        alias="isNonCashCollateral",
         default=None,
     )
     is_loan_by_fund: Optional[str] = Field(
         description="Whether the holding is loan by fund.",
-        alias="isLoanByFund",
         default=None,
     )
     loan_value: Optional[float] = Field(
         description="The loan value of the holding.",
-        alias="loanVal",
         default=None,
     )
     issuer_conditional: Optional[str] = Field(

--- a/openbb_platform/providers/sec/openbb_sec/models/institutions_search.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/institutions_search.py
@@ -25,11 +25,18 @@ class SecInstitutionsSearchQueryParams(CotSearchQueryParams):
 class SecInstitutionsSearchData(Data):
     """SEC Institutions Search Data."""
 
+    __alias_dict__ = {
+        "name": "Institution",
+        "cik": "CIK Number",
+    }
+
     name: Optional[str] = Field(
-        default=None, description="The name of the institution.", alias="Institution"
+        default=None,
+        description="The name of the institution.",
     )
     cik: Optional[Union[str, int]] = Field(
-        default=None, description="Central Index Key (CIK)", alias="CIK Number"
+        default=None,
+        description="Central Index Key (CIK)",
     )
 
 

--- a/openbb_platform/providers/sec/openbb_sec/models/rss_litigation.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/rss_litigation.py
@@ -23,7 +23,11 @@ class SecRssLitigationQueryParams(QueryParams):
 class SecRssLitigationData(Data):
     """SEC Litigation RSS Feed Data."""
 
-    published: datetime = Field(description="The date of publication.", alias="date")
+    __alias_dict__ = {
+        "published": "date",
+    }
+
+    published: datetime = Field(description="The date of publication.")
     title: str = Field(description="The title of the release.")
     summary: str = Field(description="Short summary of the release.")
     id: str = Field(description="The identifier associated with the release.")

--- a/openbb_platform/providers/sec/openbb_sec/models/sic_search.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/sic_search.py
@@ -25,11 +25,16 @@ class SecSicSearchQueryParams(CotSearchQueryParams):
 class SecSicSearchData(Data):
     """SEC Standard Industrial Classification Code (SIC) Data."""
 
-    sic: int = Field(description="Sector Industrial Code (SIC)", alias="SIC Code")
-    industry: str = Field(description="Industry title.", alias="Industry Title")
+    __alias_dict__ = {
+        "sic": "SIC Code",
+        "industry": "Industry Title",
+        "office": "Office",
+    }
+
+    sic: int = Field(description="Sector Industrial Code (SIC)")
+    industry: str = Field(description="Industry title.")
     office: str = Field(
-        description="Reporting office within the Corporate Finance Office",
-        alias="Office",
+        description="Reporting office within the Corporate Finance Office"
     )
 
 

--- a/openbb_platform/providers/seeking_alpha/openbb_seeking_alpha/utils/helpers.py
+++ b/openbb_platform/providers/seeking_alpha/openbb_seeking_alpha/utils/helpers.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from openbb_core.provider.utils.helpers import amake_request
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0",  # noqa
     "Accept": "*/*",
     "Accept-Language": "en-US,en;q=0.9",
     "Accept-Encoding": "gzip, deflate, br, zstd",

--- a/openbb_platform/providers/seeking_alpha/openbb_seeking_alpha/utils/helpers.py
+++ b/openbb_platform/providers/seeking_alpha/openbb_seeking_alpha/utils/helpers.py
@@ -5,7 +5,7 @@ from datetime import timedelta
 from openbb_core.provider.utils.helpers import amake_request
 
 HEADERS = {
-    "User-Agent": "Mozilla/5.0 (X11; Linux x86_64; rv:106.0) Gecko/20100101 Firefox/106.0",
+    "User-Agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/128.0.0.0",
     "Accept": "*/*",
     "Accept-Language": "en-US,en;q=0.9",
     "Accept-Encoding": "gzip, deflate, br, zstd",

--- a/openbb_platform/providers/tiingo/openbb_tiingo/models/company_news.py
+++ b/openbb_platform/providers/tiingo/openbb_tiingo/models/company_news.py
@@ -44,12 +44,13 @@ class TiingoCompanyNewsData(CompanyNewsData):
         "symbols": "tickers",
         "date": "publishedDate",
         "text": "description",
+        "article_id": "id",
     }
 
     tags: Optional[str] = Field(
         default=None, description="Tags associated with the news article."
     )
-    article_id: int = Field(description="Unique ID of the news article.", alias="id")
+    article_id: int = Field(description="Unique ID of the news article.")
     source: str = Field(description="News source.")
     crawl_date: datetime = Field(description="Date the news article was crawled.")
 

--- a/openbb_platform/providers/tiingo/openbb_tiingo/models/crypto_historical.py
+++ b/openbb_platform/providers/tiingo/openbb_tiingo/models/crypto_historical.py
@@ -73,10 +73,14 @@ class TiingoCryptoHistoricalQueryParams(CryptoHistoricalQueryParams):
 class TiingoCryptoHistoricalData(CryptoHistoricalData):
     """Tiingo Crypto Historical Price Data."""
 
+    __alias_dict__ = {
+        "transactions": "tradesDone",
+        "volume_notional": "volumeNotional",
+    }
+
     transactions: Optional[int] = Field(
         default=None,
         description="Number of transactions for the symbol in the time period.",
-        alias="tradesDone",
     )
 
     volume_notional: Optional[float] = Field(
@@ -86,7 +90,6 @@ class TiingoCryptoHistoricalData(CryptoHistoricalData):
             "quote currency. The volume of the asset on the specific date in "
             "the quote currency."
         ),
-        alias="volumeNotional",
     )
 
 

--- a/openbb_platform/providers/tiingo/openbb_tiingo/models/equity_historical.py
+++ b/openbb_platform/providers/tiingo/openbb_tiingo/models/equity_historical.py
@@ -66,40 +66,43 @@ class TiingoEquityHistoricalQueryParams(EquityHistoricalQueryParams):
 class TiingoEquityHistoricalData(EquityHistoricalData):
     """Tiingo Equity Historical Price Data."""
 
+    __alias_dict__ = {
+        "adj_open": "adjOpen",
+        "adj_high": "adjHigh",
+        "adj_low": "adjLow",
+        "adj_close": "adjClose",
+        "adj_volume": "adjVolume",
+        "split_ratio": "splitFactor",
+        "dividend": "divCash",
+    }
+
     adj_open: Optional[float] = Field(
         default=None,
         description="The adjusted open price.",
-        alias="adjOpen",
     )
     adj_high: Optional[float] = Field(
         default=None,
         description="The adjusted high price.",
-        alias="adjHigh",
     )
     adj_low: Optional[float] = Field(
         default=None,
         description="The adjusted low price.",
-        alias="adjLow",
     )
     adj_close: Optional[float] = Field(
         default=None,
         description=DATA_DESCRIPTIONS.get("adj_close", ""),
-        alias="adjClose",
     )
     adj_volume: Optional[float] = Field(
         default=None,
         description="The adjusted volume.",
-        alias="adjVolume",
     )
     split_ratio: Optional[float] = Field(
         default=None,
         description="Ratio of the equity split, if a split occurred.",
-        alias="splitFactor",
     )
     dividend: Optional[float] = Field(
         default=None,
         description="Dividend amount, if a dividend was paid.",
-        alias="divCash",
     )
 
 

--- a/openbb_platform/providers/tiingo/openbb_tiingo/models/world_news.py
+++ b/openbb_platform/providers/tiingo/openbb_tiingo/models/world_news.py
@@ -40,15 +40,17 @@ class TiingoWorldNewsData(WorldNewsData):
     __alias_dict__ = {
         "date": "publishedDate",
         "text": "description",
+        "symbols": "tickers",
+        "article_id": "id",
+        "site": "source",
     }
 
     symbols: Optional[str] = Field(
         default=None,
         description="Ticker tagged in the fetched news.",
-        alias="tickers",
     )
-    article_id: int = Field(description="Unique ID of the news article.", alias="id")
-    site: str = Field(description="News source.", alias="source")
+    article_id: int = Field(description="Unique ID of the news article.")
+    site: str = Field(description="News source.")
     tags: Optional[str] = Field(
         default=None,
         description="Tags associated with the news article.",

--- a/openbb_platform/providers/tmx/openbb_tmx/models/bond_prices.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/bond_prices.py
@@ -55,6 +55,15 @@ class TmxBondPricesData(BondReferenceData):
 
     __alias_dict__ = {
         "coupon_rate": "couponRate",
+        "ytm": "lastYield",
+        "price": "lastPrice",
+        "highest_price": "highestPrice",
+        "lowest_price": "lowestPrice",
+        "total_trades": "totalTrades",
+        "last_traded_date": "lastTradedDate",
+        "maturity_date": "maturityDate",
+        "issue_date": "originalIssueDate",
+        "issuer_name": "issuer",
     }
 
     ytm: Optional[float] = Field(
@@ -64,48 +73,39 @@ class TmxBondPricesData(BondReferenceData):
         + " the current market price, par value, coupon rate and time to maturity. It is assumed that all"
         + " coupons are reinvested at the same rate."
         + " Values are returned as a normalized percent.",
-        alias="lastYield",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     price: Optional[float] = Field(
         default=None,
         description="The last price for the bond.",
-        alias="lastPrice",
     )
     highest_price: Optional[float] = Field(
         default=None,
         description="The highest price for the bond on the last traded date.",
-        alias="highestPrice",
     )
     lowest_price: Optional[float] = Field(
         default=None,
         description="The lowest price for the bond on the last traded date.",
-        alias="lowestPrice",
     )
     total_trades: Optional[int] = Field(
         default=None,
         description="Total number of trades on the last traded date.",
-        alias="totalTrades",
     )
     last_traded_date: Optional[dateType] = Field(
         default=None,
         description="Last traded date of the bond.",
-        alias="lastTradedDate",
     )
     maturity_date: Optional[dateType] = Field(
         default=None,
         description="Maturity date of the bond.",
-        alias="maturityDate",
     )
     issue_date: Optional[dateType] = Field(
         default=None,
         description="Issue date of the bond. This is the date when the bond first accrues interest.",
-        alias="originalIssueDate",
     )
     issuer_name: Optional[str] = Field(
         default=None,
         description="Name of the issuing entity.",
-        alias="issuer",
     )
 
     @field_validator(

--- a/openbb_platform/providers/tmx/openbb_tmx/models/calendar_earnings.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/calendar_earnings.py
@@ -26,9 +26,10 @@ class TmxCalendarEarningsData(CalendarEarningsData):
         "eps_consensus": "estimatedEps",
         "eps_surprise": "epsSurpriseDollar",
         "surprise_percent": "epsSurprisePercent",
+        "name": "companyName",
     }
 
-    name: str = Field(description="The company's name.", alias="companyName")
+    name: str = Field(description="The company's name.")
     eps_consensus: Optional[float] = Field(
         default=None, description="The consensus estimated EPS in dollars."
     )

--- a/openbb_platform/providers/tmx/openbb_tmx/models/equity_profile.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/equity_profile.py
@@ -30,25 +30,28 @@ class TmxEquityProfileData(EquityInfoData):
         "stock_exchange": "exchangeCode",
         "industry_category": "industry",
         "industry_group": "qmdescription",
+        "issue_type": "issueType",
+        "share_outstanding": "shareOutStanding",
+        "shares_escrow": "sharesESCROW",
+        "total_shares_outstanding": "totalSharesOutStanding",
     }
+
     email: Optional[str] = Field(description="The email of the company.", default=None)
     issue_type: Optional[str] = Field(
-        description="The issuance type of the asset.", default=None, alias="issueType"
+        description="The issuance type of the asset.",
+        default=None,
     )
     shares_outstanding: Optional[int] = Field(
         description="The number of listed shares outstanding.",
         default=None,
-        alias="shareOutStanding",
     )
     shares_escrow: Optional[int] = Field(
         description="The number of shares held in escrow.",
         default=None,
-        alias="sharesESCROW",
     )
     shares_total: Optional[int] = Field(
         description="The total number of shares outstanding from all classes.",
         default=None,
-        alias="totalSharesOutStanding",
     )
     dividend_frequency: Optional[str] = Field(
         description="The dividend frequency.", default=None

--- a/openbb_platform/providers/tmx/openbb_tmx/models/equity_quote.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/equity_quote.py
@@ -40,7 +40,35 @@ class TmxEquityQuoteData(EquityQuoteData):
         "industry_group": "qmdescription",
         "exchange": "exchangeCode",
         "security_type": "datatype",
+        "year_high": "weeks52high",
+        "year_low": "weeks52low",
+        "ma_21": "day21MovingAvg",
+        "ma_50": "day50MovingAvg",
+        "ma_200": "day200MovingAvg",
+        "volume_avg_10d": "averageVolume10D",
+        "volume_avg_30d": "averageVolume30D",
+        "volume_avg_50d": "averageVolume50D",
+        "market_cap": "marketCap",
+        "market_cap_all_classes": "MarketCapAllClasses",
+        "div_amount": "dividendAmount",
+        "div_currency": "dividendCurrency",
+        "div_yield": "dividendYield",
+        "div_freq": "dividendFrequency",
+        "div_ex_date": "exDividendDate",
+        "div_pay_date": "dividendPayDate",
+        "div_growth_3y": "dividend3Years",
+        "div_growth_5y": "dividend5Years",
+        "pe": "peRatio",
+        "debt_to_equity": "totalDebtToEquity",
+        "price_to_book": "priceToBook",
+        "price_to_cf": "priceToCashFlow",
+        "return_on_equity": "returnOnEquity",
+        "return_on_assets": "returnOnAssets",
+        "shares_outstanding": "shareOutStanding",
+        "shares_escrow": "sharesESCROW",
+        "shares_total": "totalSharesOutStanding",
     }
+
     name: Optional[str] = Field(default=None, description="The name of the asset.")
     security_type: Optional[str] = Field(
         description="The issuance type of the asset.", default=None
@@ -95,109 +123,107 @@ class TmxEquityQuoteData(EquityQuoteData):
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     year_high: Optional[float] = Field(
-        description="Fifty-two week high.", default=None, alias="weeks52high"
+        description="Fifty-two week high.",
+        default=None,
     )
     year_low: Optional[float] = Field(
-        description="Fifty-two week low.", default=None, alias="weeks52low"
+        description="Fifty-two week low.",
+        default=None,
     )
     ma_21: Optional[float] = Field(
         description="Twenty-one day moving average.",
         default=None,
-        alias="day21MovingAvg",
     )
     ma_50: Optional[float] = Field(
-        description="Fifty day moving average.", default=None, alias="day50MovingAvg"
+        description="Fifty day moving average.",
+        default=None,
     )
     ma_200: Optional[float] = Field(
         description="Two-hundred day moving average.",
         default=None,
-        alias="day200MovingAvg",
     )
     volume_avg_10d: Optional[int] = Field(
-        description="Ten day average volume.", default=None, alias="averageVolume10D"
+        description="Ten day average volume.",
+        default=None,
     )
     volume_avg_30d: Optional[int] = Field(
-        description="Thirty day average volume.", default=None, alias="averageVolume30D"
+        description="Thirty day average volume.",
+        default=None,
     )
     volume_avg_50d: Optional[int] = Field(
-        description="Fifty day average volume.", default=None, alias="averageVolume50D"
+        description="Fifty day average volume.",
+        default=None,
     )
     market_cap: Optional[int] = Field(
-        description="Market capitalization.", default=None, alias="MarketCap"
+        description="Market capitalization.",
+        default=None,
     )
     market_cap_all_classes: Optional[int] = Field(
         description="Market capitalization of all share classes.",
         default=None,
-        alias="MarketCapAllClasses",
     )
     div_amount: Optional[float] = Field(
         description="The most recent dividend amount.",
         default=None,
-        alias="dividendAmount",
     )
     div_currency: Optional[str] = Field(
         description="The currency the dividend is paid in.",
         default=None,
-        alias="dividendCurrency",
     )
     div_yield: Optional[float] = Field(
         description="The dividend yield as a normalized percentage.",
         default=None,
-        alias="dividendYield",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     div_freq: Optional[str] = Field(
         description="The frequency of dividend payments.",
         default=None,
-        alias="dividendFrequency",
     )
     div_ex_date: Optional[dateType] = Field(
-        description="The ex-dividend date.", default=None, alias="exDividendDate"
+        description="The ex-dividend date.",
+        default=None,
     )
     div_pay_date: Optional[dateType] = Field(
         description="The next dividend ayment date.",
         default=None,
-        alias="dividendPayDate",
     )
     div_growth_3y: Optional[Union[float, str]] = Field(
         description="The three year dividend growth as a normalized percentage.",
         default=None,
-        alias="dividend3Years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     div_growth_5y: Optional[Union[float, str]] = Field(
         description="The five year dividend growth as a normalized percentage.",
         default=None,
-        alias="dividend5Years",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     pe: Optional[Union[float, str]] = Field(
-        description="The price to earnings ratio.", default=None, alias="peRatio"
+        description="The price to earnings ratio.",
+        default=None,
     )
     eps: Optional[Union[float, str]] = Field(
         description="The earnings per share.", default=None
     )
     debt_to_equity: Optional[Union[float, str]] = Field(
-        description="The debt to equity ratio.", default=None, alias="totalDebtToEquity"
+        description="The debt to equity ratio.",
+        default=None,
     )
     price_to_book: Optional[Union[float, str]] = Field(
-        description="The price to book ratio.", default=None, alias="priceToBook"
+        description="The price to book ratio.",
+        default=None,
     )
     price_to_cf: Optional[Union[float, str]] = Field(
         description="The price to cash flow ratio.",
         default=None,
-        alias="priceToCashFlow",
     )
     return_on_equity: Optional[Union[float, str]] = Field(
         description="The return on equity, as a normalized percentage.",
         default=None,
-        alias="returnOnEquity",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     return_on_assets: Optional[Union[float, str]] = Field(
         description="The return on assets, as a normalized percentage.",
         default=None,
-        alias="returnOnAssets",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     beta: Optional[Union[float, str]] = Field(
@@ -209,17 +235,14 @@ class TmxEquityQuoteData(EquityQuoteData):
     shares_outstanding: Optional[int] = Field(
         description="The number of listed shares outstanding.",
         default=None,
-        alias="shareOutStanding",
     )
     shares_escrow: Optional[int] = Field(
         description="The number of shares held in escrow.",
         default=None,
-        alias="sharesESCROW",
     )
     shares_total: Optional[int] = Field(
         description="The total number of shares outstanding from all classes.",
         default=None,
-        alias="totalSharesOutStanding",
     )
 
     @field_validator(

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_holdings.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_holdings.py
@@ -28,6 +28,10 @@ class TmxEtfHoldingsQueryParams(EtfHoldingsQueryParams):
 class TmxEtfHoldingsData(EtfHoldingsData):
     """TMX ETF Holdings Data."""
 
+    __alias_dict__ = {
+        "shares": "number_of_shares",
+    }
+
     symbol: Optional[str] = Field(
         description="The ticker symbol of the asset.", default=None
     )
@@ -39,7 +43,6 @@ class TmxEtfHoldingsData(EtfHoldingsData):
     )
     shares: Optional[Union[int, str]] = Field(
         description="The value of the assets under management.",
-        alias="number_of_shares",
         default=None,
     )
     market_value: Optional[Union[float, str]] = Field(

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_info.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_info.py
@@ -27,9 +27,14 @@ class TmxEtfInfoQueryParams(EtfInfoQueryParams):
 class TmxEtfInfoData(EtfInfoData):
     """TMX ETF Info Data."""
 
-    issuer: Optional[str] = Field(
-        description="The issuer of the ETF.", alias="fund_family", default=None
-    )
+    __alias_dict__ = {
+        "avg_volume": "volume_avg_daily",
+        "issuer": "fund_family",
+        "avg_volume_30d": "volume_avg_30d",
+        "description": "investment_objectives",
+    }
+
+    issuer: Optional[str] = Field(description="The issuer of the ETF.", default=None)
     investment_style: Optional[str] = Field(
         description="The investment style of the ETF.", default=None
     )
@@ -91,12 +96,10 @@ class TmxEtfInfoData(EtfInfoData):
     )
     avg_volume: Optional[int] = Field(
         description="The average daily volume of the ETF.",
-        alias="volume_avg_daily",
         default=None,
     )
     avg_volume_30d: Optional[int] = Field(
         description="The 30-day average volume of the ETF.",
-        alias="volume_avg_30d",
         default=None,
     )
     aum: Optional[float] = Field(description="The AUM of the ETF.", default=None)
@@ -127,7 +130,6 @@ class TmxEtfInfoData(EtfInfoData):
     website: Optional[str] = Field(description="The website of the ETF.", default=None)
     description: Optional[str] = Field(
         description="The description of the ETF.",
-        alias="investment_objectives",
         default=None,
     )
 

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_search.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_search.py
@@ -50,15 +50,19 @@ class TmxEtfSearchQueryParams(EtfSearchQueryParams):
 class TmxEtfSearchData(EtfSearchData):
     """TMX ETF Search Data."""
 
+    __alias_dict__ = {
+        "issuer": "fund_family",
+        "avg_volume": "volume_avg_daily",
+        "avg_volume_30d": "volume_avg_30d",
+    }
+
     short_name: Optional[str] = Field(
         description="The short name of the ETF.", default=None
     )
     inception_date: Optional[str] = Field(
         description="The inception date of the ETF.", default=None
     )
-    issuer: Optional[str] = Field(
-        description="The issuer of the ETF.", alias="fund_family", default=None
-    )
+    issuer: Optional[str] = Field(description="The issuer of the ETF.", default=None)
     investment_style: Optional[str] = Field(
         description="The investment style of the ETF.", default=None
     )
@@ -141,12 +145,10 @@ class TmxEtfSearchData(EtfSearchData):
     )
     avg_volume: Optional[int] = Field(
         description="The average daily volume of the ETF.",
-        alias="volume_avg_daily",
         default=None,
     )
     avg_volume_30d: Optional[int] = Field(
         description="The 30-day average volume of the ETF.",
-        alias="volume_avg_30d",
         default=None,
     )
     aum: Optional[float] = Field(description="The AUM of the ETF.", default=None)

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/available_indices.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/available_indices.py
@@ -23,10 +23,14 @@ class YFinanceAvailableIndicesQueryParams(AvailableIndicesQueryParams):
 class YFinanceAvailableIndicesData(AvailableIndicesData):
     """Yahoo Finance Available Indices Data."""
 
+    __alias_dict__ = {
+        "symbol": "ticker",
+    }
+
     code: str = Field(
         description="ID code for keying the index in the OpenBB Terminal."
     )
-    symbol: str = Field(description="Symbol for the index.", alias="ticker")
+    symbol: str = Field(description="Symbol for the index.")
 
 
 class YFinanceAvailableIndicesFetcher(

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
@@ -52,7 +52,6 @@ class YFinanceEquityProfileData(EquityInfoData):
     issue_type: Optional[str] = Field(
         description="The issuance type of the asset.",
         default=None,
-        alias="issueType",
     )
     currency: Optional[str] = Field(
         description="The currency in which the asset is traded.", default=None
@@ -84,7 +83,6 @@ class YFinanceEquityProfileData(EquityInfoData):
         description="The dividend yield of the asset, as a normalized percent.",
         default=None,
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="dividendYield",
     )
     beta: Optional[float] = Field(
         description="The beta of the asset relative to the broad market.",
@@ -166,7 +164,11 @@ class YFinanceEquityProfileFetcher(
             if ticker:
                 for field in fields:
                     if field in ticker:
-                        result[field] = ticker.get(field, None)
+                        result[
+                            field.replace("dividendYield", "dividend_yield").replace(
+                                "issueType", "issue_type"
+                            )
+                        ] = ticker.get(field, None)
                 if result:
                     results.append(result)
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
@@ -38,16 +38,21 @@ class YFinanceEquityProfileData(EquityInfoData):
         "long_description": "longBusinessSummary",
         "employees": "fullTimeEmployees",
         "market_cap": "marketCap",
-        "dividend_yield": "dividendYield",
+        "shares_outstanding": "sharesOutstanding",
+        "shares_float": "floatShares",
+        "shares_implied_outstanding": "impliedSharesOutstanding",
+        "shares_short": "sharesShort",
+        "dividend_yield": "yield",
     }
 
     exchange_timezone: Optional[str] = Field(
         description="The timezone of the exchange.",
         default=None,
-        alias="timeZoneFullName",
     )
     issue_type: Optional[str] = Field(
-        description="The issuance type of the asset.", default=None, alias="issueType"
+        description="The issuance type of the asset.",
+        default=None,
+        alias="issueType",
     )
     currency: Optional[str] = Field(
         description="The currency in which the asset is traded.", default=None
@@ -59,12 +64,10 @@ class YFinanceEquityProfileData(EquityInfoData):
     shares_outstanding: Optional[int] = Field(
         description="The number of listed shares outstanding.",
         default=None,
-        alias="sharesOutstanding",
     )
     shares_float: Optional[int] = Field(
         description="The number of shares in the public float.",
         default=None,
-        alias="floatShares",
     )
     shares_implied_outstanding: Optional[int] = Field(
         description=(
@@ -72,18 +75,16 @@ class YFinanceEquityProfileData(EquityInfoData):
             "assuming the conversion of all convertible subsidiary equity into common."
         ),
         default=None,
-        alias="impliedSharesOutstanding",
     )
     shares_short: Optional[int] = Field(
         description="The reported number of shares short.",
         default=None,
-        alias="sharesShort",
     )
     dividend_yield: Optional[float] = Field(
         description="The dividend yield of the asset, as a normalized percent.",
         default=None,
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="yield",
+        alias="dividendYield",
     )
     beta: Optional[float] = Field(
         description="The beta of the asset relative to the broad market.",

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_quote.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_quote.py
@@ -31,27 +31,27 @@ class YFinanceEquityQuoteData(EquityQuoteData):
         "prev_close": "previousClose",
         "year_high": "fiftyTwoWeekHigh",
         "year_low": "fiftyTwoWeekLow",
+        "ma_50d": "fiftyDayAverage",
+        "ma_200d": "twoHundredDayAverage",
+        "volume_average": "averageVolume",
+        "volume_average_10d": "averageDailyVolume10Day",
     }
 
     ma_50d: Optional[float] = Field(
         default=None,
         description="50-day moving average price.",
-        alias="fiftyDayAverage",
     )
     ma_200d: Optional[float] = Field(
         default=None,
         description="200-day moving average price.",
-        alias="twoHundredDayAverage",
     )
     volume_average: Optional[float] = Field(
         default=None,
         description="Average daily trading volume.",
-        alias="averageVolume",
     )
     volume_average_10d: Optional[float] = Field(
         default=None,
         description="Average daily trading volume in the last 10 days.",
-        alias="averageDailyVolume10Day",
     )
     currency: Optional[str] = Field(
         default=None,

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/etf_info.py
@@ -26,17 +26,39 @@ class YFinanceEtfInfoData(EtfInfoData):
         "name": "longName",
         "inception_date": "fundInceptionDate",
         "description": "longBusinessSummary",
+        "fund_type": "legalType",
+        "fund_family": "fundFamily",
+        "exchange_timezone": "timeZoneFullName",
+        "nav_price": "navPrice",
+        "total_assets": "totalAssets",
+        "trailing_pe": "trailingPE",
+        "dividend_yield": "yield",
+        "dividend_rate_ttm": "trailingAnnualDividendRate",
+        "dividend_yield_ttm": "trailingAnnualDividendYield",
+        "year_high": "fiftyTwoWeekHigh",
+        "year_low": "fiftyTwoWeekLow",
+        "ma_50d": "fiftyDayAverage",
+        "ma_200d": "twoHundredDayAverage",
+        "return_ytd": "ytdReturn",
+        "return_3y_avg": "threeYearAverageReturn",
+        "return_5y_avg": "fiveYearAverageReturn",
+        "beta_3y_avg": "beta3Year",
+        "volume_avg": "averageVolume",
+        "volume_avg_10d": "averageDailyVolume10Day",
+        "bid_size": "bidSize",
+        "ask_size": "askSize",
+        "high": "dayHigh",
+        "low": "dayLow",
+        "prev_close": "previousClose",
     }
 
     fund_type: Optional[str] = Field(
         default=None,
         description="The legal type of fund.",
-        alias="legalType",
     )
     fund_family: Optional[str] = Field(
         default=None,
         description="The fund family.",
-        alias="fundFamily",
     )
     category: Optional[str] = Field(
         default=None,
@@ -49,7 +71,6 @@ class YFinanceEtfInfoData(EtfInfoData):
     exchange_timezone: Optional[str] = Field(
         default=None,
         description="The timezone of the exchange.",
-        alias="timeZoneFullName",
     )
     currency: Optional[str] = Field(
         default=None,
@@ -58,87 +79,71 @@ class YFinanceEtfInfoData(EtfInfoData):
     nav_price: Optional[float] = Field(
         default=None,
         description="The net asset value per unit of the fund.",
-        alias="navPrice",
     )
     total_assets: Optional[int] = Field(
         default=None,
         description="The total value of assets held by the fund.",
-        alias="totalAssets",
     )
     trailing_pe: Optional[float] = Field(
         default=None,
         description="The trailing twelve month P/E ratio of the fund's assets.",
-        alias="trailingPE",
     )
     dividend_yield: Optional[float] = Field(
         default=None,
         description="The dividend yield of the fund, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="yield",
     )
     dividend_rate_ttm: Optional[float] = Field(
         default=None,
         description="The trailing twelve month annual dividend rate of the fund, in currency units.",
-        alias="trailingAnnualDividendRate",
     )
     dividend_yield_ttm: Optional[float] = Field(
         default=None,
         description="The trailing twelve month annual dividend yield of the fund, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="trailingAnnualDividendYield",
     )
     year_high: Optional[float] = Field(
         default=None,
         description="The fifty-two week high price.",
-        alias="fiftyTwoWeekHigh",
     )
     year_low: Optional[float] = Field(
         default=None,
         description="The fifty-two week low price.",
-        alias="fiftyTwoWeekLow",
     )
     ma_50d: Optional[float] = Field(
         default=None,
         description="50-day moving average price.",
-        alias="fiftyDayAverage",
     )
     ma_200d: Optional[float] = Field(
         default=None,
         description="200-day moving average price.",
-        alias="twoHundredDayAverage",
     )
     return_ytd: Optional[float] = Field(
         default=None,
         description="The year-to-date return of the fund, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="ytdReturn",
     )
     return_3y_avg: Optional[float] = Field(
         default=None,
         description="The three year average return of the fund, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="threeYearAverageReturn",
     )
     return_5y_avg: Optional[float] = Field(
         default=None,
         description="The five year average return of the fund, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="fiveYearAverageReturn",
     )
     beta_3y_avg: Optional[float] = Field(
         default=None,
         description="The three year average beta of the fund.",
-        alias="beta3Year",
     )
     volume_avg: Optional[float] = Field(
         default=None,
         description="The average daily trading volume of the fund.",
-        alias="averageVolume",
     )
     volume_avg_10d: Optional[float] = Field(
         default=None,
         description="The average daily trading volume of the fund over the past ten days.",
-        alias="averageDailyVolume10Day",
     )
     bid: Optional[float] = Field(
         default=None,
@@ -147,7 +152,6 @@ class YFinanceEtfInfoData(EtfInfoData):
     bid_size: Optional[float] = Field(
         default=None,
         description="The current bid size.",
-        alias="bidSize",
     )
     ask: Optional[float] = Field(
         default=None,
@@ -156,7 +160,6 @@ class YFinanceEtfInfoData(EtfInfoData):
     ask_size: Optional[float] = Field(
         default=None,
         description="The current ask size.",
-        alias="askSize",
     )
     open: Optional[float] = Field(
         default=None,
@@ -165,12 +168,10 @@ class YFinanceEtfInfoData(EtfInfoData):
     high: Optional[float] = Field(
         default=None,
         description="The highest price of the most recent trading session.",
-        alias="dayHigh",
     )
     low: Optional[float] = Field(
         default=None,
         description="The lowest price of the most recent trading session.",
-        alias="dayLow",
     )
     volume: Optional[int] = Field(
         default=None,
@@ -179,7 +180,6 @@ class YFinanceEtfInfoData(EtfInfoData):
     prev_close: Optional[float] = Field(
         default=None,
         description="The previous closing price.",
-        alias="previousClose",
     )
 
     @field_validator("inception_date", mode="before", check_fields=False)

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/key_metrics.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/key_metrics.py
@@ -25,131 +25,144 @@ class YFinanceKeyMetricsData(KeyMetricsData):
     __alias_dict__ = {
         "market_cap": "marketCap",
         "pe_ratio": "trailingPE",
+        "forward_pe": "forwardPE",
+        "peg_ratio": "pegRatio",
+        "peg_ratio_ttm": "trailingPegRatio",
+        "eps_ttm": "trailingEps",
+        "eps_forward": "forwardEps",
+        "enterprise_to_ebitda": "enterpriseToEbitda",
+        "earnings_growth": "earningsGrowth",
+        "earnings_growth_quarterly": "earningsQuarterlyGrowth",
+        "revenue_per_share": "revenuePerShare",
+        "revenue_growth": "revenueGrowth",
+        "enterprise_to_revenue": "enterpriseToRevenue",
+        "cash_per_share": "totalCashPerShare",
+        "quick_ratio": "quickRatio",
+        "current_ratio": "currentRatio",
+        "debt_to_equity": "debtToEquity",
+        "gross_margin": "grossMargins",
+        "operating_margin": "operatingMargins",
+        "ebitda_margin": "ebitdaMargins",
+        "profit_margin": "profitMargins",
+        "return_on_assets": "returnOnAssets",
+        "return_on_equity": "returnOnEquity",
+        "dividend_yield": "dividendYield",
+        "dividend_yield_5y_avg": "fiveYearAvgDividendYield",
+        "payout_ratio": "payoutRatio",
+        "book_value": "bookValue",
+        "price_to_book": "priceToBook",
+        "enterprise_value": "enterpriseValue",
+        "overall_risk": "overallRisk",
+        "audit_risk": "auditRisk",
+        "board_risk": "boardRisk",
+        "compensation_risk": "compensationRisk",
+        "shareholder_rights_risk": "shareHolderRightsRisk",
+        "price_return_1y": "52WeekChange",
+        "currency": "financialCurrency",
     }
+
     forward_pe: Optional[float] = Field(
         default=None,
         description="Forward price-to-earnings ratio.",
-        alias="forwardPE",
     )
     peg_ratio: Optional[float] = Field(
         default=None,
         description="PEG ratio (5-year expected).",
-        alias="pegRatio",
     )
     peg_ratio_ttm: Optional[float] = Field(
         default=None,
         description="PEG ratio (TTM).",
-        alias="trailingPegRatio",
     )
     eps_ttm: Optional[float] = Field(
         default=None,
         description="Earnings per share (TTM).",
-        alias="trailingEps",
     )
     eps_forward: Optional[float] = Field(
         default=None,
         description="Forward earnings per share.",
-        alias="forwardEps",
     )
     enterprise_to_ebitda: Optional[float] = Field(
         default=None,
         description="Enterprise value to EBITDA ratio.",
-        alias="enterpriseToEbitda",
     )
     earnings_growth: Optional[float] = Field(
         default=None,
         description="Earnings growth (Year Over Year), as a normalized percent.",
-        alias="earningsGrowth",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
     )
     earnings_growth_quarterly: Optional[float] = Field(
         default=None,
         description="Quarterly earnings growth (Year Over Year), as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="earningsQuarterlyGrowth",
     )
     revenue_per_share: Optional[float] = Field(
         default=None,
         description="Revenue per share (TTM).",
-        alias="revenuePerShare",
     )
     revenue_growth: Optional[float] = Field(
         default=None,
         description="Revenue growth (Year Over Year), as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="revenueGrowth",
     )
     enterprise_to_revenue: Optional[float] = Field(
         default=None,
         description="Enterprise value to revenue ratio.",
-        alias="enterpriseToRevenue",
     )
     cash_per_share: Optional[float] = Field(
         default=None,
         description="Cash per share.",
-        alias="totalCashPerShare",
     )
     quick_ratio: Optional[float] = Field(
         default=None,
         description="Quick ratio.",
-        alias="quickRatio",
     )
     current_ratio: Optional[float] = Field(
         default=None,
         description="Current ratio.",
-        alias="currentRatio",
     )
     debt_to_equity: Optional[float] = Field(
         default=None,
         description="Debt-to-equity ratio.",
-        alias="debtToEquity",
     )
     gross_margin: Optional[float] = Field(
         default=None,
         description="Gross margin, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="grossMargins",
     )
     operating_margin: Optional[float] = Field(
         default=None,
         description="Operating margin, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="operatingMargins",
     )
     ebitda_margin: Optional[float] = Field(
         default=None,
         description="EBITDA margin, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="ebitdaMargins",
     )
     profit_margin: Optional[float] = Field(
         default=None,
         description="Profit margin, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="profitMargins",
     )
     return_on_assets: Optional[float] = Field(
         default=None,
         description="Return on assets, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="returnOnAssets",
     )
     return_on_equity: Optional[float] = Field(
         default=None,
         description="Return on equity, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="returnOnEquity",
     )
     dividend_yield: Optional[float] = Field(
         default=None,
         description="Dividend yield, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="dividendYield",
     )
     dividend_yield_5y_avg: Optional[float] = Field(
         default=None,
         description="5-year average dividend yield, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="fiveYearAvgDividendYield",
     )
     payout_ratio: Optional[float] = Field(
         default=None,
@@ -158,42 +171,34 @@ class YFinanceKeyMetricsData(KeyMetricsData):
     book_value: Optional[float] = Field(
         default=None,
         description="Book value per share.",
-        alias="bookValue",
     )
     price_to_book: Optional[float] = Field(
         default=None,
         description="Price-to-book ratio.",
-        alias="priceToBook",
     )
     enterprise_value: Optional[int] = Field(
         default=None,
         description="Enterprise value.",
-        alias="enterpriseValue",
     )
     overall_risk: Optional[float] = Field(
         default=None,
         description="Overall risk score.",
-        alias="overallRisk",
     )
     audit_risk: Optional[float] = Field(
         default=None,
         description="Audit risk score.",
-        alias="auditRisk",
     )
     board_risk: Optional[float] = Field(
         default=None,
         description="Board risk score.",
-        alias="boardRisk",
     )
     compensation_risk: Optional[float] = Field(
         default=None,
         description="Compensation risk score.",
-        alias="compensationRisk",
     )
     shareholder_rights_risk: Optional[float] = Field(
         default=None,
         description="Shareholder rights risk score.",
-        alias="shareHolderRightsRisk",
     )
     beta: Optional[float] = Field(
         default=None,
@@ -203,12 +208,10 @@ class YFinanceKeyMetricsData(KeyMetricsData):
         default=None,
         description="One-year price return, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="52WeekChange",
     )
     currency: Optional[str] = Field(
         default=None,
         description="Currency in which the data is presented.",
-        alias="financialCurrency",
     )
 
     @field_validator("dividend_yield_5y_avg")

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
@@ -30,62 +30,62 @@ class YFinanceShareStatisticsData(ShareStatisticsData):
         "outstanding_shares": "sharesOutstanding",
         "float_shares": "floatShares",
         "date": "dateShortInterest",
+        "implied_shares_outstanding": "impliedSharesOutstanding",
+        "short_interest": "sharesShort",
+        "short_percent_of_float": "shortPercentOfFloat",
+        "days_to_cover": "shortRatio",
+        "short_interest_prev_month": "sharesShortPriorMonth",
+        "short_interest_prev_date": "sharesShortPreviousMonthDate",
+        "insider_ownership": "heldPercentInsiders",
+        "institution_ownership": "heldPercentInstitutions",
+        "institution_float_ownership": "institutionsFloatPercentHeld",
+        "institutions_count": "institutionsCount",
     }
 
     implied_shares_outstanding: Optional[int] = Field(
         default=None,
         description="Implied Shares Outstanding of common equity,"
         + " assuming the conversion of all convertible subsidiary equity into common.",
-        alias="impliedSharesOutstanding",
     )
     short_interest: Optional[int] = Field(
         default=None,
         description="Number of shares that are reported short.",
-        alias="sharesShort",
     )
     short_percent_of_float: Optional[float] = Field(
         default=None,
         description="Percentage of shares that are reported short, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="shortPercentOfFloat",
     )
     days_to_cover: Optional[float] = Field(
         default=None,
         description="Number of days to repurchase the shares as a ratio of average daily volume",
-        alias="shortRatio",
     )
     short_interest_prev_month: Optional[int] = Field(
         default=None,
         description="Number of shares that were reported short in the previous month.",
-        alias="sharesShortPriorMonth",
     )
     short_interest_prev_date: Optional[dateType] = Field(
         default=None,
         description="Date of the previous month's report.",
-        alias="sharesShortPreviousMonthDate",
     )
     insider_ownership: Optional[float] = Field(
         default=None,
         description="Percentage of shares held by insiders, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="heldPercentInsiders",
     )
     institution_ownership: Optional[float] = Field(
         default=None,
         description="Percentage of shares held by institutions, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="heldPercentInstitutions",
     )
     institution_float_ownership: Optional[float] = Field(
         default=None,
         description="Percentage of float held by institutions, as a normalized percent.",
         json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
-        alias="institutionsFloatPercentHeld",
     )
     institutions_count: Optional[int] = Field(
         default=None,
         description="Number of institutions holding shares.",
-        alias="institutionsCount",
     )
 
     @field_validator(


### PR DESCRIPTION
1. **Why**?:

    - OpenAPI gets confused by having `Field(alias='someAlias')` and will end up labeling the Field as the Alias unless we use`__alias_dict__`.

2. **What**?:

    - Moves the alias definition from `Field` to `__alias_dict__`

3. **Impact**:

    - A few Finviz field names have been adjusted to be more like the others.
    - Improved data model schemas in `openapi.json`

4. **Testing Done**:

    - Ran the test suites
