### PR TITLE
[BugFix] Make User Preferences -> Defaults Work With Any Parameter

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -195,6 +195,46 @@ def build_api_wrapper(
                 UserService.read_from_file(),
             )
         )
+        p = path.strip("/").replace("/", ".")
+        defaults = (
+            getattr(user_settings.defaults, "__dict__", {})
+            .get("commands", {})
+            .get(p, {})
+        )
+
+        if defaults:
+            provider_choices = getattr(
+                kwargs.get("provider_choices", None), "__dict__", {}
+            )
+            _provider = defaults.pop("provider", None)
+
+            if (
+                _provider
+                and isinstance(_provider, list)
+                and _provider[0] == provider_choices.get("provider")
+            ):
+                standard_params = getattr(
+                    kwargs.pop("standard_params", None), "__dict__", {}
+                )
+                extra_params = getattr(kwargs.pop("extra_params", None), "__dict__", {})
+
+                if "chart" in defaults:
+                    kwargs["chart"] = defaults.pop("chart", False)
+
+                if "chart_params" in defaults:
+                    extra_params["chart_params"] = defaults.pop("chart_params", {})
+
+                for k, v in defaults.items():
+                    if k in standard_params and standard_params[k] is None:
+                        standard_params[k] = v
+                    elif k not in extra_params or (
+                        k in extra_params and extra_params[k] is None
+                    ):
+                        extra_params[k] = v
+
+                kwargs["standard_params"] = standard_params
+                kwargs["extra_params"] = extra_params
+
         execute = partial(command_runner.run, path, user_settings)
         output: OBBject = await execute(*args, **kwargs)
 

--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -227,6 +227,10 @@ def build_api_wrapper(
                 for k, v in defaults.items():
                     if k in standard_params and standard_params[k] is None:
                         standard_params[k] = v
+                    elif (k in standard_params and standard_params[k] is not None) or (
+                        k in extra_params and extra_params[k] is not None
+                    ):
+                        continue
                     elif k not in extra_params or (
                         k in extra_params and extra_params[k] is None
                     ):

--- a/openbb_platform/core/openbb_core/app/model/defaults.py
+++ b/openbb_platform/core/openbb_core/app/model/defaults.py
@@ -49,7 +49,6 @@ class Defaults(BaseModel):
                 v["provider"] = [provider]
             new_values["commands"][clean_k] = v
 
-        print(new_values)
         return new_values
 
     def update(self, incoming: "Defaults"):

--- a/openbb_platform/core/openbb_core/app/model/defaults.py
+++ b/openbb_platform/core/openbb_core/app/model/defaults.py
@@ -1,6 +1,6 @@
 """Defaults model."""
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Optional, Union
 from warnings import warn
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -13,7 +13,7 @@ class Defaults(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True, populate_by_name=True)
 
-    commands: Dict[str, Dict[str, Optional[List[str]]]] = Field(
+    commands: Dict[str, Dict[str, Any]] = Field(
         default_factory=dict,
         alias="routes",
     )
@@ -41,13 +41,15 @@ class Defaults(BaseModel):
                 )
                 key = "routes"
 
-        new_values: Dict[str, Dict[str, Optional[List[str]]]] = {"commands": {}}
+        new_values: dict = {"commands": {}}
         for k, v in values.get(key, {}).items():
             clean_k = k.strip("/").replace("/", ".")
             provider = v.get("provider") if v else None
             if isinstance(provider, str):
                 v["provider"] = [provider]
             new_values["commands"][clean_k] = v
+
+        print(new_values)
         return new_values
 
     def update(self, incoming: "Defaults"):

--- a/openbb_platform/core/openbb_core/app/model/defaults.py
+++ b/openbb_platform/core/openbb_core/app/model/defaults.py
@@ -1,6 +1,6 @@
 """Defaults model."""
 
-from typing import Any, Dict, List, Optional, Union
+from typing import Any
 from warnings import warn
 
 from pydantic import BaseModel, ConfigDict, Field, model_validator
@@ -13,7 +13,7 @@ class Defaults(BaseModel):
 
     model_config = ConfigDict(validate_assignment=True, populate_by_name=True)
 
-    commands: Dict[str, Dict[str, Any]] = Field(
+    commands: dict[str, dict[str, Any]] = Field(
         default_factory=dict,
         alias="routes",
     )

--- a/openbb_platform/core/openbb_core/app/static/container.py
+++ b/openbb_platform/core/openbb_core/app/static/container.py
@@ -22,10 +22,10 @@ class Container:
 
     def _run(self, *args, **kwargs) -> Any:
         """Run a command in the container."""
-        endpoint = args[0][1:].replace("/", ".")
+        endpoint = args[0][1:].replace("/", ".") if args else ""
         defaults = self._command_runner.user_settings.defaults.commands
 
-        if defaults and defaults.get(endpoint):
+        if endpoint and defaults and defaults.get(endpoint):
             default_params = {
                 k: v for k, v in defaults[endpoint].items() if k != "provider"
             }

--- a/openbb_platform/core/openbb_core/app/static/container.py
+++ b/openbb_platform/core/openbb_core/app/static/container.py
@@ -85,9 +85,6 @@ class Container:
         """
         if choice is None:
             commands = self._command_runner.user_settings.defaults.commands
-            _command = self._command_runner._command_map.get_command(
-                command
-            )  # pylint: disable=protected-access
             providers = (
                 commands.get(command, {}).get("provider", []) or default_priority
             )


### PR DESCRIPTION
1. **Why**?:

    - The "defaults" section of the `user_settings.json` was not able to cope with anything other than "provider".
    - The app fails to import if the defaults configuration is incorrect.

2. **What**?:

    - Fixes the `Defaults` class so that validation errors don't happen when supplying other parameters.
      - Issue here was being unnecessarily, overly, specific with type hints.
    - Applies any defaults in the `Container`/`Command` classes if they are not supplied at runtime.
    - In the API: Default params will only work where the API has a default of None for the parameter.
    - Resolves #6686 via bypassing Provider Fallback if there is only one provider. Not a full solution, but will cover most scenarios in the custom router/provider world.

3. **Impact**:

    - Improved configurability.
    - The API only partially supports this behavior because all mandatory fields need to be supplied to the URL.

4. **Testing Done**:

    - Ran integration tests and have not found unexpected behavior.

User Settings:

```json
{
  "defaults": {
    "commands": {
      "/equity/price/historical": {
        "provider": "yfinance",
        "chart": true,
        "chart_params": {
          "heikin_ashi": true,
          "indicators": {
            "sma": {
              "length": [21, 50]
            },
            "ema": {
              "length": 150
            }
          }
        }
      }
    }
  }
}
```

Before:

```python
from openbb import obb
```

```sh
ValidationError: 2 validation errors for UserSettings
defaults.commands.`equity.price.historical`.chart
  Input should be a valid list [type=list_type, input_value=True, input_type=bool]
    For further information visit https://errors.pydantic.dev/2.9/v/list_type
defaults.commands.`equity.price.historical`.chart_params
  Input should be a valid list [type=list_type, input_value={'heikin_ashi': True, 'in...'ema': {'length': 150}}}, input_type=dict]
    For further information visit https://errors.pydantic.dev/2.9/v/list_type
```

After:

```python
from openbb import obb

res = obb.equity.price.historical(symbol="AAPL")
res.show()
```

![image](https://github.com/user-attachments/assets/6a3754ee-5131-4898-9b5c-838abd36cb28)
