### PR TITLE
[BugFix] Fixes #6688 BLS Title String Concactenation

### DIFF
--- a/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
+++ b/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
@@ -123,7 +123,11 @@ async def get_bls_timeseries(  # pylint: disable=too-many-branches  # noqa: PLR0
                 _date = year + "-12-31" if month == "13" else year + "-" + month + "-01"
             new_d["symbol"] = seriesID
             title = metadata[seriesID].get("series_title") if catalog else None
-            title = title + (" (Annual Average)" if month == "13" else "")
+            title = (
+                title + (" (Annual Average)" if month == "13" else "")
+                if title
+                else None
+            )
             if title:
                 new_d["title"] = title
             new_d["date"] = _date

--- a/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
+++ b/openbb_platform/providers/bls/openbb_bls/utils/helpers.py
@@ -8,7 +8,7 @@ if TYPE_CHECKING:
 
 # We need to wrap this as a helper to accommodate requests for historical data
 # greater than 20 years in length, or containing more than 50 symbols.
-async def get_bls_timeseries(  # pylint: disable=too-many-branches  # noqa: PLR0912
+async def get_bls_timeseries(  # pylint: disable=too-many-branches,too-many-positional-arguments  # noqa: PLR0912
     api_key: str,
     series_ids: Union[str, List[str]],
     start_year: Optional[int] = None,


### PR DESCRIPTION
1. **Why**?:

    - Resolves #6688

2. **What**?:

    - Error created by concatenating a title string that does not exist.
    - Skips if title is None


3. **Impact**:

    - BLS series that do not have catalogue metadata are being handled correctly.

4. **Testing Done**:

```python
obb.economy.survey.bls_series("JTS000000000000000QUR")
```

After:

![Screenshot 2024-09-23 at 7 49 08 PM](https://github.com/user-attachments/assets/b7fec79f-9f12-422a-ae78-e1578a721bdc)
