### PR TITLE
[BugFix] Handle Options Skew Error From Zero/Empty IV Value

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/options_chains.py
@@ -68,7 +68,8 @@ class OptionsChainsData(OptionsChainsProperties):
     Methods
     -------
     filter_data(
-        date: Optional[Union[str, int]] = None, column: Optional[str] = None,
+        date: Optional[Union[str, int]] = None,
+        column: Optional[str] = None,
         option_type: Optional[Literal["call", "put"]] = None,
         moneyness: Optional[Literal["otm", "itm"]] = None,
         value_min: Optional[float] = None,
@@ -78,7 +79,7 @@ class OptionsChainsData(OptionsChainsProperties):
     ) -> DataFrame:
         Return statistics by strike or expiration; or, the filtered chains data.
     skew(
-        days: Optional[int] = None, underlying_price: Optional[float] = None)
+        date: Optional[Union[int, str]] = None, underlying_price: Optional[float] = None)
     -> DataFrame:
         Return skewness of the options, either vertical or horizontal, by nearest DTE.
     straddle(

--- a/openbb_platform/core/openbb_core/provider/utils/options_chains_properties.py
+++ b/openbb_platform/core/openbb_core/provider/utils/options_chains_properties.py
@@ -1,6 +1,6 @@
 """Options Chains Properties."""
 
-# pylint: disable=too-many-lines, too-many-arguments, too-many-locals, too-many-statements
+# pylint: disable=too-many-lines, too-many-arguments, too-many-locals, too-many-statements, too-many-positional-arguments
 
 from datetime import datetime
 from typing import TYPE_CHECKING, Dict, List, Literal, Optional, Union

--- a/openbb_platform/core/openbb_core/provider/utils/options_chains_properties.py
+++ b/openbb_platform/core/openbb_core/provider/utils/options_chains_properties.py
@@ -1673,6 +1673,9 @@ class OptionsChainsProperties(Data):
             else data.underlying_price.iloc[0]
         )
 
+        if moneyness is not None and date is None:
+            date = -1
+
         if moneyness is None and date is None:
             date = 30
             moneyness = 20
@@ -1749,6 +1752,12 @@ class OptionsChainsProperties(Data):
                         puts = concat([puts, put_iv])  # type: ignore
                         atm_put_iv = concat([atm_put_iv, atm_put])  # type: ignore
 
+            if calls.empty or puts.empty:
+                raise OpenBBError(
+                    "Error: Not enough information to complete the operation."
+                    " Likely due to zero values in the IV field of the expiration."
+                )
+
             calls = calls.drop_duplicates(subset=["expiration"]).set_index("expiration")  # type: ignore
             atm_call_iv = atm_call_iv.drop_duplicates(subset=["expiration"]).set_index(  # type: ignore
                 "expiration"
@@ -1789,10 +1798,11 @@ class OptionsChainsProperties(Data):
                 call = _calls.set_index("expiration").copy()  # type: ignore
                 call_atm_iv = call.query("`strike` == @atm_call_strike")[
                     "implied_volatility"
-                ].iloc[0]
-                call["ATM IV"] = call_atm_iv
-                call["Skew"] = call["implied_volatility"] - call["ATM IV"]
-                call_skew = concat([call_skew, call])
+                ]
+                if len(call_atm_iv) > 0:
+                    call["ATM IV"] = call_atm_iv.iloc[0]
+                    call["Skew"] = call["implied_volatility"] - call["ATM IV"]
+                    call_skew = concat([call_skew, call])
 
             atm_put_strike = self._get_nearest_strike(
                 "put", day, force_otm=False
@@ -1805,11 +1815,15 @@ class OptionsChainsProperties(Data):
                 put = _puts.set_index("expiration").copy()  # type: ignore
                 put_atm_iv = put.query("`strike` == @atm_put_strike")[
                     "implied_volatility"
-                ].iloc[0]
-                put["ATM IV"] = put_atm_iv
-                put["Skew"] = put["implied_volatility"] - put["ATM IV"]
-                put_skew = concat([put_skew, put])
-
+                ]
+                if len(put_atm_iv) > 0:
+                    put["ATM IV"] = put_atm_iv.iloc[0]
+                    put["Skew"] = put["implied_volatility"] - put["ATM IV"]
+                    put_skew = concat([put_skew, put])
+        if call_skew.empty or put_skew.empty:
+            raise OpenBBError(
+                "Error: Not enough information to complete the operation. Likely due to zero values in the IV field."
+            )
         call_skew = call_skew.set_index(["strike", "option_type"], append=True)
         put_skew = put_skew.set_index(["strike", "option_type"], append=True)
         skew_df = concat([call_skew, put_skew]).sort_index().reset_index()


### PR DESCRIPTION
1. **Why**?:

    - This handles a KeyError from OptionsChainsProperties when skew cannot be calculated from a given expiry.
      - Error will mostly be contained to VIX and similar chains, or when new weekly expiries are opened and IV is reported as 0, resulting in an unexpectedly empty DataFrame.

2. **What**?:

    - Adds checks before accessing the potentially empty DFs and raises an error accordingly.

3. **Impact**:

    - Improved error handling.

4. **Testing Done**:

    - Kind of hard to recreate, you might need to use VIX from Cboe, after hours, or when a new expiry is opened.

Before:

<img width="1085" alt="Screenshot 2024-09-26 at 11 07 49 PM" src="https://github.com/user-attachments/assets/ffdf5c1f-3ca9-4640-bd59-608e7678765d">


After:

![Screenshot 2024-09-26 at 10 50 14 PM](https://github.com/user-attachments/assets/e7cb37ab-6bec-452d-a6fb-f94eaba571f9)
