### PR TITLE
[BugFix] `obb.derivatives.futures.historical`: Fix Start/End Filters Not Being Applied.

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/futures_historical.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/futures_historical.py
@@ -128,8 +128,8 @@ class YFinanceFuturesHistoricalFetcher(
 
         data = yf_download(
             query.symbol,
-            start=query.start_date,
-            end=query.end_date,
+            start_date=query.start_date,
+            end_date=query.end_date,
             interval=INTERVALS_DICT[query.interval],  # type: ignore
             prepost=True,
             auto_adjust=False,


### PR DESCRIPTION
1. **Why**?:

    - Start/End dates were not being filtered from the `openbb-yfinance` provider in `obb.derivatives.futures.historical`
```python 
obb.derivatives.futures.historical(symbol='es',start_date='2024-09-20',end_date='2024-09-30').to_df()
```

2. **What**?:

    - It was passing an inner function param name instead of the out function's.

3. **Impact**:

    - Just this one fetcher.

4. **Testing Done**:

    - Before/After.

After:

| date       |    open |    high |     low |   close |      volume |
|:-----------|--------:|--------:|--------:|--------:|------------:|
| 2024-09-20 | 5714.75 | 5717.25 | 5699.25 | 5699.99 | 1.62366e+06 |
| 2024-09-23 | 5762    | 5784.5  | 5745.25 | 5776.75 | 1.07794e+06 |
| 2024-09-24 | 5774    | 5794.25 | 5754.75 | 5792    | 1.18122e+06 |
| 2024-09-25 | 5792.25 | 5798.75 | 5768    | 5779    | 1.04366e+06 |
| 2024-09-26 | 5783.5  | 5830    | 5778.25 | 5804.5  | 1.36003e+06 |
| 2024-09-27 | 5804.25 | 5821.5  | 5782    | 5791.25 | 1.36003e+06 |
| 2024-09-30 | 5784    | 5804.25 | 5756.25 | 5803.5  | 1.0484e+06  |
