### PR TITLE
[BugFix] Update `ruff.toml` To Use Python 3.9 As Minimum Supported Version

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -8,7 +8,8 @@ exclude = [
 ]
 
 line-length = 122
-target-version = "py38"
+target-version = "py39"
+fix = true
 
 [lint]
 select = [

--- a/ruff.toml
+++ b/ruff.toml
@@ -28,7 +28,7 @@ select = [
     "T20",
 ]
 # These ignores should be seen as temporary solutions to problems that will NEED fixed
-ignore = ["PLR2004", "PLR0913", "PLR0915"]
+ignore = ["PLR2004", "PLR0913", "PLR0915", "UP035", "UP006"]
 
 [lint.per-file-ignores]
 "**/tests/*" = ["S101"]


### PR DESCRIPTION
1. **Why**?:

    - Lint rules are being based on the Python 3.8, which is no longer supported.

2. **What**?:

    - Updates the minimum version in ruff.toml
    - Adds temporary ignores for typing.Dict and typing.List deprecations.

3. **Impact**:

    - Lint rules will now reflect the supported versions of Python.
    - Creates future work to update primitive type hints with their core library class

4. **Testing Done**:

    - I've been working off this locally for some time now, and have not run into any associated complications.
