### PR TITLE
[BugFix] Fix Biztoc `term` Field Not Working & Fix Streamlit News Dashboard Example

### DIFF
--- a/examples/usdLiquidityIndex.ipynb
+++ b/examples/usdLiquidityIndex.ipynb
@@ -7076,7 +7076,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "If you just want to visualize the results, this is a fast way of doing it. However, titles are other customizatons clean things up."
+    "If you just want to visualize the results, this is a fast way of doing it. However, titles and other customizatons clean things up."
    ]
   },
   {

--- a/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
+++ b/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
@@ -99,7 +99,7 @@ class BiztocWorldNewsFetcher(
             query.term = query.term.replace(" ", "%20")
             url = base_url + f"search?q={query.term}"
             response = make_request(url, headers=headers).json()
-        if query.source is not None:
+        elif query.source is not None:
             sources_response = make_request(
                 "https://biztoc.p.rapidapi.com/sources",
                 headers=headers,


### PR DESCRIPTION
1. **Why**?:

    - In, `obb.news.world(provider="biztoc")`, `term` was not being passed correctly because the following block needed to be `elif` instead of `if`.
    - Streamlit example has some broken syntax from changes introduced by the Biztoc API that were not reflected in this example.

2. **What**?:

    - Updates the block in `BiztocWorldNewsFetcher`.
    - Updates the code in the `/examples/streamlit/news.py` file.

3. **Impact**:

    - Fixes bugs.

4. **Testing Done**:

```python
obb.news.world(term="earnings", provider="biztoc")
```

    - Running the Streamlit example with the Biztoc extension installed in "develop-mode".

