### PR TITLE
Added M&A Impact Analysis notebook using OpenBB

### DIFF
--- a/examples/company_performance_OpenBB.ipynb
+++ b/examples/company_performance_OpenBB.ipynb
@@ -1,0 +1,492 @@
+{
+  "nbformat": 4,
+  "nbformat_minor": 0,
+  "metadata": {
+    "colab": {
+      "provenance": [],
+      "collapsed_sections": [
+        "O5R5SibtjPT-",
+        "DZpAqsK5jciQ",
+        "pmeHxA9fj_X2",
+        "a022mQdgkdUm",
+        "hPrhDRn5k2pM"
+      ]
+    },
+    "kernelspec": {
+      "name": "python3",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "name": "python"
+    }
+  },
+  "cells": [
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## M&A Impact Analysis Using OpenBB\n",
+        "\n",
+        "#### Description\n",
+        "This notebook demonstrates how to evaluate the impact of mergers and acquisitions (M&A) on a company's performance by analyzing stock price movements before and after an M&A event. The analysis leverages OpenBB tools to fetch historical stock data and compute daily returns. We then visualize the stock price trends, calculate risk-return trade-offs, and compare these metrics before and after the M&A event.\n",
+        "\n",
+        "This specific example uses **Apple Inc. (AAPL)** and assumes an M&A date of **January 1, 2020**. The notebook performs the following steps:\n",
+        "\n",
+        "1. Fetch historical stock data.\n",
+        "2. Calculate daily returns.\n",
+        "3. Visualize stock price and daily returns.\n",
+        "4. Split data into periods before and after the M&A event.\n",
+        "5. Compare the risk-return trade-offs before and after the M&A.\n",
+        "\n",
+        "#### Author\n",
+        "[sonu4435](https://github.com/sonu4435)\n",
+        "\n",
+        "[![Open in Colab](https://colab.research.google.com/assets/colab-badge.svg)](https://colab.research.google.com/github/[YourGitHubUsername]/[YourRepo]/blob/develop/examples/[Notebook_Name].ipynb)\n",
+        "\n",
+        "### 1. Install OpenBB\n",
+        "First, install the OpenBB platform to ensure the necessary dependencies are available.\n",
+        "\n",
+        "```python\n",
+        "!pip install openbb --upgrade\n"
+      ],
+      "metadata": {
+        "id": "dCMSYK7CzggV"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "pip install openbb --upgrade"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "9tAWsvq7Xo3s"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 1.Fatch a stock data & Calculate Daily Returns\n",
+        "We calculate the daily returns based on the adjusted close price. Daily returns are computed as the percentage change in the adjusted close price between consecutive trading days."
+      ],
+      "metadata": {
+        "id": "O5R5SibtjPT-"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Import the necessary libraries,\n",
+        "from openbb import obb\n",
+        "import pandas as pd\n",
+        "import matplotlib.pyplot as plt\n",
+        "import openbb"
+      ],
+      "metadata": {
+        "id": "ig30iKOlYDjO"
+      },
+      "execution_count": 71,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Fetch & show historical data for any stock / crypto ex: (AAPL) using Yahoo Finance as the data provider\n",
+        "historical_data = obb.equity.price.historical(symbol=\"AAPL\", provider=\"yfinance\")\n",
+        "historical_data"
+      ],
+      "metadata": {
+        "id": "hZr4sDC-YRX1",
+        "collapsed": true
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Extract results from the historical data\n",
+        "historical_results = historical_data.results"
+      ],
+      "metadata": {
+        "id": "owlViq2aYqkS"
+      },
+      "execution_count": 73,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(historical_results)"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "kWh4ZpI-dVwe"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# convert them into a DataFrame\n",
+        "historical_data_df = pd.DataFrame(historical_results)"
+      ],
+      "metadata": {
+        "id": "upfx2PYEcxDP"
+      },
+      "execution_count": 75,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Check the first few rows to verify the DataFrame structure\n",
+        "print(historical_data_df.head())"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "_dfauNz1Q3Hf"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "processed_data = []\n",
+        "for record in historical_results:\n",
+        "    # Unpack each tuple into a dictionary\n",
+        "    record_dict = {item[0]: item[1] for item in record}\n",
+        "    processed_data.append(record_dict)"
+      ],
+      "metadata": {
+        "id": "XltOTfbnbBDm"
+      },
+      "execution_count": 77,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Convert processed data to DataFrame\n",
+        "historical_data_df = pd.DataFrame(processed_data)"
+      ],
+      "metadata": {
+        "id": "79BHtBs2ehhG"
+      },
+      "execution_count": 78,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(historical_data_df.head())"
+      ],
+      "metadata": {
+        "collapsed": true,
+        "id": "ZGAYCvAkekQ-"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Calculate daily returns\n",
+        "historical_data_df['Adj Close'] = historical_data_df['close']\n",
+        "historical_data_df['Daily Return'] = historical_data_df['Adj Close'].pct_change()"
+      ],
+      "metadata": {
+        "id": "5HPr_RfThpWd"
+      },
+      "execution_count": 80,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Display the first few rows\n",
+        "historical_data_df[['Adj Close', 'Daily Return']].head()"
+      ],
+      "metadata": {
+        "id": "jC5Ij40piWru"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##2.Visualize Stock Price and Daily Returns\n",
+        "Now, let's visualize the stock price and daily returns using subplots for a clearer comparison."
+      ],
+      "metadata": {
+        "id": "DZpAqsK5jciQ"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot stock price and daily returns\n",
+        "plt.figure(figsize=(14, 7))"
+      ],
+      "metadata": {
+        "id": "oZ0jJVFCjhK4"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Subplot 1: Plot the stock price\n",
+        "plt.subplot(2, 1, 1)\n",
+        "plt.plot(historical_data_df['Adj Close'], label='Stock Price', color='blue')\n",
+        "plt.title('Apple Stock Price')\n",
+        "plt.xlabel('Date')\n",
+        "plt.ylabel('Price')\n",
+        "plt.legend()"
+      ],
+      "metadata": {
+        "id": "NbeEq6Y_jlVA"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Subplot 2: Daily Returns\n",
+        "plt.subplot(2, 1, 2)\n",
+        "plt.plot(historical_data_df['Daily Return'], label='Daily Return', color='red')\n",
+        "plt.title('Apple Daily Returns')\n",
+        "plt.xlabel('Date')\n",
+        "plt.ylabel('Daily Return')\n",
+        "plt.legend()"
+      ],
+      "metadata": {
+        "id": "WhbVDy0Ujvpr"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Adjust the layout to avoid overlap\n",
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "Q3uP3HVfkxD9"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 3. Define M&A Date and Split Data\n",
+        "Now, we will define the date of the M&A event (January 1, 2024) and split the data into two subsets: one before the M&A and one after the M&A."
+      ],
+      "metadata": {
+        "id": "pmeHxA9fj_X2"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Define M&A date (You can update this date based on the actual M&A date)\n",
+        "ma_date = '2024-01-01'"
+      ],
+      "metadata": {
+        "id": "j08Z8P3fkFJc"
+      },
+      "execution_count": 86,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Convert the index to datetime\n",
+        "historical_data_df['date'] = pd.to_datetime(historical_data_df['date'])\n",
+        "historical_data_df.set_index('date', inplace=True)"
+      ],
+      "metadata": {
+        "id": "8PAkbnmMkHrt"
+      },
+      "execution_count": 87,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Split data into before and after M&A\n",
+        "before_ma = historical_data_df[historical_data_df.index < ma_date]\n",
+        "after_ma = historical_data_df[historical_data_df.index >= ma_date]"
+      ],
+      "metadata": {
+        "id": "LkN_8ODPkJ48"
+      },
+      "execution_count": 88,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Display the first few rows of each subset\n",
+        "print(\"Before M&A:\")\n",
+        "print(before_ma.head())"
+      ],
+      "metadata": {
+        "id": "Ny2qje3bkMp8"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"\\nAfter M&A:\")\n",
+        "print(after_ma.head())"
+      ],
+      "metadata": {
+        "id": "vWZwUJJ1OhnZ"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## 4. Plot Stock Price Before and After M&A\n",
+        "Now, visualize the stock price before and after the M&A."
+      ],
+      "metadata": {
+        "id": "a022mQdgkdUm"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Plot stock price before and after M&A\n",
+        "plt.figure(figsize=(14, 7))"
+      ],
+      "metadata": {
+        "id": "wrOhbtGGkgwG"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Before M&A plot\n",
+        "plt.subplot(2, 1, 1)\n",
+        "plt.plot(before_ma['Adj Close'], label=\"Before M&A\", color='blue')\n",
+        "plt.title(f\"Apple Stock Price Before M&A (before {ma_date})\")\n",
+        "plt.xlabel('Date')\n",
+        "plt.ylabel('Price')\n",
+        "plt.legend()"
+      ],
+      "metadata": {
+        "id": "NzqQuckvkkll"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# After M&A plot\n",
+        "plt.subplot(2, 1, 2)\n",
+        "plt.plot(after_ma['Adj Close'], label=\"After M&A\", color='green')\n",
+        "plt.title(f\"Apple Stock Price After M&A (after {ma_date})\")\n",
+        "plt.xlabel('Date')\n",
+        "plt.ylabel('Price')\n",
+        "plt.legend()\n"
+      ],
+      "metadata": {
+        "id": "1laSvRAFkoL-"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "plt.tight_layout()\n",
+        "plt.show()"
+      ],
+      "metadata": {
+        "id": "8v6JuzxLks_d"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "##5. Risk-Return Trade-off Analysis\n",
+        "Finally, we calculate the average return and volatility (standard deviation of returns) for both the periods before and after the M&A event. These metrics provide insights into the risk-return trade-off for each period."
+      ],
+      "metadata": {
+        "id": "hPrhDRn5k2pM"
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Calculate average return and volatility (standard deviation of returns) before and after M&A\n",
+        "before_avg_return = before_ma['Daily Return'].mean()\n",
+        "before_volatility = before_ma['Daily Return'].std()"
+      ],
+      "metadata": {
+        "id": "NPkeGwWJk4G0"
+      },
+      "execution_count": 95,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "after_avg_return = after_ma['Daily Return'].mean()\n",
+        "after_volatility = after_ma['Daily Return'].std()"
+      ],
+      "metadata": {
+        "id": "IfGmMqSZk7jV"
+      },
+      "execution_count": 96,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "# Display results\n",
+        "print(\"Before M&A:\")\n",
+        "print(f\"Average Return: {before_avg_return:.4f}\")\n",
+        "print(f\"Volatility: {before_volatility:.4f}\")\n"
+      ],
+      "metadata": {
+        "id": "SVVqCLBrk9Is"
+      },
+      "execution_count": null,
+      "outputs": []
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "print(\"\\nAfter M&A:\")\n",
+        "print(f\"Average Return: {after_avg_return:.4f}\")\n",
+        "print(f\"Volatility: {after_volatility:.4f}\")"
+      ],
+      "metadata": {
+        "id": "cCyl4Na6k_T9"
+      },
+      "execution_count": null,
+      "outputs": []
+    }
+  ]
+}


### PR DESCRIPTION
# M&A Impact Analysis Using OpenBB

### Summary:

This notebook demonstrates how to use OpenBB to analyze the impact of mergers and acquisitions (M&A) on a company's stock price and performance. The analysis focuses on the following areas:

- Stock Price Movements: Examining historical stock prices before and after the M&A event.
- Risk-Return Tradeoffs: Calculating the average return and volatility (standard deviation) of the stock before and after the M&A.
- Visualizations: Plots of stock prices and daily returns to visualize the effects of M&A on stock performance.
### Key OpenBB Features Used:
- Historical Stock Data: Using OpenBB's equity.price.historical function to retrieve historical stock data.
- Financial Analysis: Computing daily returns and modeling risk-return tradeoffs using the pandas library.
- Visualization: Creating visualizations of stock prices and daily returns using matplotlib.

This notebook aims to provide a simple but effective way to evaluate the impact of M&A events using OpenBB, and could be used as a template for analyzing other stocks or events.