### PR TITLE
[BugFix] SecCompanyFilings: Purge `nan` Values & Make `form_type` Match 

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
@@ -306,12 +306,7 @@ class SecCompanyFilingsFetcher(
             "isXBRL",
             "size",
         ]
-        filings = (
-            DataFrame(data, columns=cols)
-            .fillna(value="N/A")
-            .replace("N/A", None)
-            .astype(str)
-        )
+        filings = DataFrame(data, columns=cols).astype(str)
         filings["reportDate"] = to_datetime(filings["reportDate"]).dt.date
         filings["filingDate"] = to_datetime(filings["filingDate"]).dt.date
         filings = filings.sort_values(by=["reportDate", "filingDate"], ascending=False)

--- a/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
@@ -328,13 +328,8 @@ class SecCompanyFilingsFetcher(
             base_url + filings["accessionNumber"] + "-index.htm"
         )
         if query.form_type:
-            form_types = query.form_type.replace("_", " ").replace(",", "|")
-            form_types = f"\\b{form_types}\\b"
-
-            filings = filings[
-                filings.form.str.contains(form_types, case=False, regex=True, na=False)
-            ]
-
+            form_types = query.form_type.replace("_", " ").split(",")
+            filings = filings[filings.form.isin(form_types)]
         if query.limit:
             filings = filings.head(query.limit) if query.limit != 0 else filings
 

--- a/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/company_filings.py
@@ -283,7 +283,8 @@ class SecCompanyFilingsFetcher(
     ) -> List[SecCompanyFilingsData]:
         """Transform the data."""
         # pylint: disable=import-outside-toplevel
-        from pandas import DataFrame, to_datetime
+        from numpy import nan
+        from pandas import NA, DataFrame, to_datetime
 
         if not data:
             raise EmptyDataError(
@@ -333,6 +334,7 @@ class SecCompanyFilingsFetcher(
         )
         if query.form_type:
             form_types = query.form_type.replace("_", " ").replace(",", "|")
+            form_types = f"\\b{form_types}\\b"
 
             filings = filings[
                 filings.form.str.contains(form_types, case=False, regex=True, na=False)
@@ -343,6 +345,7 @@ class SecCompanyFilingsFetcher(
 
         if len(filings) == 0:
             raise EmptyDataError("No filings were found using the filters provided.")
+        filings = filings.replace({NA: None, nan: None})
 
         return [
             SecCompanyFilingsData.model_validate(d) for d in filings.to_dict("records")


### PR DESCRIPTION
1. **Why**?:

    - When attempting to filter for Form 4 resulted in other types of forms with '4' in it.
    - Unexpected nan values from empty dates.

2. **What**?:

    - Filters the `form_type` using "isin" instead of "contains".
    - Moves `nan` replace to the bottom, immediately before the output.

3. **Impact**:

    - Improved precision in the results.
    - Bug fix.

4. **Testing Done**:

```python
# Multiple forms with '4' in it
obb.equity.fundamental.filings("CRM", form_type='4,144,S-4', limit=0, provider="sec")

# Just Form 4
obb.equity.fundamental.filings("CRM", form_type='4', limit=0, provider="sec").to_df().report_type.unique()
```
