### PR TITLE
[BugFix] `openbb-yfinance` Add Unstacking To Single Ticker Queries From `yf.download`

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -362,7 +362,9 @@ def yf_download(
         raise EmptyDataError() from exc
 
     tickers = symbol.split(",")
-    if len(tickers) > 1:
+    if len(tickers) == 1:
+        data = data.get(symbol)
+    elif len(tickers) > 1:
         _data = DataFrame()
         for ticker in tickers:
             temp = data[ticker].copy().dropna(how="all")

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -404,6 +404,12 @@ def yf_download(
         if adjusted is False:
             data = data.drop(columns=["Adj Close"])  # type: ignore
         data.columns = data.columns.str.lower().str.replace(" ", "_").to_list()  # type: ignore
+
+        # Remove columns with no information.
+        for col in ["dividends", "capital_gains", "stock_splits"]:
+            if col in data.columns and data[col].sum() == 0:
+                data = data.drop(columns=[col])
+
     return data  # type: ignore
 
 


### PR DESCRIPTION
1. **Why**?:

    - New behavior by yFinance appears to have changed the shape of the response from `yf.download` when there is only one symbol.
      - Results in a KeyError because it is expecting a flat table response.

2. **What**?:

```
    if len(tickers) == 1:
        data = data.get(symbol)
```

3. **Impact**:

    - Bug fix.
    - Drops the "capital_gains", "dividend", and "split_ratio" when the sum of the column is 0 (equivalent to empty)

4. **Testing Done**:

    - `obb.equity.price.historical("IWM", provider="yfinance")`
    - `obb.equity.price.historical("IWM,QQQ,AAPL", provider="yfinance", start_date="2019-01-01")`
