### PR TITLE
[BugFix] Intrinio Historical Market Cap Daily Now Working

### DIFF
--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -29970,11 +29970,12 @@
                 "intrinio": [
                     {
                         "name": "interval",
-                        "type": "Literal['week', 'month', 'quarter', 'year']",
+                        "type": "Literal['day', 'week', 'month', 'quarter', 'year']",
                         "description": "None",
-                        "default": "week",
+                        "default": "day",
                         "optional": true,
                         "choices": [
+                            "day",
                             "week",
                             "month",
                             "quarter",

--- a/openbb_platform/openbb/package/equity.py
+++ b/openbb_platform/openbb/package/equity.py
@@ -112,7 +112,7 @@ class ROUTER_equity(Container):
             End date of the data, in YYYY-MM-DD format.
         provider : Optional[Literal['fmp', 'intrinio']]
             The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: fmp, intrinio.
-        interval : Literal['week', 'month', 'quarter', 'year']
+        interval : Literal['day', 'week', 'month', 'quarter', 'year']
             None
 
         Returns
@@ -168,7 +168,7 @@ class ROUTER_equity(Container):
                     "interval": {
                         "intrinio": {
                             "multiple_items_allowed": False,
-                            "choices": ["week", "month", "quarter", "year"],
+                            "choices": ["day", "week", "month", "quarter", "year"],
                         }
                     },
                 },

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/historical_market_cap.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/historical_market_cap.py
@@ -24,12 +24,12 @@ class IntrinioHistoricalMarketCapQueryParams(HistoricalMarketCapQueryParams):
         "symbol": {"multiple_items_allowed": True},
         "interval": {
             "multiple_items_allowed": False,
-            "choices": ["week", "month", "quarter", "year"],
+            "choices": ["day", "week", "month", "quarter", "year"],
         },
     }
 
-    interval: Literal["week", "month", "quarter", "year"] = Field(
-        default="week",
+    interval: Literal["day", "week", "month", "quarter", "year"] = Field(
+        default="day",
     )
 
 
@@ -59,7 +59,7 @@ class IntrinioHistoricalMarketCapFetcher(
         now = datetime.now().date()
         if params.get("start_date") is None:
             transformed_params["start_date"] = datetime(
-                2000,
+                2007,
                 1,
                 1,
             ).date()
@@ -83,7 +83,7 @@ class IntrinioHistoricalMarketCapFetcher(
 
         api_key = credentials.get("intrinio_api_key") if credentials else ""
         base_url = "https://api-v2.intrinio.com/historical_data/"
-        frequency = query.interval + "ly"
+        frequency = f"frequency={query.interval}ly&" if query.interval != "day" else ""
         start_date = query.start_date
         end_date = query.end_date
         results: list = []
@@ -93,7 +93,7 @@ class IntrinioHistoricalMarketCapFetcher(
         async def get_one(symbol):
             """Get data for one symbol."""
             url_params = (
-                f"{symbol}/marketcap?frequency={frequency}&start_date={start_date}"
+                f"{symbol}/marketcap?{frequency}start_date={start_date}"
                 f"&end_date={end_date}&page_size=10000"
                 f"&api_key={api_key}"
             )


### PR DESCRIPTION
1. **Why**?:

    - For whatever reason now, I can get the daily granularity now where I wasn't this morning.

2. **What**?:

    - Add "day" to the interval choices.

Note: In the screenshot below, it's unclear why there are two entries for November 5 from FMP

![Screenshot 2024-11-05 at 4 38 45 PM](https://github.com/user-attachments/assets/21c3ad6e-9cd7-483b-94e6-204b23b5e5f1)

