### PR TITLE
[BugFix] `equity.peers`: Handle Empty Values Within FMP Response

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_peers.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_peers.py
@@ -1,13 +1,12 @@
 """FMP Equity Peers Model."""
 
-from typing import Any, Dict, Optional
+from typing import Any, Optional
 
 from openbb_core.provider.abstract.fetcher import Fetcher
 from openbb_core.provider.standard_models.equity_peers import (
     EquityPeersData,
     EquityPeersQueryParams,
 )
-from openbb_fmp.utils.helpers import create_url, get_data_one
 
 
 class FMPEquityPeersQueryParams(EquityPeersQueryParams):
@@ -27,20 +26,23 @@ class FMPEquityPeersFetcher(
         FMPEquityPeersData,
     ]
 ):
-    """Transform the query, extract and transform the data from the FMP endpoints."""
+    """FMP Equity Peers Fetcher."""
 
     @staticmethod
-    def transform_query(params: Dict[str, Any]) -> FMPEquityPeersQueryParams:
+    def transform_query(params: dict[str, Any]) -> FMPEquityPeersQueryParams:
         """Transform the query params."""
         return FMPEquityPeersQueryParams(**params)
 
     @staticmethod
     async def aextract_data(
         query: FMPEquityPeersQueryParams,
-        credentials: Optional[Dict[str, str]],
+        credentials: Optional[dict[str, str]],
         **kwargs: Any,
-    ) -> Dict:
+    ) -> dict:
         """Return the raw data from the FMP endpoint."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_fmp.utils.helpers import create_url, get_data_one
+
         api_key = credentials.get("fmp_api_key") if credentials else ""
         url = create_url(4, "stock_peers", api_key, query)
 
@@ -51,5 +53,8 @@ class FMPEquityPeersFetcher(
         query: FMPEquityPeersQueryParams, data: dict, **kwargs: Any
     ) -> FMPEquityPeersData:
         """Return the transformed data."""
-        data.pop("symbol", None)
+        _ = data.pop("symbol", None)
+        peers: list = [d for d in data.get("peersList", []) if d]
+        data["peersList"] = peers
+
         return FMPEquityPeersData.model_validate(data)


### PR DESCRIPTION
1. **Why**?:

    - FMP will return empty items within the response, for some unknown reason.

2. **What**?:

    - Check the response for empty items and remove them.

3. **Impact**:

    - Better quality results without a weird empty symbol.

4. **Testing Done**:

```python
obb.equity.compare.peers("BUDZ")
```

Response before:

![image](https://github.com/user-attachments/assets/9ddd2ffb-2263-4f6c-bd57-aac1c16eeabd)

Response after:

![Screenshot 2024-11-25 at 8 36 42 AM](https://github.com/user-attachments/assets/81e96202-8a55-4a0b-b79d-9970c36be692)
