### PR TITLE
[BugFix] Installer: Force lower version of `poetry` in `post_install` script.

### DIFF
--- a/build/conda/installer/assets/openbb_platform_installer/openbb_platform_installer/__init__.py
+++ b/build/conda/installer/assets/openbb_platform_installer/openbb_platform_installer/__init__.py
@@ -1,3 +1,3 @@
 """Placeholder for the OpenBB Platform Installer package."""
 
-__version__ = "1.0.0"
+__version__ = "1.0.2"

--- a/build/conda/installer/assets/openbb_platform_installer/pyproject.toml
+++ b/build/conda/installer/assets/openbb_platform_installer/pyproject.toml
@@ -1,7 +1,7 @@
 # If you will be using this as a template for your own package, please change the values accordingly.
 [tool.poetry]
 name = "openbb_platform_installer"  # Change this to your package name
-version = "1.0.0"  # Change this to your package version
+version = "1.0.2"  # Change this to your package version
 description = "A meta package for installing the OpenBB Platform: Investment research for everyone, anywhere."  # Change this to your description
 authors = ["OpenBB <hello@openbb.co>"]  # Change this to your name and email
 license = "AGPL-3.0-only"  # This license must be compatible with the OpenBB license

--- a/build/conda/installer/construct.yaml
+++ b/build/conda/installer/construct.yaml
@@ -32,7 +32,6 @@ channels:
 
 condarc:
   {channels: [conda-forge],
-  default_channels: [conda-forge],
   allow_softlinks: false,
   auto_activate_base: false,
   always_copy: true,

--- a/build/conda/installer/post_install.bat
+++ b/build/conda/installer/post_install.bat
@@ -14,7 +14,7 @@ python -m pip install -U pip >> "%LOG_FILE%" 2>&1
 
 pip install -U setuptools >> "%LOG_FILE%" 2>&1
 
-pip install poetry >> "%LOG_FILE%" 2>&1
+pip install poetry==1.8.5 >> "%LOG_FILE%" 2>&1
 
 poetry config virtualenvs.path "%PREFIX%\envs" --local >> "%LOG_FILE%" 2>&1
 

--- a/build/conda/installer/post_install.sh
+++ b/build/conda/installer/post_install.sh
@@ -19,6 +19,8 @@ python -m pip install -U pip >>"$LOG_FILE" 2>&1
 
 pip install -U setuptools poetry >>"$LOG_FILE" 2>&1
 
+pip install poetry==1.8.5 >>"$LOG_FILE" 2>&1
+
 poetry config virtualenvs.path "$PREFIX/envs" --local >>"$LOG_FILE" 2>&1
 
 poetry config virtualenvs.create false --local >>"$LOG_FILE" 2>&1


### PR DESCRIPTION
1. **Why**?:

    - Resolves #7001

2. **What**?:

    - Forces 1.8.5 in the `post_install` script so it doesn't crash while trying to downgrade itself.
    - Taking this approach until the main library is updated for Poetry 2.0

3. **Impact** (1-2 sentences or a bullet point list):
    - Fixes failing Windows installers.

5. **Testing Done**:

    - Locally built.
