### PR TITLE
[Feature] openbb-platform-api:  Add column header tooltips and templates.json route.

### DIFF
--- a/openbb_platform/extensions/platform_api/README.md
+++ b/openbb_platform/extensions/platform_api/README.md
@@ -94,3 +94,16 @@ openbb-api --no-build
 ```
 
 If you would like to construct this file manually for a custom backend configuration, save the file in the path above.
+
+
+### Location of `templates.json`
+
+> ~/OpenBBUserData/workspace_templates.json
+
+The OpenBB Workspace allows you to export the current dashboard layout - when it is a custom backend - as a template.
+
+To export the layout, right-click on the dashboard and select, "Export Template".
+
+A JSON dictionary will be exported. Insert the contents of the export into "~/OpenBBUserData/workspace_templates.json" by pasting between the JSON list markers, [ ].
+
+If there is more than one, add a comma to the closing curly brace, }.

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -89,16 +89,17 @@ def get_templates():
     if os.path.exists(TEMPLATES_PATH):
         with open(TEMPLATES_PATH) as f:
             templates = json.load(f)
-            if isinstance(templates, list):
-                return templates
-            elif isinstance(templates, dict):
-                return [templates]
-            else:
-                return []
+
+        if isinstance(templates, list):
+            return JSONResponse(content=templates)
+        if isinstance(templates, dict):
+            return JSONResponse(content=[templates])
+
     else:
         with open(TEMPLATES_PATH, "w") as f:
             json.dump([], f)
-    return []
+
+    return JSONResponse(content=[])
 
 
 @app.get("/")

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -74,6 +74,32 @@ current_settings = get_user_settings(login, CURRENT_USER_SETTINGS, USER_SETTINGS
 
 widgets_json = get_widgets_json(build, openapi, widget_exclude_filter)
 
+# A template file will be served from the OpenBBUserDataDirectory, if it exists.
+# If it doesn't exist, an empty list will be returned, and an empty file will be created.
+TEMPLATES_PATH = (
+    current_settings["preferences"].get("data_directory", HOME + "/OpenBBUserData")
+    + "/workspace_templates.json"
+)
+
+
+# If a custom implementation, you might want to override.
+@app.get("/templates.json")
+def get_templates():
+    """Get the templates.json file."""
+    if os.path.exists(TEMPLATES_PATH):
+        with open(TEMPLATES_PATH) as f:
+            templates = json.load(f)
+            if isinstance(templates, list):
+                return templates
+            elif isinstance(templates, dict):
+                return [templates]
+            else:
+                return []
+    else:
+        with open(TEMPLATES_PATH, "w") as f:
+            json.dump([], f)
+    return []
+
 
 @app.get("/")
 async def get_root():

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -87,8 +87,8 @@ TEMPLATES_PATH = (
 def get_templates():
     """Get the templates.json file."""
     if os.path.exists(TEMPLATES_PATH):
-        with open(TEMPLATES_PATH) as f:
-            templates = json.load(f)
+        with open(TEMPLATES_PATH) as templates_file:
+            templates = json.load(templates_file)
 
         if isinstance(templates, list):
             return JSONResponse(content=templates)
@@ -96,8 +96,8 @@ def get_templates():
             return JSONResponse(content=[templates])
 
     else:
-        with open(TEMPLATES_PATH, "w") as f:
-            json.dump([], f)
+        with open(TEMPLATES_PATH, "w", encoding="utf-8") as templates_file:
+            json.dump([], templates_file)
 
     return JSONResponse(content=[])
 

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -474,7 +474,7 @@ def data_schema_to_columns_defs(openapi_json, operation_id, provider):
                 for word in header_name.split(" ")
             ]
         )
-        column_def["description"] = prop.get(
+        column_def["headerTooltip"] = prop.get(
             "description", prop.get("title", key.title())
         )
         column_def["cellDataType"] = cell_data_type

--- a/openbb_platform/extensions/platform_api/tests/mock_widgets.json
+++ b/openbb_platform/extensions/platform_api/tests/mock_widgets.json
@@ -1,14 +1,14 @@
 {
     "economy_survey_sloos_fred_obb": {
         "name": "SLOOS",
-        "headerTooltip": "Get Senior Loan Officers Opinion Survey.",
+        "description": "Get Senior Loan Officers Opinion Survey.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_sloos_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -17,7 +17,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -26,7 +26,7 @@
             },
             {
                 "label": "Category",
-                "headerTooltip": "Category of survey response.",
+                "description": "Category of survey response.",
                 "optional": true,
                 "value": "spreads",
                 "type": "text",
@@ -77,7 +77,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -178,14 +178,14 @@
     },
     "economy_survey_university_of_michigan_fred_obb": {
         "name": "University Of Michigan",
-        "headerTooltip": "Get University of Michigan Consumer Sentiment and Inflation Expectations Surveys.",
+        "description": "Get University of Michigan Consumer Sentiment and Inflation Expectations Surveys.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_university_of_michigan_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -194,7 +194,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -203,7 +203,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -222,7 +222,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -245,7 +245,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -337,14 +337,14 @@
     },
     "economy_survey_economic_conditions_chicago_fred_obb": {
         "name": "Economic Conditions Chicago",
-        "headerTooltip": "Get The Survey Of Economic Conditions For The Chicago Region.",
+        "description": "Get The Survey Of Economic Conditions For The Chicago Region.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_economic_conditions_chicago_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -353,7 +353,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -362,7 +362,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -381,7 +381,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -404,7 +404,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -543,14 +543,14 @@
     },
     "economy_survey_manufacturing_outlook_texas_fred_obb": {
         "name": "Manufacturing Outlook Texas",
-        "headerTooltip": "Get The Manufacturing Outlook Survey For The Texas Region.",
+        "description": "Get The Manufacturing Outlook Survey For The Texas Region.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_manufacturing_outlook_texas_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -559,7 +559,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -568,7 +568,7 @@
             },
             {
                 "label": "Topic",
-                "headerTooltip": "The topic for the survey response. Multiple comma separated items allowed.",
+                "description": "The topic for the survey response. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": "new_orders_growth",
                 "show": true,
@@ -636,7 +636,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -655,7 +655,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n            avg = Average\n            sum = Sum\n            eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n            avg = Average\n            sum = Sum\n            eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -678,7 +678,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -796,14 +796,14 @@
     },
     "economy_survey_nonfarm_payrolls_fred_obb": {
         "name": "Nonfarm Payrolls",
-        "headerTooltip": "Get Nonfarm Payrolls Survey.",
+        "description": "Get Nonfarm Payrolls Survey.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_nonfarm_payrolls_fred_obb",
         "params": [
             {
                 "label": "Date",
-                "headerTooltip": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
+                "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -813,7 +813,7 @@
             },
             {
                 "label": "Category",
-                "headerTooltip": "The category to query.",
+                "description": "The category to query.",
                 "optional": true,
                 "value": "employees_nsa",
                 "type": "text",
@@ -981,14 +981,14 @@
     },
     "economy_cpi_fred_obb": {
         "name": "CPI",
-        "headerTooltip": "Get Consumer Price Index (CPI).\n\nReturns either the rescaled index value, or a rate of change (inflation).",
+        "description": "Get Consumer Price Index (CPI).\n\nReturns either the rescaled index value, or a rate of change (inflation).",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_cpi_fred_obb",
         "params": [
             {
                 "label": "Country",
-                "headerTooltip": "The country to get data. Multiple comma separated items allowed.",
+                "description": "The country to get data. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -1196,7 +1196,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation of the CPI data. Period represents the change since previous. Defaults to change from one year ago (yoy).",
+                "description": "Transformation of the CPI data. Period represents the change since previous. Defaults to change from one year ago (yoy).",
                 "optional": true,
                 "value": "yoy",
                 "type": "text",
@@ -1219,7 +1219,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "The frequency of the data.",
+                "description": "The frequency of the data.",
                 "optional": true,
                 "value": "monthly",
                 "type": "text",
@@ -1242,7 +1242,7 @@
             },
             {
                 "label": "Harmonized",
-                "headerTooltip": "If true, returns harmonized data.",
+                "description": "If true, returns harmonized data.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -1251,7 +1251,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1260,7 +1260,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1316,14 +1316,14 @@
     },
     "economy_balance_of_payments_fred_obb": {
         "name": "Balance Of Payments",
-        "headerTooltip": "Balance of Payments Reports.",
+        "description": "Balance of Payments Reports.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_balance_of_payments_fred_obb",
         "params": [
             {
                 "label": "Country",
-                "headerTooltip": "The country to get data. Enter as a 3-letter ISO country code, default is USA.",
+                "description": "The country to get data. Enter as a 3-letter ISO country code, default is USA.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -1526,7 +1526,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1535,7 +1535,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1725,14 +1725,14 @@
     },
     "economy_fred_search_fred_obb": {
         "name": "FRED Search",
-        "headerTooltip": "Search for FRED series or economic releases by ID or string.\n\nThis does not return the observation values, only the metadata.\nUse this function to find series IDs for `fred_series()`.",
+        "description": "Search for FRED series or economic releases by ID or string.\n\nThis does not return the observation values, only the metadata.\nUse this function to find series IDs for `fred_series()`.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_search_fred_obb",
         "params": [
             {
                 "label": "Query",
-                "headerTooltip": "The search word(s).",
+                "description": "The search word(s).",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1740,7 +1740,7 @@
             },
             {
                 "label": "Is Release",
-                "headerTooltip": "Is release?  If True, other search filter variables are ignored. If no query text or release_id is supplied, this defaults to True.",
+                "description": "Is release?  If True, other search filter variables are ignored. If no query text or release_id is supplied, this defaults to True.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -1749,7 +1749,7 @@
             },
             {
                 "label": "Release ID",
-                "headerTooltip": "A specific release ID to target.",
+                "description": "A specific release ID to target.",
                 "optional": true,
                 "type": "text",
                 "show": true,
@@ -1757,7 +1757,7 @@
             },
             {
                 "label": "Limit",
-                "headerTooltip": "The number of data entries to return. (1-1000)",
+                "description": "The number of data entries to return. (1-1000)",
                 "optional": true,
                 "value": null,
                 "type": "number",
@@ -1766,7 +1766,7 @@
             },
             {
                 "label": "Offset",
-                "headerTooltip": "Offset the results in conjunction with limit.",
+                "description": "Offset the results in conjunction with limit.",
                 "optional": true,
                 "value": 0,
                 "type": "number",
@@ -1775,7 +1775,7 @@
             },
             {
                 "label": "Filter Variable",
-                "headerTooltip": "Filter by an attribute.",
+                "description": "Filter by an attribute.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1798,7 +1798,7 @@
             },
             {
                 "label": "Filter Value",
-                "headerTooltip": "String value to filter the variable by.  Used in conjunction with filter_variable.",
+                "description": "String value to filter the variable by.  Used in conjunction with filter_variable.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1806,7 +1806,7 @@
             },
             {
                 "label": "Tag Names",
-                "headerTooltip": "A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' Multiple comma separated items allowed.",
+                "description": "A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1816,7 +1816,7 @@
             },
             {
                 "label": "Exclude Tag Names",
-                "headerTooltip": "A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple comma separated items allowed.",
+                "description": "A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1826,7 +1826,7 @@
             },
             {
                 "label": "Series ID",
-                "headerTooltip": "A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas.",
+                "description": "A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas.",
                 "optional": true,
                 "type": "text",
                 "show": true,
@@ -2016,14 +2016,14 @@
     },
     "economy_fred_series_fred_obb": {
         "name": "FRED Series",
-        "headerTooltip": "Get data by series ID from FRED.",
+        "description": "Get data by series ID from FRED.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_series_fred_obb",
         "params": [
             {
                 "label": "Symbol",
-                "headerTooltip": "Symbol to get data for. Multiple comma separated items allowed.",
+                "description": "Symbol to get data for. Multiple comma separated items allowed.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2032,7 +2032,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2041,7 +2041,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2050,7 +2050,7 @@
             },
             {
                 "label": "Limit",
-                "headerTooltip": "The number of data entries to return.",
+                "description": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2059,7 +2059,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2126,7 +2126,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2149,7 +2149,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2224,14 +2224,14 @@
     },
     "economy_fred_series_fred_obb_chart": {
         "name": "FRED Series (Chart)",
-        "headerTooltip": "Get data by series ID from FRED.",
+        "description": "Get data by series ID from FRED.",
         "category": "Economy",
         "searchCategory": "chart",
         "widgetId": "economy_fred_series_fred_obb_chart",
         "params": [
             {
                 "label": "Symbol",
-                "headerTooltip": "Symbol to get data for. Multiple comma separated items allowed.",
+                "description": "Symbol to get data for. Multiple comma separated items allowed.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2240,7 +2240,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2249,7 +2249,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2258,7 +2258,7 @@
             },
             {
                 "label": "Limit",
-                "headerTooltip": "The number of data entries to return.",
+                "description": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2267,7 +2267,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2334,7 +2334,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2357,7 +2357,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2406,7 +2406,7 @@
             {
                 "paramName": "chart",
                 "label": "Chart",
-                "headerTooltip": "Returns chart",
+                "description": "Returns chart",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -2442,14 +2442,14 @@
     },
     "economy_fred_release_table_fred_obb": {
         "name": "FRED Release Table",
-        "headerTooltip": "Get economic release data by ID and/or element from FRED.",
+        "description": "Get economic release data by ID and/or element from FRED.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_release_table_fred_obb",
         "params": [
             {
                 "label": "Release ID",
-                "headerTooltip": "The ID of the release. Use `fred_search` to find releases.",
+                "description": "The ID of the release. Use `fred_search` to find releases.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2457,7 +2457,7 @@
             },
             {
                 "label": "Element Id",
-                "headerTooltip": "The element ID of a specific table in the release.",
+                "description": "The element ID of a specific table in the release.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2465,7 +2465,7 @@
             },
             {
                 "label": "Date",
-                "headerTooltip": "A specific date to get data for. Multiple comma separated items allowed.",
+                "description": "A specific date to get data for. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -2578,14 +2578,14 @@
     },
     "economy_fred_regional_fred_obb": {
         "name": "FRED Regional",
-        "headerTooltip": "Query the Geo Fred API for regional economic data by series group.\n\nThe series group ID is found by using `fred_search` and the `series_id` parameter.",
+        "description": "Query the Geo Fred API for regional economic data by series group.\n\nThe series group ID is found by using `fred_search` and the `series_id` parameter.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_regional_fred_obb",
         "params": [
             {
                 "label": "Symbol",
-                "headerTooltip": "Symbol to get data for.",
+                "description": "Symbol to get data for.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2593,7 +2593,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2602,7 +2602,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2611,7 +2611,7 @@
             },
             {
                 "label": "Limit",
-                "headerTooltip": "The number of data entries to return.",
+                "description": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2620,7 +2620,7 @@
             },
             {
                 "label": "Is Series Group",
-                "headerTooltip": "When True, the symbol provided is for a series_group, else it is for a series ID.",
+                "description": "When True, the symbol provided is for a series_group, else it is for a series ID.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -2629,7 +2629,7 @@
             },
             {
                 "label": "Region Type",
-                "headerTooltip": "The type of regional data. Parameter is only valid when `is_series_group` is True.",
+                "description": "The type of regional data. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2672,7 +2672,7 @@
             },
             {
                 "label": "Season",
-                "headerTooltip": "The seasonal adjustments to the data. Parameter is only valid when `is_series_group` is True.",
+                "description": "The seasonal adjustments to the data. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": "nsa",
                 "type": "text",
@@ -2695,7 +2695,7 @@
             },
             {
                 "label": "Units",
-                "headerTooltip": "The units of the data. This should match the units returned from searching by series ID. An incorrect field will not necessarily return an error. Parameter is only valid when `is_series_group` is True.",
+                "description": "The units of the data. This should match the units returned from searching by series ID. An incorrect field will not necessarily return an error. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2703,7 +2703,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2770,7 +2770,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2793,7 +2793,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2899,14 +2899,14 @@
     },
     "economy_retail_prices_fred_obb": {
         "name": "Retail Prices",
-        "headerTooltip": "Get retail prices for common items.",
+        "description": "Get retail prices for common items.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_retail_prices_fred_obb",
         "params": [
             {
                 "label": "Item",
-                "headerTooltip": "The item or basket of items to query.",
+                "description": "The item or basket of items to query.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2914,7 +2914,7 @@
             },
             {
                 "label": "Country",
-                "headerTooltip": "The country to get data.",
+                "description": "The country to get data.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -2923,7 +2923,7 @@
             },
             {
                 "label": "Start Date",
-                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
+                "description": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2932,7 +2932,7 @@
             },
             {
                 "label": "End Date",
-                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
+                "description": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2941,7 +2941,7 @@
             },
             {
                 "label": "Region",
-                "headerTooltip": "The region to get average price levels for.",
+                "description": "The region to get average price levels for.",
                 "optional": true,
                 "value": "all_city",
                 "type": "text",
@@ -2972,7 +2972,7 @@
             },
             {
                 "label": "Frequency",
-                "headerTooltip": "The frequency of the data.",
+                "description": "The frequency of the data.",
                 "optional": true,
                 "value": "monthly",
                 "type": "text",
@@ -2995,7 +2995,7 @@
             },
             {
                 "label": "Transform",
-                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -3102,14 +3102,14 @@
     },
     "economy_pce_fred_obb": {
         "name": "PCE",
-        "headerTooltip": "Get Personal Consumption Expenditures (PCE) reports.",
+        "description": "Get Personal Consumption Expenditures (PCE) reports.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_pce_fred_obb",
         "params": [
             {
                 "label": "Date",
-                "headerTooltip": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
+                "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -3119,7 +3119,7 @@
             },
             {
                 "label": "Category",
-                "headerTooltip": "The category to query.",
+                "description": "The category to query.",
                 "optional": true,
                 "value": "personal_income",
                 "type": "text",
@@ -3257,14 +3257,14 @@
     },
     "regulators_sec_cik_map_sec_obb": {
         "name": "CIK Map",
-        "headerTooltip": "Map a ticker symbol to a CIK number.",
+        "description": "Map a ticker symbol to a CIK number.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_cik_map_sec_obb",
         "params": [
             {
                 "label": "Symbol",
-                "headerTooltip": "Symbol to get data for.",
+                "description": "Symbol to get data for.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -3272,7 +3272,7 @@
             },
             {
                 "label": "Use Cache",
-                "headerTooltip": "Whether or not to use cache for the request, default is True.",
+                "description": "Whether or not to use cache for the request, default is True.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3303,14 +3303,14 @@
     },
     "regulators_sec_institutions_search_sec_obb": {
         "name": "Institutions Search",
-        "headerTooltip": "Search SEC-regulated institutions by name and return a list of results with CIK numbers.",
+        "description": "Search SEC-regulated institutions by name and return a list of results with CIK numbers.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_institutions_search_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "headerTooltip": "Search query.",
+                "description": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3319,7 +3319,7 @@
             },
             {
                 "label": "Use Cache",
-                "headerTooltip": "Whether or not to use cache.",
+                "description": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3367,14 +3367,14 @@
     },
     "regulators_sec_schema_files_sec_obb": {
         "name": "Schema Files",
-        "headerTooltip": "Use tool for navigating the directory of SEC XML schema files by year.",
+        "description": "Use tool for navigating the directory of SEC XML schema files by year.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_schema_files_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "headerTooltip": "Search query.",
+                "description": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3383,7 +3383,7 @@
             },
             {
                 "label": "Use Cache",
-                "headerTooltip": "Whether or not to use cache.",
+                "description": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3392,7 +3392,7 @@
             },
             {
                 "label": "Url",
-                "headerTooltip": "Enter an optional URL path to fetch the next level.",
+                "description": "Enter an optional URL path to fetch the next level.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -3422,14 +3422,14 @@
     },
     "regulators_sec_symbol_map_sec_obb": {
         "name": "Symbol Map",
-        "headerTooltip": "Map a CIK number to a ticker symbol, leading 0s can be omitted or included.",
+        "description": "Map a CIK number to a ticker symbol, leading 0s can be omitted or included.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_symbol_map_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "headerTooltip": "Search query.",
+                "description": "Search query.",
                 "optional": false,
                 "value": null,
                 "type": "text",
@@ -3438,7 +3438,7 @@
             },
             {
                 "label": "Use Cache",
-                "headerTooltip": "Whether or not to use cache. If True, cache will store for seven days.",
+                "description": "Whether or not to use cache. If True, cache will store for seven days.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3469,7 +3469,7 @@
     },
     "regulators_sec_rss_litigation_sec_obb": {
         "name": "RSS Litigation",
-        "headerTooltip": "Get the RSS feed that provides links to litigation releases concerning civil lawsuits brought by the Commission in federal court.",
+        "description": "Get the RSS feed that provides links to litigation releases concerning civil lawsuits brought by the Commission in federal court.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_rss_litigation_sec_obb",
@@ -3542,14 +3542,14 @@
     },
     "regulators_sec_sic_search_sec_obb": {
         "name": "SIC Search",
-        "headerTooltip": "Search for Industry Titles, Reporting Office, and SIC Codes. An empty query string returns all results.",
+        "description": "Search for Industry Titles, Reporting Office, and SIC Codes. An empty query string returns all results.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_sic_search_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "headerTooltip": "Search query.",
+                "description": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3558,7 +3558,7 @@
             },
             {
                 "label": "Use Cache",
-                "headerTooltip": "Whether or not to use cache.",
+                "description": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",

--- a/openbb_platform/extensions/platform_api/tests/mock_widgets.json
+++ b/openbb_platform/extensions/platform_api/tests/mock_widgets.json
@@ -1,14 +1,14 @@
 {
     "economy_survey_sloos_fred_obb": {
         "name": "SLOOS",
-        "description": "Get Senior Loan Officers Opinion Survey.",
+        "headerTooltip": "Get Senior Loan Officers Opinion Survey.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_sloos_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -17,7 +17,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -26,7 +26,7 @@
             },
             {
                 "label": "Category",
-                "description": "Category of survey response.",
+                "headerTooltip": "Category of survey response.",
                 "optional": true,
                 "value": "spreads",
                 "type": "text",
@@ -77,7 +77,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -139,7 +139,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -148,14 +148,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Symbol",
-                        "description": "Symbol representing the entity requested in the data.",
+                        "headerTooltip": "Symbol representing the entity requested in the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "Survey value.",
+                        "headerTooltip": "Survey value.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -164,7 +164,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Title",
-                        "description": "Survey title.",
+                        "headerTooltip": "Survey title.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     }
@@ -178,14 +178,14 @@
     },
     "economy_survey_university_of_michigan_fred_obb": {
         "name": "University Of Michigan",
-        "description": "Get University of Michigan Consumer Sentiment and Inflation Expectations Surveys.",
+        "headerTooltip": "Get University of Michigan Consumer Sentiment and Inflation Expectations Surveys.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_university_of_michigan_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -194,7 +194,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -203,7 +203,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -222,7 +222,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -245,7 +245,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -307,14 +307,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
                     {
                         "field": "consumer_sentiment",
                         "headerName": "Consumer Sentiment",
-                        "description": "Index of the results of the University of Michigan's monthly Survey of Consumers, which is used to estimate future spending and saving.  (1966:Q1=100).",
+                        "headerTooltip": "Index of the results of the University of Michigan's monthly Survey of Consumers, which is used to estimate future spending and saving.  (1966:Q1=100).",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -322,7 +322,7 @@
                         "field": "inflation_expectation",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Inflation Expectation",
-                        "description": "Median expected price change next 12 months, Surveys of Consumers.",
+                        "headerTooltip": "Median expected price change next 12 months, Surveys of Consumers.",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -337,14 +337,14 @@
     },
     "economy_survey_economic_conditions_chicago_fred_obb": {
         "name": "Economic Conditions Chicago",
-        "description": "Get The Survey Of Economic Conditions For The Chicago Region.",
+        "headerTooltip": "Get The Survey Of Economic Conditions For The Chicago Region.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_economic_conditions_chicago_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -353,7 +353,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -362,7 +362,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -381,7 +381,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -404,7 +404,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -466,70 +466,70 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
                     {
                         "field": "activity_index",
                         "headerName": "Activity Index",
-                        "description": "Activity Index.",
+                        "headerTooltip": "Activity Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "one_year_outlook",
                         "headerName": "One Year Outlook",
-                        "description": "One Year Outlook Index.",
+                        "headerTooltip": "One Year Outlook Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "manufacturing_activity",
                         "headerName": "Manufacturing Activity",
-                        "description": "Manufacturing Activity Index.",
+                        "headerTooltip": "Manufacturing Activity Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "non_manufacturing_activity",
                         "headerName": "Non Manufacturing Activity",
-                        "description": "Non-Manufacturing Activity Index.",
+                        "headerTooltip": "Non-Manufacturing Activity Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "capital_expenditures_expectations",
                         "headerName": "Capital Expenditures Expectations",
-                        "description": "Capital Expenditures Expectations Index.",
+                        "headerTooltip": "Capital Expenditures Expectations Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "hiring_expectations",
                         "headerName": "Hiring Expectations",
-                        "description": "Hiring Expectations Index.",
+                        "headerTooltip": "Hiring Expectations Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "current_hiring",
                         "headerName": "Current Hiring",
-                        "description": "Current Hiring Index.",
+                        "headerTooltip": "Current Hiring Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "labor_costs",
                         "headerName": "Labor Costs",
-                        "description": "Labor Costs Index.",
+                        "headerTooltip": "Labor Costs Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "non_labor_costs",
                         "headerName": "Non Labor Costs",
-                        "description": "Non-Labor Costs Index.",
+                        "headerTooltip": "Non-Labor Costs Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -543,14 +543,14 @@
     },
     "economy_survey_manufacturing_outlook_texas_fred_obb": {
         "name": "Manufacturing Outlook Texas",
-        "description": "Get The Manufacturing Outlook Survey For The Texas Region.",
+        "headerTooltip": "Get The Manufacturing Outlook Survey For The Texas Region.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_manufacturing_outlook_texas_fred_obb",
         "params": [
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -559,7 +559,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -568,7 +568,7 @@
             },
             {
                 "label": "Topic",
-                "description": "The topic for the survey response. Multiple comma separated items allowed.",
+                "headerTooltip": "The topic for the survey response. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": "new_orders_growth",
                 "show": true,
@@ -636,7 +636,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
+                "headerTooltip": "Frequency aggregation to convert monthly data to lower frequency. None is monthly.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -655,7 +655,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n            avg = Average\n            sum = Sum\n            eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n            avg = Average\n            sum = Sum\n            eop = End of Period",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -678,7 +678,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -740,7 +740,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -748,14 +748,14 @@
                         "field": "topic",
                         "formatterFn": null,
                         "headerName": "Topic",
-                        "description": "Topic of the survey response.",
+                        "headerTooltip": "Topic of the survey response.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "diffusion_index",
                         "headerName": "Diffusion Index",
-                        "description": "Diffusion Index.",
+                        "headerTooltip": "Diffusion Index.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -763,7 +763,7 @@
                         "field": "percent_reporting_increase",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Percent Reporting Increase",
-                        "description": "Percent of respondents reporting an increase over the last month.",
+                        "headerTooltip": "Percent of respondents reporting an increase over the last month.",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -772,7 +772,7 @@
                         "field": "percent_reporting_decrease",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Percent Reporting Decrease",
-                        "description": "Percent of respondents reporting a decrease over the last month.",
+                        "headerTooltip": "Percent of respondents reporting a decrease over the last month.",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -781,7 +781,7 @@
                         "field": "percent_reporting_no_change",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Percent Reporting No Change",
-                        "description": "Percent of respondents reporting no change over the last month.",
+                        "headerTooltip": "Percent of respondents reporting no change over the last month.",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -796,14 +796,14 @@
     },
     "economy_survey_nonfarm_payrolls_fred_obb": {
         "name": "Nonfarm Payrolls",
-        "description": "Get Nonfarm Payrolls Survey.",
+        "headerTooltip": "Get Nonfarm Payrolls Survey.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_survey_nonfarm_payrolls_fred_obb",
         "params": [
             {
                 "label": "Date",
-                "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
+                "headerTooltip": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -813,7 +813,7 @@
             },
             {
                 "label": "Category",
-                "description": "The category to query.",
+                "headerTooltip": "The category to query.",
                 "optional": true,
                 "value": "employees_nsa",
                 "type": "text",
@@ -911,7 +911,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -920,14 +920,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Symbol",
-                        "description": "Symbol representing the entity requested in the data.",
+                        "headerTooltip": "Symbol representing the entity requested in the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "",
+                        "headerTooltip": "",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -936,7 +936,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Name",
-                        "description": "The name of the series.",
+                        "headerTooltip": "The name of the series.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -944,7 +944,7 @@
                         "field": "element_id",
                         "formatterFn": null,
                         "headerName": "Element ID",
-                        "description": "The element id in the parent/child relationship.",
+                        "headerTooltip": "The element id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -952,7 +952,7 @@
                         "field": "parent_id",
                         "formatterFn": null,
                         "headerName": "Parent ID",
-                        "description": "The parent id in the parent/child relationship.",
+                        "headerTooltip": "The parent id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -960,14 +960,14 @@
                         "field": "children",
                         "formatterFn": null,
                         "headerName": "Children",
-                        "description": "The element_id of each child, as a comma-separated string.",
+                        "headerTooltip": "The element_id of each child, as a comma-separated string.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "level",
                         "headerName": "Level",
-                        "description": "The indentation level of the element.",
+                        "headerTooltip": "The indentation level of the element.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -981,14 +981,14 @@
     },
     "economy_cpi_fred_obb": {
         "name": "CPI",
-        "description": "Get Consumer Price Index (CPI).\n\nReturns either the rescaled index value, or a rate of change (inflation).",
+        "headerTooltip": "Get Consumer Price Index (CPI).\n\nReturns either the rescaled index value, or a rate of change (inflation).",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_cpi_fred_obb",
         "params": [
             {
                 "label": "Country",
-                "description": "The country to get data. Multiple comma separated items allowed.",
+                "headerTooltip": "The country to get data. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -1196,7 +1196,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation of the CPI data. Period represents the change since previous. Defaults to change from one year ago (yoy).",
+                "headerTooltip": "Transformation of the CPI data. Period represents the change since previous. Defaults to change from one year ago (yoy).",
                 "optional": true,
                 "value": "yoy",
                 "type": "text",
@@ -1219,7 +1219,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "The frequency of the data.",
+                "headerTooltip": "The frequency of the data.",
                 "optional": true,
                 "value": "monthly",
                 "type": "text",
@@ -1242,7 +1242,7 @@
             },
             {
                 "label": "Harmonized",
-                "description": "If true, returns harmonized data.",
+                "headerTooltip": "If true, returns harmonized data.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -1251,7 +1251,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1260,7 +1260,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1288,7 +1288,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -1296,14 +1296,14 @@
                         "field": "country",
                         "formatterFn": null,
                         "headerName": "Country",
-                        "description": "Country",
+                        "headerTooltip": "Country",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "CPI index value or period change.",
+                        "headerTooltip": "CPI index value or period change.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -1316,14 +1316,14 @@
     },
     "economy_balance_of_payments_fred_obb": {
         "name": "Balance Of Payments",
-        "description": "Balance of Payments Reports.",
+        "headerTooltip": "Balance of Payments Reports.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_balance_of_payments_fred_obb",
         "params": [
             {
                 "label": "Country",
-                "description": "The country to get data. Enter as a 3-letter ISO country code, default is USA.",
+                "headerTooltip": "The country to get data. Enter as a 3-letter ISO country code, default is USA.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -1526,7 +1526,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1535,7 +1535,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -1562,7 +1562,7 @@
                         "field": "period",
                         "formatterFn": null,
                         "headerName": "Period",
-                        "description": "The date representing the beginning of the reporting period.",
+                        "headerTooltip": "The date representing the beginning of the reporting period.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -1570,7 +1570,7 @@
                         "field": "balance_percent_of_gdp",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Balance Percent Of GDP",
-                        "description": "Current Account Balance as Percent of GDP",
+                        "headerTooltip": "Current Account Balance as Percent of GDP",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -1578,35 +1578,35 @@
                     {
                         "field": "balance_total",
                         "headerName": "Balance Total",
-                        "description": "Current Account Total Balance (USD)",
+                        "headerTooltip": "Current Account Total Balance (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "balance_total_services",
                         "headerName": "Balance Total Services",
-                        "description": "Current Account Total Services Balance (USD)",
+                        "headerTooltip": "Current Account Total Services Balance (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "balance_total_secondary_income",
                         "headerName": "Balance Total Secondary Income",
-                        "description": "Current Account Total Secondary Income Balance (USD)",
+                        "headerTooltip": "Current Account Total Secondary Income Balance (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "balance_total_goods",
                         "headerName": "Balance Total Goods",
-                        "description": "Current Account Total Goods Balance (USD)",
+                        "headerTooltip": "Current Account Total Goods Balance (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "balance_total_primary_income",
                         "headerName": "Balance Total Primary Income",
-                        "description": "Current Account Total Primary Income Balance (USD)",
+                        "headerTooltip": "Current Account Total Primary Income Balance (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -1614,7 +1614,7 @@
                         "field": "credits_services_percent_of_goods_and_services",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Credits Services Percent Of Goods And Services",
-                        "description": "Current Account Credits Services as Percent of Goods and Services",
+                        "headerTooltip": "Current Account Credits Services as Percent of Goods and Services",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -1623,7 +1623,7 @@
                         "field": "credits_services_percent_of_current_account",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Credits Services Percent Of Current Account",
-                        "description": "Current Account Credits Services as Percent of Current Account",
+                        "headerTooltip": "Current Account Credits Services as Percent of Current Account",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -1631,35 +1631,35 @@
                     {
                         "field": "credits_total_services",
                         "headerName": "Credits Total Services",
-                        "description": "Current Account Credits Total Services (USD)",
+                        "headerTooltip": "Current Account Credits Total Services (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "credits_total_goods",
                         "headerName": "Credits Total Goods",
-                        "description": "Current Account Credits Total Goods (USD)",
+                        "headerTooltip": "Current Account Credits Total Goods (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "credits_total_primary_income",
                         "headerName": "Credits Total Primary Income",
-                        "description": "Current Account Credits Total Primary Income (USD)",
+                        "headerTooltip": "Current Account Credits Total Primary Income (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "credits_total_secondary_income",
                         "headerName": "Credits Total Secondary Income",
-                        "description": "Current Account Credits Total Secondary Income (USD)",
+                        "headerTooltip": "Current Account Credits Total Secondary Income (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "credits_total",
                         "headerName": "Credits Total",
-                        "description": "Current Account Credits Total (USD)",
+                        "headerTooltip": "Current Account Credits Total (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -1667,7 +1667,7 @@
                         "field": "debits_services_percent_of_goods_and_services",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Debits Services Percent Of Goods And Services",
-                        "description": "Current Account Debits Services as Percent of Goods and Services",
+                        "headerTooltip": "Current Account Debits Services as Percent of Goods and Services",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -1676,7 +1676,7 @@
                         "field": "debits_services_percent_of_current_account",
                         "formatterFn": "normalizedPercent",
                         "headerName": "Debits Services Percent Of Current Account",
-                        "description": "Current Account Debits Services as Percent of Current Account",
+                        "headerTooltip": "Current Account Debits Services as Percent of Current Account",
                         "cellDataType": "number",
                         "chartDataType": "series",
                         "renderFn": "greenRed"
@@ -1684,35 +1684,35 @@
                     {
                         "field": "debits_total_services",
                         "headerName": "Debits Total Services",
-                        "description": "Current Account Debits Total Services (USD)",
+                        "headerTooltip": "Current Account Debits Total Services (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "debits_total_goods",
                         "headerName": "Debits Total Goods",
-                        "description": "Current Account Debits Total Goods (USD)",
+                        "headerTooltip": "Current Account Debits Total Goods (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "debits_total_primary_income",
                         "headerName": "Debits Total Primary Income",
-                        "description": "Current Account Debits Total Primary Income (USD)",
+                        "headerTooltip": "Current Account Debits Total Primary Income (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "debits_total",
                         "headerName": "Debits Total",
-                        "description": "Current Account Debits Total (USD)",
+                        "headerTooltip": "Current Account Debits Total (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "debits_total_secondary_income",
                         "headerName": "Debits Total Secondary Income",
-                        "description": "Current Account Debits Total Secondary Income (USD)",
+                        "headerTooltip": "Current Account Debits Total Secondary Income (USD)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -1725,14 +1725,14 @@
     },
     "economy_fred_search_fred_obb": {
         "name": "FRED Search",
-        "description": "Search for FRED series or economic releases by ID or string.\n\nThis does not return the observation values, only the metadata.\nUse this function to find series IDs for `fred_series()`.",
+        "headerTooltip": "Search for FRED series or economic releases by ID or string.\n\nThis does not return the observation values, only the metadata.\nUse this function to find series IDs for `fred_series()`.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_search_fred_obb",
         "params": [
             {
                 "label": "Query",
-                "description": "The search word(s).",
+                "headerTooltip": "The search word(s).",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1740,7 +1740,7 @@
             },
             {
                 "label": "Is Release",
-                "description": "Is release?  If True, other search filter variables are ignored. If no query text or release_id is supplied, this defaults to True.",
+                "headerTooltip": "Is release?  If True, other search filter variables are ignored. If no query text or release_id is supplied, this defaults to True.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -1749,7 +1749,7 @@
             },
             {
                 "label": "Release ID",
-                "description": "A specific release ID to target.",
+                "headerTooltip": "A specific release ID to target.",
                 "optional": true,
                 "type": "text",
                 "show": true,
@@ -1757,7 +1757,7 @@
             },
             {
                 "label": "Limit",
-                "description": "The number of data entries to return. (1-1000)",
+                "headerTooltip": "The number of data entries to return. (1-1000)",
                 "optional": true,
                 "value": null,
                 "type": "number",
@@ -1766,7 +1766,7 @@
             },
             {
                 "label": "Offset",
-                "description": "Offset the results in conjunction with limit.",
+                "headerTooltip": "Offset the results in conjunction with limit.",
                 "optional": true,
                 "value": 0,
                 "type": "number",
@@ -1775,7 +1775,7 @@
             },
             {
                 "label": "Filter Variable",
-                "description": "Filter by an attribute.",
+                "headerTooltip": "Filter by an attribute.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1798,7 +1798,7 @@
             },
             {
                 "label": "Filter Value",
-                "description": "String value to filter the variable by.  Used in conjunction with filter_variable.",
+                "headerTooltip": "String value to filter the variable by.  Used in conjunction with filter_variable.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1806,7 +1806,7 @@
             },
             {
                 "label": "Tag Names",
-                "description": "A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' Multiple comma separated items allowed.",
+                "headerTooltip": "A semicolon delimited list of tag names that series match all of.  Example: 'japan;imports' Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1816,7 +1816,7 @@
             },
             {
                 "label": "Exclude Tag Names",
-                "description": "A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple comma separated items allowed.",
+                "headerTooltip": "A semicolon delimited list of tag names that series match none of.  Example: 'imports;services'. Requires that variable tag_names also be set to limit the number of matching series. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -1826,7 +1826,7 @@
             },
             {
                 "label": "Series ID",
-                "description": "A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas.",
+                "headerTooltip": "A FRED Series ID to return series group information for. This returns the required information to query for regional data. Not all series that are in FRED have geographical data. Entering a value for series_id will override all other parameters. Multiple series_ids can be separated by commas.",
                 "optional": true,
                 "type": "text",
                 "show": true,
@@ -1851,7 +1851,7 @@
                     {
                         "field": "release_id",
                         "headerName": "Release ID",
-                        "description": "The release ID for queries.",
+                        "headerTooltip": "The release ID for queries.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -1860,7 +1860,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Series ID",
-                        "description": "The series ID for the item in the release.",
+                        "headerTooltip": "The series ID for the item in the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1869,7 +1869,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Name",
-                        "description": "The name of the release.",
+                        "headerTooltip": "The name of the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1878,7 +1878,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Title",
-                        "description": "The title of the series.",
+                        "headerTooltip": "The title of the series.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1886,7 +1886,7 @@
                         "field": "observation_start",
                         "formatterFn": null,
                         "headerName": "Observation Start",
-                        "description": "The date of the first observation in the series.",
+                        "headerTooltip": "The date of the first observation in the series.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -1894,7 +1894,7 @@
                         "field": "observation_end",
                         "formatterFn": null,
                         "headerName": "Observation End",
-                        "description": "The date of the last observation in the series.",
+                        "headerTooltip": "The date of the last observation in the series.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -1902,7 +1902,7 @@
                         "field": "frequency",
                         "formatterFn": null,
                         "headerName": "Frequency",
-                        "description": "The frequency of the data.",
+                        "headerTooltip": "The frequency of the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1910,7 +1910,7 @@
                         "field": "frequency_short",
                         "formatterFn": null,
                         "headerName": "Frequency Short",
-                        "description": "Short form of the data frequency.",
+                        "headerTooltip": "Short form of the data frequency.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1918,7 +1918,7 @@
                         "field": "units",
                         "formatterFn": null,
                         "headerName": "Units",
-                        "description": "The units of the data.",
+                        "headerTooltip": "The units of the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1926,7 +1926,7 @@
                         "field": "units_short",
                         "formatterFn": null,
                         "headerName": "Units Short",
-                        "description": "Short form of the data units.",
+                        "headerTooltip": "Short form of the data units.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1934,7 +1934,7 @@
                         "field": "seasonal_adjustment",
                         "formatterFn": null,
                         "headerName": "Seasonal Adjustment",
-                        "description": "The seasonal adjustment of the data.",
+                        "headerTooltip": "The seasonal adjustment of the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1942,7 +1942,7 @@
                         "field": "seasonal_adjustment_short",
                         "formatterFn": null,
                         "headerName": "Seasonal Adjustment Short",
-                        "description": "Short form of the data seasonal adjustment.",
+                        "headerTooltip": "Short form of the data seasonal adjustment.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1950,7 +1950,7 @@
                         "field": "last_updated",
                         "formatterFn": null,
                         "headerName": "Last Updated",
-                        "description": "The datetime of the last update to the data.",
+                        "headerTooltip": "The datetime of the last update to the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -1958,7 +1958,7 @@
                         "field": "notes",
                         "formatterFn": null,
                         "headerName": "Notes",
-                        "description": "Description of the release.",
+                        "headerTooltip": "Description of the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1966,7 +1966,7 @@
                         "field": "press_release",
                         "formatterFn": null,
                         "headerName": "Press Release",
-                        "description": "If the release is a press release.",
+                        "headerTooltip": "If the release is a press release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -1974,21 +1974,21 @@
                         "field": "url",
                         "formatterFn": null,
                         "headerName": "Url",
-                        "description": "URL to the release.",
+                        "headerTooltip": "URL to the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "popularity",
                         "headerName": "Popularity",
-                        "description": "Popularity of the series",
+                        "headerTooltip": "Popularity of the series",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "group_popularity",
                         "headerName": "Group Popularity",
-                        "description": "Group popularity of the release",
+                        "headerTooltip": "Group popularity of the release",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -1996,14 +1996,14 @@
                         "field": "region_type",
                         "formatterFn": null,
                         "headerName": "Region Type",
-                        "description": "The region type of the series.",
+                        "headerTooltip": "The region type of the series.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "series_group",
                         "headerName": "Series Group",
-                        "description": "The series group ID of the series. This value is used to query for regional data.",
+                        "headerTooltip": "The series group ID of the series. This value is used to query for regional data.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -2016,14 +2016,14 @@
     },
     "economy_fred_series_fred_obb": {
         "name": "FRED Series",
-        "description": "Get data by series ID from FRED.",
+        "headerTooltip": "Get data by series ID from FRED.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_series_fred_obb",
         "params": [
             {
                 "label": "Symbol",
-                "description": "Symbol to get data for. Multiple comma separated items allowed.",
+                "headerTooltip": "Symbol to get data for. Multiple comma separated items allowed.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2032,7 +2032,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2041,7 +2041,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2050,7 +2050,7 @@
             },
             {
                 "label": "Limit",
-                "description": "The number of data entries to return.",
+                "headerTooltip": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2059,7 +2059,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2126,7 +2126,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2149,7 +2149,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2211,7 +2211,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     }
@@ -2224,14 +2224,14 @@
     },
     "economy_fred_series_fred_obb_chart": {
         "name": "FRED Series (Chart)",
-        "description": "Get data by series ID from FRED.",
+        "headerTooltip": "Get data by series ID from FRED.",
         "category": "Economy",
         "searchCategory": "chart",
         "widgetId": "economy_fred_series_fred_obb_chart",
         "params": [
             {
                 "label": "Symbol",
-                "description": "Symbol to get data for. Multiple comma separated items allowed.",
+                "headerTooltip": "Symbol to get data for. Multiple comma separated items allowed.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2240,7 +2240,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2249,7 +2249,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2258,7 +2258,7 @@
             },
             {
                 "label": "Limit",
-                "description": "The number of data entries to return.",
+                "headerTooltip": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2267,7 +2267,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2334,7 +2334,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2357,7 +2357,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2406,7 +2406,7 @@
             {
                 "paramName": "chart",
                 "label": "Chart",
-                "description": "Returns chart",
+                "headerTooltip": "Returns chart",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -2428,7 +2428,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     }
@@ -2442,14 +2442,14 @@
     },
     "economy_fred_release_table_fred_obb": {
         "name": "FRED Release Table",
-        "description": "Get economic release data by ID and/or element from FRED.",
+        "headerTooltip": "Get economic release data by ID and/or element from FRED.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_release_table_fred_obb",
         "params": [
             {
                 "label": "Release ID",
-                "description": "The ID of the release. Use `fred_search` to find releases.",
+                "headerTooltip": "The ID of the release. Use `fred_search` to find releases.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2457,7 +2457,7 @@
             },
             {
                 "label": "Element Id",
-                "description": "The element ID of a specific table in the release.",
+                "headerTooltip": "The element ID of a specific table in the release.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2465,7 +2465,7 @@
             },
             {
                 "label": "Date",
-                "description": "A specific date to get data for. Multiple comma separated items allowed.",
+                "headerTooltip": "A specific date to get data for. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -2494,14 +2494,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
                     {
                         "field": "level",
                         "headerName": "Level",
-                        "description": "The indentation level of the element.",
+                        "headerTooltip": "The indentation level of the element.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -2509,14 +2509,14 @@
                         "field": "element_type",
                         "formatterFn": null,
                         "headerName": "Element Type",
-                        "description": "The type of the element.",
+                        "headerTooltip": "The type of the element.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "line",
                         "headerName": "Line",
-                        "description": "The line number of the element.",
+                        "headerTooltip": "The line number of the element.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -2524,7 +2524,7 @@
                         "field": "element_id",
                         "formatterFn": null,
                         "headerName": "Element ID",
-                        "description": "The element id in the parent/child relationship.",
+                        "headerTooltip": "The element id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -2532,7 +2532,7 @@
                         "field": "parent_id",
                         "formatterFn": null,
                         "headerName": "Parent ID",
-                        "description": "The parent id in the parent/child relationship.",
+                        "headerTooltip": "The parent id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -2540,7 +2540,7 @@
                         "field": "children",
                         "formatterFn": null,
                         "headerName": "Children",
-                        "description": "The element_id of each child, as a comma-separated string.",
+                        "headerTooltip": "The element_id of each child, as a comma-separated string.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -2549,7 +2549,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Symbol",
-                        "description": "Symbol representing the entity requested in the data.",
+                        "headerTooltip": "Symbol representing the entity requested in the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -2558,14 +2558,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Name",
-                        "description": "The name of the series.",
+                        "headerTooltip": "The name of the series.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "The reported value of the series.",
+                        "headerTooltip": "The reported value of the series.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -2578,14 +2578,14 @@
     },
     "economy_fred_regional_fred_obb": {
         "name": "FRED Regional",
-        "description": "Query the Geo Fred API for regional economic data by series group.\n\nThe series group ID is found by using `fred_search` and the `series_id` parameter.",
+        "headerTooltip": "Query the Geo Fred API for regional economic data by series group.\n\nThe series group ID is found by using `fred_search` and the `series_id` parameter.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_fred_regional_fred_obb",
         "params": [
             {
                 "label": "Symbol",
-                "description": "Symbol to get data for.",
+                "headerTooltip": "Symbol to get data for.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -2593,7 +2593,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2602,7 +2602,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2611,7 +2611,7 @@
             },
             {
                 "label": "Limit",
-                "description": "The number of data entries to return.",
+                "headerTooltip": "The number of data entries to return.",
                 "optional": true,
                 "value": 100000,
                 "type": "number",
@@ -2620,7 +2620,7 @@
             },
             {
                 "label": "Is Series Group",
-                "description": "When True, the symbol provided is for a series_group, else it is for a series ID.",
+                "headerTooltip": "When True, the symbol provided is for a series_group, else it is for a series ID.",
                 "optional": true,
                 "value": false,
                 "type": "boolean",
@@ -2629,7 +2629,7 @@
             },
             {
                 "label": "Region Type",
-                "description": "The type of regional data. Parameter is only valid when `is_series_group` is True.",
+                "headerTooltip": "The type of regional data. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2672,7 +2672,7 @@
             },
             {
                 "label": "Season",
-                "description": "The seasonal adjustments to the data. Parameter is only valid when `is_series_group` is True.",
+                "headerTooltip": "The seasonal adjustments to the data. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": "nsa",
                 "type": "text",
@@ -2695,7 +2695,7 @@
             },
             {
                 "label": "Units",
-                "description": "The units of the data. This should match the units returned from searching by series ID. An incorrect field will not necessarily return an error. Parameter is only valid when `is_series_group` is True.",
+                "headerTooltip": "The units of the data. This should match the units returned from searching by series ID. An incorrect field will not necessarily return an error. Parameter is only valid when `is_series_group` is True.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2703,7 +2703,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
+                "headerTooltip": "Frequency aggregation to convert high frequency data to lower frequency.\n        \n    None = No change\n        \n    a = Annual\n        \n    q = Quarterly\n        \n    m = Monthly\n        \n    w = Weekly\n        \n    d = Daily\n        \n    wef = Weekly, Ending Friday\n        \n    weth = Weekly, Ending Thursday\n        \n    wew = Weekly, Ending Wednesday\n        \n    wetu = Weekly, Ending Tuesday\n        \n    wem = Weekly, Ending Monday\n        \n    wesu = Weekly, Ending Sunday\n        \n    wesa = Weekly, Ending Saturday\n        \n    bwew = Biweekly, Ending Wednesday\n        \n    bwem = Biweekly, Ending Monday",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2770,7 +2770,7 @@
             },
             {
                 "label": "Aggregation Method",
-                "description": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
+                "headerTooltip": "A key that indicates the aggregation method used for frequency aggregation.\n        This parameter has no affect if the frequency parameter is not set.\n        \n    avg = Average\n        \n    sum = Sum\n        \n    eop = End of Period",
                 "optional": true,
                 "value": "eop",
                 "show": true,
@@ -2793,7 +2793,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
+                "headerTooltip": "Transformation type\n        \n    None = No transformation\n        \n    chg = Change\n        \n    ch1 = Change from Year Ago\n        \n    pch = Percent Change\n        \n    pc1 = Percent Change from Year Ago\n        \n    pca = Compounded Annual Rate of Change\n        \n    cch = Continuously Compounded Rate of Change\n        \n    cca = Continuously Compounded Annual Rate of Change\n        \n    log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2855,7 +2855,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -2863,21 +2863,21 @@
                         "field": "region",
                         "formatterFn": null,
                         "headerName": "Region",
-                        "description": "The name of the region.",
+                        "headerTooltip": "The name of the region.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "code",
                         "headerName": "Code",
-                        "description": "The code of the region.",
+                        "headerTooltip": "The code of the region.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "The obersvation value. The units are defined in the search results by series ID.",
+                        "headerTooltip": "The obersvation value. The units are defined in the search results by series ID.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -2886,7 +2886,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Series ID",
-                        "description": "The individual series ID for the region.",
+                        "headerTooltip": "The individual series ID for the region.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     }
@@ -2899,14 +2899,14 @@
     },
     "economy_retail_prices_fred_obb": {
         "name": "Retail Prices",
-        "description": "Get retail prices for common items.",
+        "headerTooltip": "Get retail prices for common items.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_retail_prices_fred_obb",
         "params": [
             {
                 "label": "Item",
-                "description": "The item or basket of items to query.",
+                "headerTooltip": "The item or basket of items to query.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -2914,7 +2914,7 @@
             },
             {
                 "label": "Country",
-                "description": "The country to get data.",
+                "headerTooltip": "The country to get data.",
                 "optional": true,
                 "value": "united_states",
                 "type": "text",
@@ -2923,7 +2923,7 @@
             },
             {
                 "label": "Start Date",
-                "description": "Start date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "Start date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2932,7 +2932,7 @@
             },
             {
                 "label": "End Date",
-                "description": "End date of the data, in YYYY-MM-DD format.",
+                "headerTooltip": "End date of the data, in YYYY-MM-DD format.",
                 "optional": true,
                 "value": null,
                 "type": "date",
@@ -2941,7 +2941,7 @@
             },
             {
                 "label": "Region",
-                "description": "The region to get average price levels for.",
+                "headerTooltip": "The region to get average price levels for.",
                 "optional": true,
                 "value": "all_city",
                 "type": "text",
@@ -2972,7 +2972,7 @@
             },
             {
                 "label": "Frequency",
-                "description": "The frequency of the data.",
+                "headerTooltip": "The frequency of the data.",
                 "optional": true,
                 "value": "monthly",
                 "type": "text",
@@ -2995,7 +2995,7 @@
             },
             {
                 "label": "Transform",
-                "description": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
+                "headerTooltip": "Transformation type\n            None = No transformation\n            chg = Change\n            ch1 = Change from Year Ago\n            pch = Percent Change\n            pc1 = Percent Change from Year Ago\n            pca = Compounded Annual Rate of Change\n            cch = Continuously Compounded Rate of Change\n            cca = Continuously Compounded Annual Rate of Change\n            log = Natural Log",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -3057,7 +3057,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -3066,7 +3066,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Symbol",
-                        "description": "Symbol representing the entity requested in the data.",
+                        "headerTooltip": "Symbol representing the entity requested in the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3074,7 +3074,7 @@
                         "field": "country",
                         "formatterFn": null,
                         "headerName": "Country",
-                        "description": "",
+                        "headerTooltip": "",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3082,14 +3082,14 @@
                         "field": "description",
                         "formatterFn": null,
                         "headerName": "Description",
-                        "description": "Description of the item.",
+                        "headerTooltip": "Description of the item.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "Price, or change in price, per unit.",
+                        "headerTooltip": "Price, or change in price, per unit.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -3102,14 +3102,14 @@
     },
     "economy_pce_fred_obb": {
         "name": "PCE",
-        "description": "Get Personal Consumption Expenditures (PCE) reports.",
+        "headerTooltip": "Get Personal Consumption Expenditures (PCE) reports.",
         "category": "Economy",
         "searchCategory": "Economy",
         "widgetId": "economy_pce_fred_obb",
         "params": [
             {
                 "label": "Date",
-                "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
+                "headerTooltip": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed.",
                 "optional": true,
                 "value": null,
                 "type": "text",
@@ -3119,7 +3119,7 @@
             },
             {
                 "label": "Category",
-                "description": "The category to query.",
+                "headerTooltip": "The category to query.",
                 "optional": true,
                 "value": "personal_income",
                 "type": "text",
@@ -3181,7 +3181,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of the data.",
+                        "headerTooltip": "The date of the data.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -3190,14 +3190,14 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Symbol",
-                        "description": "Symbol representing the entity requested in the data.",
+                        "headerTooltip": "Symbol representing the entity requested in the data.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "value",
                         "headerName": "Value",
-                        "description": "",
+                        "headerTooltip": "",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -3206,7 +3206,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Name",
-                        "description": "The name of the series.",
+                        "headerTooltip": "The name of the series.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3214,7 +3214,7 @@
                         "field": "element_id",
                         "formatterFn": null,
                         "headerName": "Element ID",
-                        "description": "The element id in the parent/child relationship.",
+                        "headerTooltip": "The element id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3222,7 +3222,7 @@
                         "field": "parent_id",
                         "formatterFn": null,
                         "headerName": "Parent ID",
-                        "description": "The parent id in the parent/child relationship.",
+                        "headerTooltip": "The parent id in the parent/child relationship.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3230,21 +3230,21 @@
                         "field": "children",
                         "formatterFn": null,
                         "headerName": "Children",
-                        "description": "The element_id of each child, as a comma-separated string.",
+                        "headerTooltip": "The element_id of each child, as a comma-separated string.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "level",
                         "headerName": "Level",
-                        "description": "The indentation level of the element.",
+                        "headerTooltip": "The indentation level of the element.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
                     {
                         "field": "line",
                         "headerName": "Line",
-                        "description": "The line number of the series in the table.",
+                        "headerTooltip": "The line number of the series in the table.",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -3257,14 +3257,14 @@
     },
     "regulators_sec_cik_map_sec_obb": {
         "name": "CIK Map",
-        "description": "Map a ticker symbol to a CIK number.",
+        "headerTooltip": "Map a ticker symbol to a CIK number.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_cik_map_sec_obb",
         "params": [
             {
                 "label": "Symbol",
-                "description": "Symbol to get data for.",
+                "headerTooltip": "Symbol to get data for.",
                 "optional": false,
                 "type": "text",
                 "show": true,
@@ -3272,7 +3272,7 @@
             },
             {
                 "label": "Use Cache",
-                "description": "Whether or not to use cache for the request, default is True.",
+                "headerTooltip": "Whether or not to use cache for the request, default is True.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3303,14 +3303,14 @@
     },
     "regulators_sec_institutions_search_sec_obb": {
         "name": "Institutions Search",
-        "description": "Search SEC-regulated institutions by name and return a list of results with CIK numbers.",
+        "headerTooltip": "Search SEC-regulated institutions by name and return a list of results with CIK numbers.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_institutions_search_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "description": "Search query.",
+                "headerTooltip": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3319,7 +3319,7 @@
             },
             {
                 "label": "Use Cache",
-                "description": "Whether or not to use cache.",
+                "headerTooltip": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3346,14 +3346,14 @@
                         "field": "institution",
                         "formatterFn": null,
                         "headerName": "Institution",
-                        "description": "The name of the institution.",
+                        "headerTooltip": "The name of the institution.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
                     {
                         "field": "cik_number",
                         "headerName": "CIK Number",
-                        "description": "Central Index Key (CIK)",
+                        "headerTooltip": "Central Index Key (CIK)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     }
@@ -3367,14 +3367,14 @@
     },
     "regulators_sec_schema_files_sec_obb": {
         "name": "Schema Files",
-        "description": "Use tool for navigating the directory of SEC XML schema files by year.",
+        "headerTooltip": "Use tool for navigating the directory of SEC XML schema files by year.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_schema_files_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "description": "Search query.",
+                "headerTooltip": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3383,7 +3383,7 @@
             },
             {
                 "label": "Use Cache",
-                "description": "Whether or not to use cache.",
+                "headerTooltip": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3392,7 +3392,7 @@
             },
             {
                 "label": "Url",
-                "description": "Enter an optional URL path to fetch the next level.",
+                "headerTooltip": "Enter an optional URL path to fetch the next level.",
                 "optional": true,
                 "value": null,
                 "show": true,
@@ -3422,14 +3422,14 @@
     },
     "regulators_sec_symbol_map_sec_obb": {
         "name": "Symbol Map",
-        "description": "Map a CIK number to a ticker symbol, leading 0s can be omitted or included.",
+        "headerTooltip": "Map a CIK number to a ticker symbol, leading 0s can be omitted or included.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_symbol_map_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "description": "Search query.",
+                "headerTooltip": "Search query.",
                 "optional": false,
                 "value": null,
                 "type": "text",
@@ -3438,7 +3438,7 @@
             },
             {
                 "label": "Use Cache",
-                "description": "Whether or not to use cache. If True, cache will store for seven days.",
+                "headerTooltip": "Whether or not to use cache. If True, cache will store for seven days.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3469,7 +3469,7 @@
     },
     "regulators_sec_rss_litigation_sec_obb": {
         "name": "RSS Litigation",
-        "description": "Get the RSS feed that provides links to litigation releases concerning civil lawsuits brought by the Commission in federal court.",
+        "headerTooltip": "Get the RSS feed that provides links to litigation releases concerning civil lawsuits brought by the Commission in federal court.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_rss_litigation_sec_obb",
@@ -3495,7 +3495,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Date",
-                        "description": "The date of publication.",
+                        "headerTooltip": "The date of publication.",
                         "cellDataType": "date",
                         "chartDataType": "category"
                     },
@@ -3504,7 +3504,7 @@
                         "pinned": "left",
                         "formatterFn": null,
                         "headerName": "Title",
-                        "description": "The title of the release.",
+                        "headerTooltip": "The title of the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3512,7 +3512,7 @@
                         "field": "summary",
                         "formatterFn": null,
                         "headerName": "Summary",
-                        "description": "Short summary of the release.",
+                        "headerTooltip": "Short summary of the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3520,7 +3520,7 @@
                         "field": "id",
                         "formatterFn": null,
                         "headerName": "ID",
-                        "description": "The identifier associated with the release.",
+                        "headerTooltip": "The identifier associated with the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3528,7 +3528,7 @@
                         "field": "link",
                         "formatterFn": null,
                         "headerName": "Link",
-                        "description": "URL to the release.",
+                        "headerTooltip": "URL to the release.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     }
@@ -3542,14 +3542,14 @@
     },
     "regulators_sec_sic_search_sec_obb": {
         "name": "SIC Search",
-        "description": "Search for Industry Titles, Reporting Office, and SIC Codes. An empty query string returns all results.",
+        "headerTooltip": "Search for Industry Titles, Reporting Office, and SIC Codes. An empty query string returns all results.",
         "category": "Regulators",
         "searchCategory": "Regulators",
         "widgetId": "regulators_sec_sic_search_sec_obb",
         "params": [
             {
                 "label": "Query",
-                "description": "Search query.",
+                "headerTooltip": "Search query.",
                 "optional": true,
                 "value": "",
                 "type": "text",
@@ -3558,7 +3558,7 @@
             },
             {
                 "label": "Use Cache",
-                "description": "Whether or not to use cache.",
+                "headerTooltip": "Whether or not to use cache.",
                 "optional": true,
                 "value": true,
                 "type": "boolean",
@@ -3584,7 +3584,7 @@
                     {
                         "field": "sic_code",
                         "headerName": "SIC Code",
-                        "description": "Sector Industrial Code (SIC)",
+                        "headerTooltip": "Sector Industrial Code (SIC)",
                         "cellDataType": "number",
                         "chartDataType": "series"
                     },
@@ -3592,7 +3592,7 @@
                         "field": "industry_title",
                         "formatterFn": null,
                         "headerName": "Industry Title",
-                        "description": "Industry title.",
+                        "headerTooltip": "Industry title.",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     },
@@ -3600,7 +3600,7 @@
                         "field": "office",
                         "formatterFn": null,
                         "headerName": "Office",
-                        "description": "Reporting office within the Corporate Finance Office",
+                        "headerTooltip": "Reporting office within the Corporate Finance Office",
                         "cellDataType": "text",
                         "chartDataType": "category"
                     }


### PR DESCRIPTION
1. **Why**?:

    - Updating the `openbb-platform-api` package to include hover readout for table column headers, and to add a route for `templates.json`

2. **What**?:

    - For Workspace tables, all field descriptions will now display on hover.
    - `templates.json` is served from a local file, `~/OpenBBUserData/workspace_templates.json`
      - If the file does not exist, an empty JSON will be generated.
      - Add exported dashboard templates to the list in that file.

3. **Impact**:

    - Improved UX.
    - Ability to use the custom templates functionality with the Platform backend.


4. **Testing Done**:

    - Test by launching via, `openbb-api`

<img width="1392" alt="Screenshot 2025-01-24 at 9 50 34 AM" src="https://github.com/user-attachments/assets/2d2af216-a81b-4aa7-b805-4c2f32507fab" />

