### PR TITLE
[BugFix] Fix Missing 'title' In IMF Economic Indicators

### DIFF
--- a/openbb_platform/providers/imf/openbb_imf/models/economic_indicators.py
+++ b/openbb_platform/providers/imf/openbb_imf/models/economic_indicators.py
@@ -294,6 +294,10 @@ class ImfEconomicIndicatorsFetcher(
             by=["date", "parent", "symbol", "value"],
             ascending=[True, True, True, False],
         ).reset_index(drop=True)
+
+        df.loc[:, "title"] = df.symbol.apply(
+            lambda x: all_symbols.get(x, {}).get("title")
+        )
         records = df.replace({nan: None}).to_dict(orient="records")
 
         return [ImfEconomicIndicatorsData.model_validate(r) for r in records]


### PR DESCRIPTION
1. **Why**?:

    - This fixes an issue where the series title was not being mapped in, `obb.economy.indicators(provider="imf")`

2. **What**?:

    - Maps it from the symbols static asset, in `transform_data`

3. **Impact**:

    - More clarity and better presentation.

4. **Testing Done**:

    - "title" field now returned when `provider="imf"`
