### PR TITLE
[BugFix] `obb.equity.profile(provider='fmp')` - Fix 'NoneType' object has no attribute 'split' where symbol is untraded.

### DIFF
--- a/openbb_platform/providers/fmp/openbb_fmp/models/equity_profile.py
+++ b/openbb_platform/providers/fmp/openbb_fmp/models/equity_profile.py
@@ -164,7 +164,9 @@ class FMPEquityProfileFetcher(
         """Return the transformed data."""
         results: List[FMPEquityProfileData] = []
         for d in data:
-            d["year_low"], d["year_high"] = d.get("range", "-").split("-")
+            d["year_low"], d["year_high"] = (
+                d.get("range", "-").split("-") if d.get("range") else (None, None)
+            )
 
             # Clear out fields that don't belong and can be had elsewhere.
             entries_to_remove = (


### PR DESCRIPTION
1. **Why**?:

    - In, `obb.equity.profile(provider='fmp')`, an untraded symbol created an error where the high/low was attempting to access a field that did not exist.

2. **What**?:

    - Add check to the `split`.

3. **Impact**:

    - Fixes a bug.

4. **Testing Done**:

```python
obb.equity.profile("FB", provider="fmp").to_dict("records")
```

```sh 
[{'symbol': 'FB',
  'name': 'Meta Platforms, Inc.',
  'cik': '0001326801',
  'cusip': '30303M102',
  'isin': 'US30303M1027',
  'stock_exchange': 'NASDAQ Global Select',
  'long_description': "Meta Platforms, Inc. develops products that enable people to connect and share with friends and family through mobile devices, personal computers, virtual reality headsets, wearables, and in-home devices worldwide. It operates in two segments, Family of Apps and Reality Labs. The Family of Apps segment's products include Facebook, which enables people to share, discover, and connect with interests; Instagram, a community for sharing photos, videos, and private messages, as well as feed, stories, reels, video, live, and shops; Messenger, a messaging application for people to connect with friends, family, groups, and businesses across platforms and devices through chat, audio and video calls, and rooms; and WhatsApp, a messaging application that is used by people and businesses to communicate and transact privately. The Reality Labs segment provides augmented and virtual reality related products comprising virtual reality hardware, software, and content that help people feel connected, anytime, and anywhere. The company was formerly known as Facebook, Inc. and changed its name to Meta Platforms, Inc. in October 2021. Meta Platforms, Inc. was incorporated in 2004 and is headquartered in Menlo Park, California.",
  'ceo': 'Mr. Mark Zuckerberg',
  'company_url': 'https://investor.fb.com',
  'business_phone_no': '16506187714',
  'hq_address1': '1601 Willow Rd',
  'hq_address_city': 'Menlo Park',
  'hq_address_postal_code': '94025',
  'hq_state': 'CALIFORNIA',
  'hq_country': 'US',
  'employees': 77805,
  'sector': 'Communication Services',
  'industry_category': 'Internet Content & Information',
  'first_stock_price_date': datetime.date(2012, 5, 18),
  'is_etf': False,
  'is_actively_trading': False,
  'is_adr': False,
  'is_fund': False,
  'image': 'https://images.financialmodelingprep.com/symbol/FB.png',
  'currency': 'USD',
  'market_cap': 0,
  'volume_avg': 0,
  'annualized_dividend_amount': 0.0,
  'beta': 1.376134}]
```