### PR TITLE
[Feature] `openbb-platform-api`: Adds Configurations Supplied In Router Decorator To `widgets.json`

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -360,20 +360,19 @@ def get_data_schema_for_widget(openapi_json, operation_id):
                 if isinstance(response_ref, dict) and "type" in response_ref:
                     response_ref = response_ref["type"]
 
-                if (
-                    response_ref
-                    and response_ref in openapi_json["components"]["schemas"]
-                ):
+                if response_ref:
                     # Extract the schema name from the reference
                     schema_name = response_ref.split("/")[-1]
                     # Fetch and return the schema from components
-                    return (
-                        openapi_json["components"]["schemas"][schema_name]
-                        .get("properties", {})
-                        .get("results", {})
-                    )
-                if response_ref:
-                    return response_ref
+                    if (
+                        schema_name
+                        and schema_name in openapi_json["components"]["schemas"]
+                    ):
+                        return (
+                            openapi_json["components"]["schemas"][schema_name]
+                            .get("properties", {})
+                            .get("results", {})
+                        )
 
     # Return None if the schema is not found
     return None

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -354,9 +354,16 @@ def get_data_schema_for_widget(openapi_json, operation_id):
                 ][
                     "application/json"
                 ].get(
-                    "schema", ""
+                    "schema"
                 )
-                if response_ref:
+
+                if isinstance(response_ref, dict) and "type" in response_ref:
+                    response_ref = response_ref["type"]
+
+                if (
+                    response_ref
+                    and response_ref in openapi_json["components"]["schemas"]
+                ):
                     # Extract the schema name from the reference
                     schema_name = response_ref.split("/")[-1]
                     # Fetch and return the schema from components
@@ -365,6 +372,8 @@ def get_data_schema_for_widget(openapi_json, operation_id):
                         .get("properties", {})
                         .get("results", {})
                     )
+                elif response_ref:
+                    return response_ref
 
     # Return None if the schema is not found
     return None

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -372,7 +372,7 @@ def get_data_schema_for_widget(openapi_json, operation_id):
                         .get("properties", {})
                         .get("results", {})
                     )
-                elif response_ref:
+                if response_ref:
                     return response_ref
 
     # Return None if the schema is not found

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -356,14 +356,15 @@ def get_data_schema_for_widget(openapi_json, operation_id):
                 ].get(
                     "schema", ""
                 )
-                # Extract the schema name from the reference
-                schema_name = response_ref.split("/")[-1]
-                # Fetch and return the schema from components
-                return (
-                    openapi_json["components"]["schemas"][schema_name]
-                    .get("properties", {})
-                    .get("results", {})
-                )
+                if response_ref:
+                    # Extract the schema name from the reference
+                    schema_name = response_ref.split("/")[-1]
+                    # Fetch and return the schema from components
+                    return (
+                        openapi_json["components"]["schemas"][schema_name]
+                        .get("properties", {})
+                        .get("results", {})
+                    )
 
     # Return None if the schema is not found
     return None
@@ -377,7 +378,7 @@ def data_schema_to_columns_defs(openapi_json, operation_id, provider):
 
     result_schema_ref = get_data_schema_for_widget(openapi_json, operation_id)
     # Check if 'anyOf' is in the result_schema_ref and handle the nested structure
-    if "anyOf" in result_schema_ref:
+    if result_schema_ref and "anyOf" in result_schema_ref:
         for item in result_schema_ref["anyOf"]:
             # When there are multiple providers a 'oneOf' is used
             if "items" in item and "oneOf" in item["items"]:
@@ -397,7 +398,7 @@ def data_schema_to_columns_defs(openapi_json, operation_id, provider):
     schemas = [
         openapi_json["components"]["schemas"][ref]
         for ref in schema_refs
-        if ref in openapi_json["components"]["schemas"]
+        if ref and ref in openapi_json["components"]["schemas"]
     ]
 
     # Proceed with finding common keys and generating column definitions

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
@@ -82,7 +82,7 @@ def build_json(openapi: dict, widget_exclude_filter: list):
         route_api = openapi["paths"][route]
         method = list(route_api)[0]
         widget_id = route_api[method]["operationId"]
-
+        widget_config_dict = route_api[method].get("widget_config", {})
         # Prepare the query schema of the widget
         query_schema, has_chart = get_query_schema_for_widget(openapi, route)
         response_schema = route_api[method]["responses"]["200"]["content"][
@@ -177,6 +177,10 @@ def build_json(openapi: dict, widget_exclude_filter: list):
 
             if columns_defs:
                 widget_config["data"]["table"]["columnsDefs"] = columns_defs
+
+            # Update the widget configuration with the supplied configurations in @router.command
+            if widget_config_dict:
+                widget_config.update(widget_config_dict)
 
             # Add the widget configuration to the widgets.json
             if widget_config["widgetId"] not in widget_exclude_filter:


### PR DESCRIPTION
1. **Why**?:

    - Provides a way to define some, or all, widget configuration settings that will override the automatically-generated content.

2. **What**?:

    - Reads a dictionary supplied in the `@router.command` decorator and updates the generated widget entry with the supplied settings.

3. **Impact**:

    - Improves developer experience.
    - Requires knowing the nested dictionary structure that is `widgets.json`. 


4. **Testing Done**:

    - Some router extension, and change the "type".

```python
"""Empty Router Extenision for OpenBB Platform."""

from datetime import datetime
from typing import Annotated

from fastapi import Query
from fastapi.responses import JSONResponse
from openbb_core.app.router import Router

router = Router(prefix="", description="A custom OpenBB router extension.")


@router.command(
    methods=["GET"],
    no_validate=True,
    openapi_extra={"widget_config": {"type": "markdown"}},
)
async def hello(
    input: Annotated[str, Query(description="some description")] = "Hello",
) -> str:
    """Widget description created by doctring."""

    return "Hello from the Empty Router extension!"
```

<img width="1077" alt="Screenshot 2025-01-30 at 1 47 44 PM" src="https://github.com/user-attachments/assets/4f69f3ac-ec6b-44c2-922b-20758fef64b2" />


Removing all params from the function:

<img width="846" alt="Screenshot 2025-01-30 at 1 59 40 PM" src="https://github.com/user-attachments/assets/8a4209ac-c0fe-4829-8f6d-4e89287ed362" />
