### PR TITLE
[BugFix] Remove Crashing Elements That Attempt To Limit X-Range Displayed In Candles

### DIFF
--- a/frontend-components/plotly/src/components/Chart.tsx
+++ b/frontend-components/plotly/src/components/Chart.tsx
@@ -632,28 +632,6 @@ function Chart({
       if (theme !== "dark") {
         setChangeTheme(true);
       }
-
-      const traceTypes = originalData.data.map(
-        (trace) => trace.type === "candlestick",
-      );
-      if (
-        (originalData.data[0]?.x !== undefined &&
-          originalData.data[0]?.x.length <= 1000) ||
-        !traceTypes.includes(true)
-      )
-        return;
-      setModal({
-        name: "alertDialog",
-        data: {
-          title: "Warning",
-          content: `Data has been truncated to 1000 points for performance reasons.
-						Please use the zoom tool to see more data.`,
-        },
-      });
-      const new_figure = CreateDataXrange(originalData);
-      setPlotData(new_figure);
-      setDateSliced(true);
-      setAutoScaling(true);
     }
   }, [plotLoaded]);
 


### PR DESCRIPTION

1. **Why**?:

    - Resolves #6567

2. **What**?:

    - Removes a function that attempted to limit the x-range in candlestick charts. 

3. **Impact** (1-2 sentences or a bullet point list):
    - CLI and other consumers via PyWry affected.

4. **Testing Done**:

This now works, no crashing or glitch-out.

```python
from openbb import obb

data = obb.equity.price.historical("AAPL", start_date="2000-01-01", provider="yfinance", chart=True)
data.show()
```

<img width="1457" alt="Screenshot 2025-01-30 at 3 04 23 PM" src="https://github.com/user-attachments/assets/5984e98c-cdf2-44bd-bb7b-cff0b9a8ef3f" />

