### PR TITLE
[BugFix] `openbb-yfinance`: Remove Duplicated Line In Screener Causing Double Results For First Pass

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -521,7 +521,7 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     _start_date = start_date
     intraday = False
     if interval in ["60m", "1h"]:
-        period = "2y" if period in ["5y", "10y"] else period
+        period = "2y" if period in ["5y", "10y", "max"] else period
         _start_date = None
         intraday = True
 
@@ -543,7 +543,6 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     if session.proxies:
         kwargs["proxy"] = session.proxies
     try:
-        print(interval)
         data = yf.download(
             tickers=symbol,
             start=_start_date,

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -114,14 +114,13 @@ async def get_custom_screener(
 
     results.extend(res["quotes"])
     total_results = res["total"]
-    results.extend(res["quotes"])
 
     while len(results) < total_results:
         if limit is not None and len(results) >= limit:
             break
         offset = len(results)
         body["offset"] = offset
-        res = _data.post(
+        response = _data.post(
             "https://query2.finance.yahoo.com/v1/finance/screener",
             body=body,
             user_agent_headers=_data.user_agent_headers,
@@ -130,6 +129,7 @@ async def get_custom_screener(
         )
         if not res:
             break
+        res = response.json()["finance"]["result"][0]
         results.extend(res.get("quotes", []))
 
     output: list = []
@@ -186,7 +186,6 @@ async def get_defined_screener(
     if not response.get("quotes"):
         raise EmptyDataError("No data found for the predefined screener.")
 
-    results.extend(response["quotes"])
     total_results = response["total"]
     results.extend(response["quotes"])
 
@@ -522,7 +521,7 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     _start_date = start_date
     intraday = False
     if interval in ["60m", "1h"]:
-        period = "2y" if period in ["5y", "10y", "max"] else period
+        period = "2y" if period in ["5y", "10y"] else period
         _start_date = None
         intraday = True
 
@@ -544,6 +543,7 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     if session.proxies:
         kwargs["proxy"] = session.proxies
     try:
+        print(interval)
         data = yf.download(
             tickers=symbol,
             start=_start_date,


### PR DESCRIPTION
1. **Why**?:

    - YFinance functions in `obb.equity.discovery` and `obb.equity.screener` were subjected to a duplicated line creating double results from the first page of results.

2. **What**?:

    - Fixes the bad code.

3. **Impact**:

    - Fixes duplicate results.

4. **Testing Done**:

    - Before/After - i.e, `obb.equity.discovery.aggressive_small_caps`, etc.
