### PR TITLE
[BugFix] Fix Chart Widgets Not Overwriting '{"type": "table"}'

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
@@ -344,6 +344,7 @@ def build_json(openapi: dict, widget_exclude_filter: list):
 
             if has_chart:
                 widget_config_chart = deepcopy(widget_config)
+                widget_config_chart["type"] = "chart"
                 widget_config_chart["name"] = widget_config_chart["name"] + " (Chart)"
                 widget_config_chart["widgetId"] = (
                     f"{widget_config_chart['widgetId']}_chart"

--- a/openbb_platform/extensions/platform_api/tests/mock_widgets.json
+++ b/openbb_platform/extensions/platform_api/tests/mock_widgets.json
@@ -2248,7 +2248,7 @@
         "name": "Fred Series (Chart)",
         "description": "Get data by series ID from FRED.",
         "category": "Economy",
-        "type": "table",
+        "type": "chart",
         "searchCategory": "chart",
         "widgetId": "economy_fred_series_fred_obb_chart",
         "params": [


### PR DESCRIPTION
1. **Why**?:

    - Somewhere along the way the chart widget lost its "type" setting, this restores it.

2. **What**?:

    - Overwrites the default, "table".

3. **Impact** (1-2 sentences or a bullet point list):

    - Briefly note the expected outcome or any potential risks and share the Impact Analysis score.

4. **Testing Done**:

    - Can be checked by generating widgets from Platform API, built locally, and opening a chart.
