### PR TITLE
[BugFix] `openbb-platform-api`: Handle Parmeter Labels Where Platform Hijacks 'title' Annotation

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -225,10 +225,6 @@ def set_parameter_options(p: dict, p_schema: dict, providers: list[str]) -> dict
 
     if is_provider_specific:
         p["available_providers"] = list(available_providers)
-
-    if (title := p_schema.get("title", "")) and title not in providers:
-        p["label"] = title
-
     return p
 
 
@@ -295,6 +291,14 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
     p["value"] = p_schema.get("default", None)
     p = set_parameter_options(p, p_schema, providers)
     p = set_parameter_type(p, p_schema)
+
+    if title := p_schema.get("title", ""):
+        p["label"] = (
+            p.get("parameter_name", "").replace("_", " ").title()
+            if ("," in title and title.replace(",", "").islower())
+            or title.lower() in providers
+            else title
+        )
 
     if _widget_config := p_schema.get("x-widget_config", {}):
         p.update(_widget_config)


### PR DESCRIPTION
1. **Why**?:

    - This fixes widget parameter placeholder labels where the Platform is using "title" as a list of providers for that function.


2. **What**?:

Before:

![image](https://github.com/user-attachments/assets/ebcd7db6-1f29-45e1-a384-c46e59fe6386)

After:

<img width="448" alt="Screenshot 2025-02-10 at 3 54 50 PM" src="https://github.com/user-attachments/assets/aedec168-a598-4687-a09e-3468464177d4" />
<img width="517" alt="Screenshot 2025-02-10 at 3 53 47 PM" src="https://github.com/user-attachments/assets/92b124dd-f490-45f7-b1df-aa29b617b663" />
