### PR TITLE
[Feature] `openbb-sec` & `openbb-regulators`: Add New Path: `regulators.sec.filing_headers`

### DIFF
--- a/openbb_platform/extensions/regulators/integration/test_regulators_api.py
+++ b/openbb_platform/extensions/regulators/integration/test_regulators_api.py
@@ -179,3 +179,27 @@ def test_regulators_cftc_cot(params, headers):
     result = requests.get(url, headers=headers, timeout=10)
     assert isinstance(result, requests.Response)
     assert result.status_code == 200
+
+
+@parametrize(
+    "params",
+    [
+        (
+            {
+                "url": "https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/",
+                "provider": "sec",
+                "use_cache": True,
+            }
+        ),
+    ],
+)
+@pytest.mark.integration
+def test_regulators_sec_filing_headers(params, headers):
+    """Test the SEC Filing headers endpoint."""
+    params = {p: v for p, v in params.items() if v}
+
+    query_str = get_querystring(params, [])
+    url = f"http://0.0.0.0:8000/api/v1/regulators/sec/filing_headers?{query_str}"
+    result = requests.get(url, headers=headers, timeout=10)
+    assert isinstance(result, requests.Response)
+    assert result.status_code == 200

--- a/openbb_platform/extensions/regulators/integration/test_regulators_python.py
+++ b/openbb_platform/extensions/regulators/integration/test_regulators_python.py
@@ -161,3 +161,27 @@ def test_regulators_cftc_cot(params, obb):
     assert result
     assert isinstance(result, OBBject)
     assert len(result.results) > 0
+
+
+@parametrize(
+    "params",
+    [
+        (
+            {
+                "url": "https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/",
+                "provider": "sec",
+                "use_cache": True,
+            }
+        ),
+    ],
+)
+@pytest.mark.integration
+def test_regulators_sec_filing_headers(params, obb):
+    """Test the SEC Filing Headers endpoint."""
+    from openbb_sec.models.sec_filing import SecFilingData
+
+    result = obb.regulators.sec.filing_headers(**params)
+    assert result
+    assert isinstance(result, OBBject)
+    assert isinstance(result.results, SecFilingData)
+    assert hasattr(result.results, "cover_page")

--- a/openbb_platform/extensions/regulators/openbb_regulators/sec/sec_router.py
+++ b/openbb_platform/extensions/regulators/openbb_regulators/sec/sec_router.py
@@ -16,6 +16,38 @@ router = Router(prefix="/sec")
 
 
 @router.command(
+    model="SecFiling",
+    examples=[
+        APIEx(
+            parameters={
+                "url": "https://www.sec.gov/Archives/edgar/data/317540/000119312524076556/d645509ddef14a.htm",
+                "provider": "sec",
+            }
+        )
+    ],
+    openapi_extra={
+        "widget_config": {
+            "description": "Get a list of all the documents associated with a filing, and their direct URLs.",
+            "gridData": {
+                "w": 30,
+                "h": 10,
+            },
+            "staleTime": 86400000,
+            "refetchInterval": 86400000,
+        }
+    },
+)
+async def filing_headers(
+    cc: CommandContext,
+    provider_choices: ProviderChoices,
+    standard_params: StandardParams,
+    extra_params: ExtraParams,
+) -> OBBject:
+    """Download the index headers, and cover page if available, for any SEC filing."""
+    return await OBBject.from_query(Query(**locals()))
+
+
+@router.command(
     model="CikMap",
     examples=[APIEx(parameters={"symbol": "MSFT", "provider": "sec"})],
 )

--- a/openbb_platform/openbb/assets/reference.json
+++ b/openbb_platform/openbb/assets/reference.json
@@ -41463,6 +41463,182 @@
             },
             "model": "CompanyNews"
         },
+        "/regulators/sec/filing_headers": {
+            "deprecated": {
+                "flag": null,
+                "message": null
+            },
+            "description": "Download the index headers, and cover page if available, for any SEC filing.",
+            "examples": "\nExamples\n--------\n\n```python\nfrom openbb import obb\nobb.regulators.sec.filing_headers(url=https://www.sec.gov/Archives/edgar/data/317540/000119312524076556/d645509ddef14a.htm, provider='sec')\n```\n\n",
+            "parameters": {
+                "standard": [],
+                "sec": [
+                    {
+                        "name": "url",
+                        "type": "str",
+                        "description": "URL for the SEC filing. The specific URL is not directly used or downloaded, but is used to generate the base URL for the filing. e.g. https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/coke-20240731.htm and https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/ are both valid URLs for the same filing.",
+                        "default": "",
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "use_cache",
+                        "type": "bool",
+                        "description": "Use cache for the index headers and cover page. Default is True.",
+                        "default": true,
+                        "optional": true,
+                        "choices": null
+                    }
+                ]
+            },
+            "returns": {
+                "OBBject": [
+                    {
+                        "name": "results",
+                        "type": "List[SecFiling]",
+                        "description": "Serializable results."
+                    },
+                    {
+                        "name": "provider",
+                        "type": "Optional[Literal['sec']]",
+                        "description": "Provider name."
+                    },
+                    {
+                        "name": "warnings",
+                        "type": "Optional[List[Warning_]]",
+                        "description": "List of warnings."
+                    },
+                    {
+                        "name": "chart",
+                        "type": "Optional[Chart]",
+                        "description": "Chart object."
+                    },
+                    {
+                        "name": "extra",
+                        "type": "Dict[str, Any]",
+                        "description": "Extra info."
+                    }
+                ]
+            },
+            "data": {
+                "standard": [],
+                "sec": [
+                    {
+                        "name": "base_url",
+                        "type": "str",
+                        "description": "Base URL of the filing.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "name",
+                        "type": "str",
+                        "description": "Name of the entity filing.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "cik",
+                        "type": "str",
+                        "description": "Central Index Key.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "trading_symbols",
+                        "type": "list",
+                        "description": "Trading symbols, if available.",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "sic",
+                        "type": "str",
+                        "description": "Standard Industrial Classification.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "sic_organization_name",
+                        "type": "str",
+                        "description": "SIC Organization Name.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "filing_date",
+                        "type": "date",
+                        "description": "Filing date.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "period_ending",
+                        "type": "date",
+                        "description": "Date of the ending period for the filing, if available.",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "fiscal_year_end",
+                        "type": "str",
+                        "description": "Fiscal year end of the entity, if available. Format: MM-DD",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "document_type",
+                        "type": "str",
+                        "description": "Specific SEC filing type.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "has_cover_page",
+                        "type": "bool",
+                        "description": "True if the filing has a cover page.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    },
+                    {
+                        "name": "description",
+                        "type": "str",
+                        "description": "Description of attached content, mostly applicable to 8-K filings.",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "cover_page",
+                        "type": "dict",
+                        "description": "Cover page information, if available.",
+                        "default": null,
+                        "optional": true,
+                        "choices": null
+                    },
+                    {
+                        "name": "document_urls",
+                        "type": "list",
+                        "description": "List of files associated with the filing.",
+                        "default": "",
+                        "optional": false,
+                        "choices": null
+                    }
+                ]
+            },
+            "model": "SecFiling"
+        },
         "/regulators/sec/cik_map": {
             "deprecated": {
                 "flag": null,

--- a/openbb_platform/openbb/package/regulators_sec.py
+++ b/openbb_platform/openbb/package/regulators_sec.py
@@ -13,6 +13,7 @@ from typing_extensions import Annotated
 class ROUTER_regulators_sec(Container):
     """/regulators/sec
     cik_map
+    filing_headers
     institutions_search
     rss_litigation
     schema_files
@@ -85,6 +86,95 @@ class ROUTER_regulators_sec(Container):
                 standard_params={
                     "symbol": symbol,
                 },
+                extra_params=kwargs,
+            )
+        )
+
+    @exception_handler
+    @validate
+    def filing_headers(
+        self,
+        provider: Annotated[
+            Optional[Literal["sec"]],
+            OpenBBField(
+                description="The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: sec."
+            ),
+        ] = None,
+        **kwargs
+    ) -> OBBject:
+        """Download the index headers, and cover page if available, for any SEC filing.
+
+        Parameters
+        ----------
+        provider : Optional[Literal['sec']]
+            The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: sec.
+        url : str
+            URL for the SEC filing. The specific URL is not directly used or downloaded, but is used to generate the base URL for the filing. e.g. https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/coke-20240731.htm and https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/ are both valid URLs for the same filing. (provider: sec)
+        use_cache : bool
+            Use cache for the index headers and cover page. Default is True. (provider: sec)
+
+        Returns
+        -------
+        OBBject
+            results : SecFiling
+                Serializable results.
+            provider : Optional[Literal['sec']]
+                Provider name.
+            warnings : Optional[List[Warning_]]
+                List of warnings.
+            chart : Optional[Chart]
+                Chart object.
+            extra : Dict[str, Any]
+                Extra info.
+
+        SecFiling
+        ---------
+        base_url : Optional[str]
+            Base URL of the filing. (provider: sec)
+        name : Optional[str]
+            Name of the entity filing. (provider: sec)
+        cik : Optional[str]
+            Central Index Key. (provider: sec)
+        trading_symbols : Optional[list]
+            Trading symbols, if available. (provider: sec)
+        sic : Optional[str]
+            Standard Industrial Classification. (provider: sec)
+        sic_organization_name : Optional[str]
+            SIC Organization Name. (provider: sec)
+        filing_date : Optional[date]
+            Filing date. (provider: sec)
+        period_ending : Optional[date]
+            Date of the ending period for the filing, if available. (provider: sec)
+        fiscal_year_end : Optional[str]
+            Fiscal year end of the entity, if available. Format: MM-DD (provider: sec)
+        document_type : Optional[str]
+            Specific SEC filing type. (provider: sec)
+        has_cover_page : Optional[bool]
+            True if the filing has a cover page. (provider: sec)
+        description : Optional[str]
+            Description of attached content, mostly applicable to 8-K filings. (provider: sec)
+        cover_page : Optional[dict]
+            Cover page information, if available. (provider: sec)
+        document_urls : Optional[list]
+            List of files associated with the filing. (provider: sec)
+
+        Examples
+        --------
+        >>> from openbb import obb
+        >>> obb.regulators.sec.filing_headers(url='https://www.sec.gov/Archives/edgar/data/317540/000119312524076556/d645509ddef14a.htm', provider='sec')
+        """  # noqa: E501
+
+        return self._run(
+            "/regulators/sec/filing_headers",
+            **filter_inputs(
+                provider_choices={
+                    "provider": self._get_provider(
+                        provider,
+                        "regulators.sec.filing_headers",
+                        ("sec",),
+                    )
+                },
+                standard_params={},
                 extra_params=kwargs,
             )
         )

--- a/openbb_platform/providers/sec/openbb_sec/__init__.py
+++ b/openbb_platform/providers/sec/openbb_sec/__init__.py
@@ -16,6 +16,7 @@ from openbb_sec.models.management_discussion_analysis import (
 )
 from openbb_sec.models.rss_litigation import SecRssLitigationFetcher
 from openbb_sec.models.schema_files import SecSchemaFilesFetcher
+from openbb_sec.models.sec_filing import SecFilingFetcher
 from openbb_sec.models.sic_search import SecSicSearchFetcher
 from openbb_sec.models.symbol_map import SecSymbolMapFetcher
 
@@ -39,6 +40,7 @@ sec_provider = Provider(
         "ManagementDiscussionAnalysis": SecManagementDiscussionAnalysisFetcher,
         "RssLitigation": SecRssLitigationFetcher,
         "SchemaFiles": SecSchemaFilesFetcher,
+        "SecFiling": SecFilingFetcher,
         "SicSearch": SecSicSearchFetcher,
         "SymbolMap": SecSymbolMapFetcher,
     },

--- a/openbb_platform/providers/sec/openbb_sec/models/sec_filing.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/sec_filing.py
@@ -1,0 +1,679 @@
+"""SEC Filing Model."""
+
+# pylint: disable=unused-argument
+
+from datetime import date as dateType
+from typing import Any, Optional, Union
+
+from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.abstract.query_params import QueryParams
+from pydantic import ConfigDict, Field, PrivateAttr, computed_field
+
+
+class SecFilingQueryParams(QueryParams):
+    """SEC Filing Query Parameters."""
+
+    __json_schema_extra__ = {
+        "url": {
+            "x-widget_config": {
+                "label": "Filing URL",
+            }
+        }
+    }
+
+    url: str = Field(
+        default="",
+        description="URL for the SEC filing."
+        + " The specific URL is not directly used or downloaded,"
+        + " but is used to generate the base URL for the filing."
+        + " e.g. https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/coke-20240731.htm"
+        + " and https://www.sec.gov/Archives/edgar/data/317540/000031754024000045/"
+        + " are both valid URLs for the same filing.",
+    )
+    use_cache: bool = Field(
+        default=True,
+        description="Use cache for the index headers and cover page. Default is True.",
+    )
+
+
+class SecFilingData(Data):
+    """SEC Filing Data."""
+
+    # For Workspace, ConfigDict is used to enter the widget configuration at the "$.data" level.
+    # Here, we are using a subset of the data - the document URLs with direct links - to avoid nested data.
+    # This creates column definitions for the target output while preserving the structure of the model.
+    model_config = ConfigDict(
+        json_schema_extra={
+            "x-widget_config": {
+                "dataKey": "results.document_urls",
+                "table": {
+                    "columnsDefs": [
+                        {
+                            "field": "sequence",
+                            "headerName": "Sequence",
+                            "headerTooltip": "The sequence of the document.",
+                            "type": "number",
+                            "pinned": "left",
+                            "maxWidth": 105,
+                        },
+                        {
+                            "field": "type",
+                            "headerName": "Document Type",
+                            "headerTooltip": "The type of document.",
+                            "type": "text",
+                            "maxWidth": 150,
+                        },
+                        {
+                            "field": "filename",
+                            "headerName": "Filename",
+                            "headerTooltip": "The filename of the document.",
+                            "type": "text",
+                            "maxWidth": 250,
+                        },
+                        {
+                            "field": "content_description",
+                            "headerName": "Description",
+                            "headerTooltip": "Description of the document.",
+                            "type": "text",
+                            "minWidth": 600,
+                        },
+                        {
+                            "field": "url",
+                            "headerName": "URL",
+                            "headerTooltip": "The URL of the document.",
+                            "type": "text",
+                            "maxWidth": 75,
+                        },
+                    ],
+                },
+            }
+        }
+    )
+
+    base_url: str = Field(
+        title="Base URL",
+        description="Base URL of the filing.",
+        json_schema_extra={
+            "x-widget_config": {
+                "exclude": True
+            }  # Tells the widget factory to exclude this field. Has no effect on endpoint.
+        },
+    )
+    name: str = Field(
+        title="Entity Name",
+        description="Name of the entity filing.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    cik: str = Field(
+        title="CIK",
+        description="Central Index Key.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    trading_symbols: Optional[list] = Field(
+        default=None,
+        title="Trading Symbols",
+        description="Trading symbols, if available.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    sic: str = Field(
+        title="SIC",
+        description="Standard Industrial Classification.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    sic_organization_name: str = Field(
+        title="SIC Organization",
+        description="SIC Organization Name.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    filing_date: dateType = Field(
+        title="Filing Date",
+        description="Filing date.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    period_ending: Optional[dateType] = Field(
+        default=None,
+        title="Period Ending",
+        description="Date of the ending period for the filing, if available.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    fiscal_year_end: Optional[str] = Field(
+        default=None,
+        title="Fiscal Year End",
+        description="Fiscal year end of the entity, if available. Format: MM-DD",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    document_type: str = Field(
+        title="Document Type",
+        description="Specific SEC filing type.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    has_cover_page: bool = Field(
+        title="Has Cover Page",
+        description="True if the filing has a cover page.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    description: Optional[str] = Field(
+        default=None,
+        title="Content Description",
+        description="Description of attached content, mostly applicable to 8-K filings.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    cover_page: Optional[dict] = Field(
+        default=None,
+        title="Cover Page",
+        description="Cover page information, if available.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+    document_urls: list = Field(
+        title="Document URLs",
+        description="List of files associated with the filing.",
+        json_schema_extra={"x-widget_config": {"exclude": True}},
+    )
+
+
+class SecBaseFiling(Data):  # pylint: disable=too-many-instance-attributes
+    """Base SEC Filing model."""
+
+    _url: str = PrivateAttr(default="")
+    _index_headers_url: str = PrivateAttr(default="")
+    _index_headers_download: str = PrivateAttr(default="")
+    _document_urls: list = PrivateAttr(default=None)
+    _filing_date: str = PrivateAttr(default="")
+    _period_ending: str = PrivateAttr(default="")
+    _document_type: str = PrivateAttr(default="")
+    _name: str = PrivateAttr(default="")
+    _cik: str = PrivateAttr(default="")
+    _sic: str = PrivateAttr(default="")
+    _sic_organization_name: Optional[str] = PrivateAttr(default="")
+    _description: Optional[str] = PrivateAttr(default=None)
+    _cover_page_url: Optional[str] = PrivateAttr(default=None)
+    _fiscal_year_end: str = PrivateAttr(default="")
+    _fiscal_period: str = PrivateAttr(default="")
+    _cover_page: dict = PrivateAttr(default=None)
+    _trading_symbols: list = PrivateAttr(default=None)
+    _use_cache: bool = PrivateAttr(default=True)
+
+    @computed_field(title="Base URL", description="Base URL of the filing.")
+    @property
+    def base_url(self) -> str:
+        """Base URL of the filing."""
+        return self._url
+
+    @computed_field(title="Entity Name", description="Name of the entity filing.")
+    @property
+    def name(self) -> str:
+        """Entity name."""
+        return self._name
+
+    @computed_field(title="CIK", description="Central Index Key.")
+    @property
+    def cik(self) -> str:
+        """Central Index Key."""
+        return self._cik
+
+    @computed_field(
+        title="Trading Symbols", description="Trading symbols, if available."
+    )
+    @property
+    def trading_symbols(self) -> Optional[list]:
+        """Trading symbols, if available."""
+        return self._trading_symbols
+
+    @computed_field(title="SIC", description="Standard Industrial Classification.")
+    @property
+    def sic(self) -> str:
+        """Standard Industrial Classification."""
+        return self._sic
+
+    @computed_field(title="SIC Organization", description="SIC Organization Name.")
+    @property
+    def sic_organization_name(self) -> str:
+        """Standard Industrial Classification Organization Name."""
+        return self._sic_organization_name
+
+    @computed_field(title="Filing Date", description="Filing date.")
+    @property
+    def filing_date(self) -> dateType:
+        """Filing date."""
+        return dateType.fromisoformat(self._filing_date)
+
+    @computed_field(
+        title="Period Ending",
+        description="Date of the ending period for the filing, if available.",
+    )
+    @property
+    def period_ending(self) -> Optional[dateType]:
+        """Date of the ending period for the filing."""
+        if self._period_ending:
+            return dateType.fromisoformat(self._period_ending)
+        return None
+
+    @computed_field(
+        title="Fiscal Year End",
+        description="Fiscal year end of the entity, if available. Format: MM-DD",
+    )
+    @property
+    def fiscal_year_end(self) -> Optional[str]:
+        """Fiscal year end date of the entity."""
+        return self._fiscal_year_end
+
+    @computed_field(title="Document Type", description="Specific SEC filing type.")
+    @property
+    def document_type(self) -> str:
+        """Document type."""
+        return self._document_type
+
+    @computed_field(
+        title="Has Cover Page", description="True if the filing has a cover page."
+    )
+    @property
+    def has_cover_page(self) -> bool:
+        """True if the filing has a cover page."""
+        return bool(self._cover_page_url)
+
+    @computed_field(
+        title="Cover Page", description="Cover page information, if available."
+    )
+    @property
+    def cover_page(self) -> Optional[dict]:
+        """Cover page information, if available."""
+        return self._cover_page
+
+    @computed_field(
+        title="Content Description",
+        description="Description of attached content, mostly applicable to 8-K filings.",
+    )
+    @property
+    def description(self) -> Optional[str]:
+        """Document description, if available."""
+        return self._description
+
+    @computed_field(
+        title="Document URLs", description="List of files associated with the filing."
+    )
+    @property
+    def document_urls(self) -> list:
+        """List of document URLs."""
+        return self._document_urls
+
+    def __init__(self, url: str, use_cache: bool = True):
+        """Initialize the Filing class."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_core.provider.utils.helpers import run_async
+        from openbb_sec.utils.helpers import cik_map
+
+        super().__init__()
+
+        if not url:
+            raise ValueError("Please enter a URL.")
+
+        if "/data/" not in url:
+            raise ValueError("Invalid SEC URL supplied, must be a filing URL.")
+
+        check_val: str = url.split("/data/")[1].split("/")[1]
+
+        if len(check_val) != 18:
+            raise ValueError("Invalid SEC URL supplied, must be a filing URL.")
+
+        new_url = url.split(check_val)[0] + check_val + "/"
+
+        cik_check = new_url.split("/")[-3]
+        new_url = new_url.replace(f"/{cik_check}/", f"/{cik_check.lstrip('0')}/")
+        self._url = new_url
+        self._use_cache = use_cache
+        index_headers = (
+            check_val[:-8]
+            + "-"
+            + check_val[-8:-6]
+            + "-"
+            + check_val[-6:]
+            + "-index-headers.htm"
+        )
+        self._index_headers_url = self._url + index_headers
+        self._download_index_headers()
+
+        if self._document_urls:
+            for doc in self._document_urls:
+                if doc.get("url", "").endswith("R1.htm"):
+                    self._cover_page_url = doc.get("url")
+                    break
+
+        if self.has_cover_page and not self._cover_page:
+            self._download_cover_page()
+
+        if not self._trading_symbols:
+            symbol = run_async(cik_map, self._cik)
+            if symbol:
+                self._trading_symbols = [symbol]
+
+    @staticmethod
+    async def _adownload_file(url, use_cache: bool = True):
+        """Download a file asynchronously from a SEC URL."""
+        # pylint: disable=import-outside-toplevel
+        from aiohttp_client_cache import SQLiteBackend
+        from aiohttp_client_cache.session import CachedSession
+        from openbb_core.app.utils import get_user_cache_directory
+        from openbb_core.provider.utils.helpers import amake_request
+        from openbb_sec.utils.definitions import SEC_HEADERS
+        from openbb_sec.utils.helpers import sec_callback
+
+        response: Union[dict, list, str, None] = None
+        if use_cache is True:
+            cache_dir = f"{get_user_cache_directory()}/http/sec_filings"
+            async with CachedSession(cache=SQLiteBackend(cache_dir)) as session:
+                try:
+                    await session.delete_expired_responses()
+                    response = await amake_request(
+                        url,
+                        headers=SEC_HEADERS,
+                        session=session,
+                        response_callback=sec_callback,
+                        raise_for_status=True,
+                    )  # type: ignore
+                finally:
+                    await session.close()
+        else:
+            response = await amake_request(
+                url,
+                headers=SEC_HEADERS,
+                response_callback=sec_callback,
+                raise_for_status=True,
+            )  # type: ignore
+
+        return response
+
+    @staticmethod
+    def download_file(url, read_html_table: bool = False, use_cache: bool = True):
+        """Download a file from a SEC URL."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_core.provider.utils.helpers import run_async  # noqa
+        from warnings import warn
+
+        try:
+            response = run_async(SecBaseFiling._adownload_file, url, use_cache)
+
+            if read_html_table is True:
+                if not url.endswith(".htm") and not url.endswith(".html"):
+                    warn(f"File is not a HTML file: {url}")
+                    return response
+
+                return SecBaseFiling.try_html_table(response)
+
+            return response
+
+        except Exception as e:
+            raise RuntimeError(f"Failed to download file: {e} -> {e.args}") from e
+
+    @staticmethod
+    def try_html_table(text: str, **kwargs) -> list:
+        """Attempt to parse tables from a HTML string. All keyword arguments passed to `pandas.read_html`"""
+        # pylint: disable=import-outside-toplevel
+        from io import StringIO  # noqa
+        from pandas import read_html
+
+        try:
+            return read_html(StringIO(text), **kwargs)
+        except Exception as e:
+            raise RuntimeError(f"Failed to parse table: {e}") from e
+
+    def _download_index_headers(
+        self,
+    ):  # pylint: disable=too-many-branches, too-many-statements, too-many-locals
+        """Download the index headers table."""
+        # pylint: disable=import-outside-toplevel
+        import re  # noqa
+        from bs4 import BeautifulSoup
+
+        try:
+            if not self._index_headers_download:
+                response = self.download_file(
+                    self._index_headers_url, False, self._use_cache
+                )
+                self._index_headers_download = response
+            else:
+                response = self._index_headers_download
+
+            soup = BeautifulSoup(response, "html.parser")
+            text = soup.find("pre").text
+
+            def document_to_dict(doc):
+                """Convert the document section to a dictionary."""
+                doc_dict: dict = {}
+                doc_dict["type"] = re.search(r"<TYPE>(.*?)\n", doc).group(1).strip()
+                doc_dict["sequence"] = (
+                    re.search(r"<SEQUENCE>(.*?)\n", doc).group(1).strip()
+                )
+                doc_dict["filename"] = (
+                    re.search(r"<FILENAME>(.*?)\n", doc).group(1).strip()
+                )
+                description_match = re.search(r"<DESCRIPTION>(.*?)\n", doc)
+
+                if description_match:
+                    doc_dict["description"] = description_match.group(1).strip()
+
+                url = self.base_url + doc_dict["filename"]
+                doc_dict["url"] = url
+
+                return doc_dict
+
+            # Isolate each document by tag
+            documents = re.findall(r"<DOCUMENT>.*?</DOCUMENT>", text, re.DOTALL)
+            # Convert each document to a dictionary
+            document_dicts = [document_to_dict(doc) for doc in documents]
+
+            if document_dicts:
+                self._document_urls = document_dicts
+
+            lines = text.split("\n")
+            n_items = 0
+
+            for line in lines:
+
+                if ":" not in line:
+                    continue
+
+                value = line.split(":")[1].strip()
+
+                if n_items == 9:
+                    break
+
+                if "CONFORMED PERIOD OF REPORT" in line:
+                    as_of_date = value
+                    self._period_ending = (
+                        as_of_date[:4] + "-" + as_of_date[4:6] + "-" + as_of_date[6:]
+                    )
+                elif "FILED AS OF DATE" in line:
+                    filing_date = value
+                    self._filing_date = (
+                        filing_date[:4] + "-" + filing_date[4:6] + "-" + filing_date[6:]
+                    )
+                    n_items += 1
+                elif "COMPANY CONFORMED NAME" in line:
+                    self._name = value
+                    n_items += 1
+                elif "CONFORMED SUBMISSION TYPE" in line:
+                    self._document_type = value
+                    n_items += 1
+                elif "CENTRAL INDEX KEY" in line:
+                    self._cik = value
+                    n_items += 1
+                elif "STANDARD INDUSTRIAL CLASSIFICATION" in line:
+                    self._sic = value
+                    n_items += 1
+                elif "ORGANIZATION NAME" in line:
+                    self._sic_organization_name = value
+                    n_items += 1
+                elif "FISCAL YEAR END" in line:
+                    fy = value
+                    self._fiscal_year_end = fy[:2] + "-" + fy[2:]
+                    n_items += 1
+                # There might be two lines of ITEM INFORMATION
+                elif "ITEM INFORMATION" in line:
+                    info = value
+                    self._description = (
+                        self._description + "; " + info if self._description else info
+                    )
+                    n_items += 1
+                continue
+
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download and read the index headers table: {e}"
+            ) from e
+
+    @staticmethod
+    def _multiplier_map(string) -> int:  # pylint: disable=too-many-return-statements
+        """Map a string to a multiplier."""
+        if string.lower() == "millions":
+            return 1000000
+        if string.lower() == "hundreds of thousands":
+            return 100000
+        if string.lower() == "tens of thousands":
+            return 10000
+        if string.lower() == "thousands":
+            return 1000
+        if string.lower() == "hundreds":
+            return 100
+        if string.lower() == "tens":
+            return 10
+        return 1
+
+    def _download_cover_page(
+        self,
+    ):  # pylint: disable=too-many-branches, too-many-statements, too-many-locals
+        """Download the cover page table."""
+        # pylint: disable=import-outside-toplevel
+        from pandas import MultiIndex, to_datetime
+
+        try:
+            response = self.download_file(self._cover_page_url, True, self._use_cache)
+            if not response:
+                raise RuntimeError("Failed to download cover page table")
+            df = response[0]
+            if isinstance(df.columns, MultiIndex):
+                df = df.droplevel(0, axis=1)
+
+            if df.empty or len(df) < 1:
+                raise RuntimeError("Failed to read cover page table")
+
+            fiscal_year = df[df.iloc[:, 0] == "Document Fiscal Year Focus"]
+
+            if not fiscal_year.empty:
+                fiscal_year = fiscal_year.iloc[:, 1].values[0]
+            elif fiscal_year.empty:
+                fiscal_year = None
+
+            if fiscal_year:
+                self._fiscal_year = fiscal_year
+
+            fiscal_period = df[df.iloc[:, 0] == "Document Fiscal Period Focus"]
+
+            if not fiscal_period.empty:
+                fiscal_period = fiscal_period.iloc[:, 1].values[0]
+            elif fiscal_period.empty:
+                fiscal_period = None
+
+            if fiscal_period:
+                self._fiscal_period = fiscal_period
+
+            title = (
+                df.columns[0][0]
+                if isinstance(df.columns, MultiIndex)
+                else df.columns[0]
+            )
+
+            if title and "- shares" in title:
+                shares_multiplier = title.split(" shares in ")[-1]
+                multiplier = self._multiplier_map(shares_multiplier)
+                shares_outstanding = (
+                    df[df.iloc[:, 0].str.contains("Shares Outstanding")]
+                    .iloc[:, 2]
+                    .values[0]
+                )
+                as_of_date = (
+                    df.columns[2][1]
+                    if isinstance(df.columns, MultiIndex)
+                    else df.columns[2]
+                )
+
+                if as_of_date and shares_outstanding:
+                    self._shares_outstanding = {
+                        to_datetime(as_of_date).strftime("%Y-%m-%d"): int(
+                            shares_outstanding * multiplier
+                        )
+                    }
+
+            if not df.empty:
+
+                trading_symbols = (
+                    df[df.iloc[:, 0].astype(str).str.lower() == "trading symbol"]
+                    .iloc[:, 1]
+                    .unique()
+                    .tolist()
+                )
+                if trading_symbols:
+                    self._trading_symbols = sorted(trading_symbols)
+
+                df.columns = [d[1] if isinstance(d, tuple) else d for d in df.columns]
+                df = df.iloc[:, :2].dropna(how="any")
+                df.columns = ["key", "value"]
+                output = df.set_index("key").to_dict()["value"]
+
+                if not output.get("SIC") and self._sic:
+                    output["SIC"] = self._sic
+                    output["SIC Organization Name"] = self.sic_organization_name
+
+                self._cover_page = output
+
+        except IndexError:
+            pass
+
+        except Exception as e:
+            raise RuntimeError(
+                f"Failed to download and read the cover page table: {e}"
+            ) from e
+
+    def __repr__(self):
+        """Return the string representation of the class."""
+        repr_str = "SEC Filing(\n"
+
+        for k, v in self.model_computed_fields.items():
+            if not v:
+                continue
+            repr_str += f"  {k} : {v.return_type.__name__} - {v.description}\n"
+
+        repr_str += ")"
+
+        return repr_str
+
+
+class SecFilingFetcher(Fetcher[SecFilingQueryParams, SecFilingData]):
+    """SEC Filing Fetcher."""
+
+    @staticmethod
+    def transform_query(params: dict[str, Any]) -> SecFilingQueryParams:
+        """Transform the query parameters."""
+        return SecFilingQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: SecFilingQueryParams,
+        credentials: Optional[dict[str, str]],
+        **kwargs: Any,
+    ) -> dict:
+        """Extract the raw data from the SEC site."""
+        try:
+            data = SecBaseFiling(query.url, query.use_cache)
+        except Exception as e:  # pylint: disable=broad-except
+            raise OpenBBError(e) from e
+
+        return data.model_dump(exclude_none=True)
+
+    @staticmethod
+    def transform_data(
+        query: SecFilingQueryParams, data: dict, **kwargs: Any
+    ) -> SecFilingData:
+        """Transform the raw data into a structured format."""
+        return SecFilingData.model_validate(data)

--- a/openbb_platform/providers/sec/tests/record/http/test_sec_fetchers/test_sec_filing_fetcher_urllib3_v1.yaml
+++ b/openbb_platform/providers/sec/tests/record/http/test_sec_fetchers/test_sec_filing_fetcher_urllib3_v1.yaml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - www.sec.gov
+    method: GET
+    uri: https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/0001552781-24-000634-index-headers.htm
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7WY33OiSBDHn+GvmNuHfRsFRaOGo2qE0XDLDw9wL9mrqxRJSMLGqIWmzr2//roB
+        BQXdvTW3D1mZ6enpT0/3dxT1KrAtTb3izNDUwAwsrvlcJ9wYM4/4b3ev8WoVL+ZEkiS502ld9GTa
+        Uig8dduK2swWiOovlIoqrKPoh3tanXXj+SFprJ5eZ2RAWlJLkVtyV1SZrvNJwBydU4MFPDBtrm1n
+        ZaXdbncyG983XYc6U3t4xL2oBjcTrvXoJ1GdTIeWqVPD1ac2dwKqu1Mn0HC7CfdM19ju0BZVM+C2
+        r3UaUmv7ud+QZFEdmZbpjNOYtCJafKTuiJZmqX7FnHHZCCYhRlHVXXvCnBu0YumjM3I9mxvUYQCp
+        uzojumvhH5g0PyGVJEFQCrAw4B07YOubOrjuSaLqemPmmF9YkCYCXUgKscP522N4v35L4vkTEHj+
+        NkedntRt9ZQu5M8P8rBNR3e9ieulPjSDY6y+zix6w5lHuWNocqsN8M2D0HPcz8yach+fgYMW6WZ6
+        oOEBIHhxRDKVWi35Ih22t8OQo05Hbvf7sMmh1+HUNx04aMoMw4P/NYzc4zyQNdfhpEjYxGJfGOYs
+        uNFYYDEnYDmkNoZPX8yJ1pbaeLqTK1ipKZJCuxdd2oLzgX1r9rGZab3jts0Df81tSTRLPSJSiiNZ
+        5w1d4waeJh7XPs7Wl2i2rd6PT+vLuoKn8fwh2jSe1/sdtV2e7XJscW0z4tKafkQfBy2560iSnetA
+        EGp7clfzxJ8ObTNbgoUzELBysj4lW1KS9in4gliKlVnLEndEPA61C/O77sWGJWZqmJY0LDWiZZhA
+        O0Rk8UiMOInu14tkRRYJ0aNkHcZz4j4+xvdRsrokfAazKG5l00vClstFPF+/RvM1zhyuGxB98bqM
+        5qsQzL8RliTh/ClC61WdeV2Qo3gezu/jcEb8dbjO14bzB8I3z/FdvF6JWDAGYT5i4znAot0x4XM+
+        lWlPeTJd6Q1EUch7GJezgSAKu4EitagisFjY0yJ4hLPwmAVBG/yafOI3aFNSJ0GAqncM5hloMoVu
+        McFat1C0RqaeUw75Z+6xMffJnyhgf8GysoRlm5Pin1CRM0EAPSsqTBAKTUtDgDRADvZEDc1A1yDF
+        qbARFDYCwobjqbaJQiY7JJOdAZpCMvKiTKsSfMMNCKKGldhvK4Tdr/NBTO4uoELicDvLLiItVE4U
+        tmpDcjlIjyITGCKDbZ3GwBGAyGDMW53JeXFojE8gNvg50xuh2CQVPJjZkzxRQD36HwNA4Wjui046
+        VpawdACzjA+Y5kyofp9y0Bock9MRzDBWBo5ELUW56Ny+LGjvBXUuc8GvM39qSJ6T6PHXD4dmHzRj
+        cf+Wtq9MKHmMZ9GAHBqpzVBT7xIti70S6NHI+TXt9xtyJfrWseijTb9P5e+HX9iV4m8dxl9Y/SzA
+        2GOTK1OvALQrAC+L29niadH4unzKXHJf98wJttmhoypVaXGJp73jKc2fcRSyJDd8/aoCo9TA0O21
+        0disHuqAroeeRcAbt1na6EfJ9jyV6JQS3Z7NmYQGH1UIO6cIbx+ix8bmdXaUEjyajpnK8I+Rbj2W
+        aDt1tFu7M4ktNqwQd08Sz8K7k8TgkVs/Cps7K8F2a2FzuzNh4UtfBfbiJOwyiU7CgkcfNmT/5YBz
+        nyXmi1rm3O5nma9tqwLbr8B6hWAe8JkGZwOSFXG+xxE471BM+zse7ywF5dc6r0LIUoVi9zXv1ouW
+        i2Td2MxWm/Ogal2WLzxpB1lr+p7HJldvbP958Xfj6+o8xtxJmaq4x/PJd+Wo3t1JlrH71ZkohZ8y
+        TXGrF/PvClS9/kbxDL5R+2+vr2Hy7Zh2/DjXZjVrVlyWEZVSGZbN8NfqDrVU1d9x5bE/CJAeejtD
+        h37zXaeauOodY0fr0IrnLysousX8vKzt+yozFtfLvs3P0sG38ypc9U6pfa2wuUtmjX/i5XmsJ12X
+        0Ytb5uSSd+2P3smfGrdQpO/TInVey+y92p8nqWV9o/yIw12v1Bl/J43NwxdPahNfSanN9P2U2kxf
+        Fov/AnSFX/M0FgAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1551'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Feb 2025 16:56:19 GMT
+      Last-Modified:
+      - Mon, 16 Dec 2024 19:34:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-id-2:
+      - 36KuPmr3UWIQ8x31DyNQbm1OVx9hB40N0dw451XQLYA4IrIsvW2q02kCDDjAMIZPKkuwZB1/wS0=
+      x-amz-meta-mode:
+      - '33188'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - 5S9961E5DEA95VYH
+      x-amz-server-side-encryption:
+      - AES256
+      x-amz-version-id:
+      - Em.xpqQlD0bTs0G3LJTAM3AKc2Z7jmV.
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - www.sec.gov
+    method: GET
+    uri: https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/R1.htm
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xaa3PaRhT9XH7FHbWN7YwBSQb8EpohQskwsYEa0ibtdDyLtIBioWVWC5hm8t97
+        Vw/b2EQmnXQGJfABYe25y96z5x7tLjaaHevdpd3umwWj/6Frm+8vLwpGz/7tnd22bPO0YLxuXdjt
+        xqVtXmmlsZgUjKbds65a3X6r0zZbTbtxBu9fXV1A2hH2Y7+X3SHYlxdKXLwIT/jUNMrxtWD4XnAD
+        nPp1JRRLn4ZjSoUCYjmldUXQW1F2wlCBMafDuuIFjj9zaZnTKeOiJFuwh9Dh3lQ8DPlI5iS+q0DI
+        nbrSG7NF6SOiyy+hyaDNBFzRCZtT6I+9ECw2mdBAwMuyUY7jzOxezcJP8Ws4CxzhsQAEG4182kZc
+        zxtgTiPYpwfwKcV5Q/y7FNw3l6JsS64XTn2yrNf3AhbQvQcRWei9gc+cm73zFPsZqB9S+ASZQdE3
+        nMPnu6i7ZAtGOZmdAXOXktIpCSAKrytJ/BnI+HPFnB+V9EqpgsEIMg1BBj4FxydhWFfiiVFgwLhL
+        eV1RFXCo7yPSwQHVFV0Bz8V5dCeV6oleramntcppVVflNAou38ZpV8LHWCZDg7qiKcDZIv1sGq43
+        T4e38FwxPgNdVae3ODojFJwFI9PCyeXGgKPSkjtGGaOk8Mar3zOO+zOb1CmBdnSIXemVFXA5Hhq/
+        zzIar5v+PcWhJqOJEy8OmBBscgbRmGBOfG+EIxdsit9F0jCSyvpeWGdz5rn76gEGMdS659wk2g3x
+        rXG1DwLlegh7Lh1i5LVLvesmc2ZSvH0U6t4hLLzAZQvAHsy0BWSTUSYyHXdl4FLWinlSfGvEcxlP
+        aSHBPUmbbVHaDczMldm99sloNe+7JpBtGYkPCVbNZqlv44x3KfeYawduk4gvTX2MAQSBRGWQcSf/
+        WP+5E4Qd4BNl+dpDE55NBpSvEhK3gmyGuD2DClXViqqua8f500ac5xUdeeh6JBBtMqFrmbiHgMRk
+        sGF1rAZYnQv5lldZWFgLnPitwKW3b+lyLSMJBiIQICpTIfjStaPKhoWyfRLpk9uWixl7Q88hcgWT
+        UTWIhVXw8zVUPSmqNf2kUqvmVTOtwGEclzNRwj2B7mmxGUpkaTF3fU2tRBxCFAOMQxIHMjDLge28
+        iqnhupyGYXK58AKqrSUoARymH0BCoRNksYKtBcCXxRxStJhPoOuTf0heVZVkbuHHDu+zRZBNlMRJ
+        CUlkBkkN4aOTb0jK1uonKpgO73I2x53e+hq7Y+auulJ4Bj1vGjmXS5eFgvh/etMves8dLzEUEPuc
+        3xypR9pR/iQjS6LBKXlKRVQssum5zPcrauUgf5K4QAv0u2Pchq97WEetEDU//3iuHdeKuqZr+Zv+
+        P7gnBA3kkc0sSJYj4SoTCQRWMd9mI7hNeugxhHnCC0aX6IXcI/4qD/ftkAK+v91wl9P4+M6h0TEI
+        7v0p7wyHj8sDcUXnARBiJETQ708bj2hpheGM8s3JifH/A0fbJJ340WlPKB9hjbzhbCHGSBqOf/0O
+        MUVCDIUE+22IGW8JMbOwOCJkeh2tr6QWLNlzZ9gTzLlp3Hph/YZdS2nJTRHeUkt6tUv478Sf0Uv6
+        9LEUQyHCHsIvEg6Ihyggg7oXP2s19Tx/oupRZ4bPn6WmD/ryJ45VNqJbwIag6fuDA0jBWccvEX/R
+        FugLHObOm/qcuFhGveVkwB49spImiNsyaHm74VnUNkrDvnXGJBjRp4dzKQJSyHOHc+0PvQ1PDXLl
+        L8iDVjo5rraZoGFzRnVVr60zlwj0K0QwQJw8u67tTOVZU4l5i0zlEXc/qJlsmvk2imJnJxvYiVo6
+        rqrP2UkE2tnJV9tJzNvOTh7YiZVfVez8ZKPliaY/XJ4cr1+eIOiRnxzv/GSD5Ynk7amfbPiD/Hfo
+        Jzn8V4SdnXzV8mTVTk7XL0+e2snpzk42WJ6st5PTH9ZOTjf8QXQbVbHzk//iJ9o6Q0EgqCUspOqj
+        wtDgrxj/985edvby9fbyKr+q2GJ7+RcAAP//7J1Lc9s2EIDv+RWYXtJORb1IuY6a8YwfScbjSeLG
+        PbRHiIQszFAkS4CWlV/fXYCSSQqKoSSTSCJ8sCUKz+Xi8y6w4u4TXoJ+ZTfF75vNFShUN1f8vuOJ
+        BU9Qbhs8Adm1lCd+3/HkuHky6A6ru7O+0VpRhRo8GTieWOymDE27s75l8NcR8uQAw94cTnbAiV/3
+        fvyhCSf+5m6KP3Q4eRYnZrm1FSWWM99HhXAosfJ0/GoYiu+bPR2/GYbi+w4lFp6ObwpD8S2/lXCE
+        ODnA72M4nOyEk1Ft42QLTkYbGycOJzY4GRk3TlqME3fOc9w8GXRPap7OyLxxcrJhsY8cTyw2Tk5M
+        Bzv+AX6l/TvxxHLm+6gUDid2UW0182RL0P1gwzxxUbJWUW1G86S1UbK2M99HpXA4sfJ2Xo2exYkq
+        5HDyFd7OK+OxTotx4ryd4+aJ39iMNQbd+4bNWBd0b3OuY5JbW1niAu6PGyX97mnV0wm2RLCdNj2d
+        wEWw2ZgmpyZPJ2htBFvgItiOnCeDbr/Gky0RbP0NnrgINpudk76RJ62NYLOd+T4qhcOJladTOycO
+        ArOns3FOHAQOJxaejklubUXJAT7C2qFkJ5TUnnwyMoac+JtPPhm5kBMblJjk1lKU2M58HxXix6Gk
+        pzLmwItKEptmjp0XZVqdRh6djEaRyqPTzKuD70upFHL2iU2vqKS/bGldpeDZlkpF9Z2fVSY14xFT
+        ci9bC9M4zcdkMeMSG7O+B9gO3AMU6T9r6a2VA3vUeX3KbjET0XoG5cTHZKiS/LyA0Vj3+5SZSd9/
+        dVM9csWmPOH4ZGA1GJXuJzu7SNOY0YRMQRRQmkoCFWQOC3sxYwlcYTrJVZgmEp+TSlF2gmQ5e+Bp
+        IeKlN+Uxi/C55DQMWSbhtSgmcy4E9NR93cvOdGqhb5/C7wTuM8vxka1iNYVt+gQz+5CSaD1lAn3y
+        GFXsOw/piklo+Pnx7KreWkdeKCUp8zmpZTiupHdaLcZVYihUUA/bYOMkXeQ0g4439L3BqFoL5Xi8
+        nN/P5JgEoHvGRmsjUp+RW5AjfzSMTo3A1OlTK7h2Vc4mU/XHSR7z8USr6TX849fJnb7U3gWNKSjJ
+        1iYT+uX6ZQ6hbdWjQie8MEFupVirbFrrBb+G4A/kXPXB8S3HnHpIfghyQGMnVCaOA9NPB1NVQQ+T
+        S0maz8Fa+8yiO5nDEB2gdgGUMbFby0n1FiwptLreXL07/1QxpVRiToH4ghJzcurdjFW5SGWFmarX
+        OhtlZ+M6o6CrTEjCHtCG08VY9CeZ2nX2wRuc697A2EPfCBvXtWkckxQ+yTdq6wpgedRHh9Wx15wm
+        QhMwU3e/S/7G9nE9yVUNNQeQ17/w471/711dOYNyH7htXLeHCXBUMQftr4E2TqTlrEZiIeuQV9Eq
+        A+mEIeIyTNIVgTP8qyjCGaGCDPreTQd//9Uhweno4vbjXYcwGf6mybeurxqEjmM+5+hNy1SxUMCK
+        wJ0h8MyhMXWlyFZAvXtz2eRvh5RsX4BSkJcfkdEvHT73CZ/bmLPP1ITq4ydNw1KOnrvQc2v+yJaj
+        tJYgc0BW0DyXMumQi4LHak8eFRwzIeaMrdL4Op79dJ5t1elDg5vz6b8z4J6yvrYcb6i8K6+2nuLW
+        8Wu/+PWkso5eLadXLQlxywGGIlhvF2Y65TK8+8wzdaziOLZvHKspr0NZy1HWyDTfcphVrTEh1UFJ
+        rnfsQDZuj2zvWNbQ3kOjmdozq0/BoWx3lF2yROY0vk4i9njDli1n2DkpEv5fwfBEIeL3XOIhgMcx
+        jXlUnhPIFAQJQuPTJcE/kjOhY/xm9EGd5UJREH0Yp6KAdUYWXM4UFKGpLrlWsYChSsccLwmdTDDo
+        j+KZBBXk8vrmZ5JyXZgMxmQmZTbu9RaLRRcth26a3/eG/b7fy9OY9TKYGkxfqTpUez3Jz4h3W0xi
+        LvDcGuaqL6n/CuuY1/NQlpcLjB4nw6Cv39+xUNF5MCzfFxNRXpp46lpbad1YoIeI6bA+BYfp3TH9
+        Zs7ye2jsXZ4u5OwynWc0aTusQZ94qIJZpiRn91xg+Iskc8akPstlpdDIvZIaUhfFRmAMErSDOtQ6
+        1FZRa1xkhwZcF9r9jah9CxacXjMt5yssgFXsC1q1JFFCKUMKOYsjjFNMF4IUGVrFgz8IoCenIbBV
+        6FKZUnIyp0v1VRfKgTqeT5RlLXREpWBgbqPy6dYbZU9rZdMMh0hjIorpZrtBpfsOoUlUxlbCQAWh
+        OXaVwedoaSuTHMS2zGbMfZ3mGwn8PwAAAP//7J3fT6NAEID/FR41uRIWWj1ffDE+NLkfxmvunhGo
+        NlehgWu0//3N7C64S8Faa67szbxaassO39dhdnb5SAO/sOeadjHPnTffnr27v3eneVKUq0J9Z1mc
+        uirWcOOw4Ymiy9lTMWrsphvL5cKbMtPZIaa5VuU1UYOHFdmFObKsu+Ho7tVL3kUDZul9XJonwiLc
+        X4S3zb0sRo26+fA+/hm85+XG/JIsvG7qhTMv62CwhlqtsmQBaV8K3vMgd5RpIWjzE45Q8oDl1xKS
+        zkUJR9xt5OKYSpdtrVItFwe4OHDZR6Vrcua5/4+y8yx+nqr5Hyw+wvfmWoHWNIyMZw+Np/VyMpt+
+        O4V78mVVeL/h+s/R03HuXT+ulsUGDuh527V8G3x0XM/LXehpuXrNTrW4z5XHUdvT2x+sbda2qe0e
+        XF3zt0yuNS3TlL29j7e/FEm8vHmA11jVYCk5HN4Kx6MuumILqkqpuTowBHW1r1jXbMXZ5uHWguDg
+        BAzCg8tap9iDVM6yHD75+3xO3mJv2GKt3tKjLhPAAQvcby1V678ruA6q+cbcgaOA/OtepaDN9hpN
+        X0EsN2gbJUZQZB8XZKYqs4DX12W1xmPh39+u4UoRUTYanySnkL5C3NSuIEYyRzxZjbKtbHWc0ExW
+        d9Hu5i8AdyEcLn5WvmPKH6cjue8vK79D+eN0S/nhHSvf5pxlT0b27Z3EiSu+2To91punKxlnOFdX
+        6aEibtCOCi9Nf7bRcc2acgGbPgd5AmzO95jT3HKfuD3NFbiNUUAQqu8hbgyqWiBqsbJPWz5NxUjQ
+        VqrJlItalW1o9UlgLx2rdS+1FnA5L7Cl9GssF0otiYv1KJWHqomC96jD0FVtiEci5FpDZ60h3lK7
+        INoLsU20a1rnGsO7dW49lou4yevnkFVyMGSlIQdRQ3DVPtExbhFd4RoxbEHIvUzrhvsihqAx60p2
+        zWCYmP4xT4Atto/FfsGNCeRTV9b0C3GbHSUvfVKB2DkRNg4nRl6qby1xs5z/NDO1z9DOTaNWbgpj
+        QzMR7aTYNZNzLvoui7/pUcNXcmcs+afADyc3cfkTW/3V04YJ6d5C+XjMHh6zfw73AWDvonAXxQcx
+        7D678Osm/M/nk5fHhIdnDO6Awe0PGFNLidoAnz/P1LpDbU/AmFpK1ApfhKa6z5naYVPbEzCmlhK1
+        QesiuGBqh01tT8CYWtLUCsbWMWwFc0uR23Fg3ChFAWM7dGw7A8bUUqJW+KFZ3oj4x3bg1PYEjKml
+        RG1kZ1xRyNQOm9qegDG1lKgN/MicAIwipnbY1PYEjKmlRe3Euk1iagdPbWfAmFpK1Ar/zEq4Jkzt
+        sKntCRhTS4taYambu6MGT21nwJhaStQG/sWEqXWI2p6AMbWUqI1axQ3uaTwKtX8BAAD//yNlDBlr
+        hI3m2pGUaw30LJAbXCajqywGea7FEWGjuXYk5VpDPQOURDC6ymKQ51ocETaaa0dSrjVGnUgwMRnN
+        tYM71+KIsNFcO7JyLcqGTdPR+dpBn2uxRthorqVproUpACVHEJ1RkpsDokNcI0JAtIu/c6ivqx+Q
+        DQAQ6ApYaiQBAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '4399'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Feb 2025 16:56:19 GMT
+      Last-Modified:
+      - Mon, 16 Dec 2024 19:34:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-id-2:
+      - E26geXEJKqcpKRmxQRW43mwPREtnu0++BGRkV1iaIm+Z/8RtQCrvg0B8lqyUjeoAu3wjcZfwbe8=
+      x-amz-meta-mode:
+      - '33188'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - 5S93Q8BMTVEG3CVQ
+      x-amz-server-side-encryption:
+      - AES256
+      x-amz-version-id:
+      - poa5Dfjus0LpfUlH7sTIt4TIBlhRg.Ab
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/openbb_platform/providers/sec/tests/record/http/test_sec_fetchers/test_sec_filing_fetcher_urllib3_v2.yaml
+++ b/openbb_platform/providers/sec/tests/record/http/test_sec_fetchers/test_sec_filing_fetcher_urllib3_v2.yaml
@@ -1,0 +1,212 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - www.sec.gov
+    method: GET
+    uri: https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/0001552781-24-000634-index-headers.htm
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA7WY33OiSBDHn+GvmNuHfRsFRaOGo2qE0XDLDw9wL9mrqxRJSMLGqIWmzr2//roB
+        BQXdvTW3D1mZ6enpT0/3dxT1KrAtTb3izNDUwAwsrvlcJ9wYM4/4b3ev8WoVL+ZEkiS502ld9GTa
+        Uig8dduK2swWiOovlIoqrKPoh3tanXXj+SFprJ5eZ2RAWlJLkVtyV1SZrvNJwBydU4MFPDBtrm1n
+        ZaXdbncyG983XYc6U3t4xL2oBjcTrvXoJ1GdTIeWqVPD1ac2dwKqu1Mn0HC7CfdM19ju0BZVM+C2
+        r3UaUmv7ud+QZFEdmZbpjNOYtCJafKTuiJZmqX7FnHHZCCYhRlHVXXvCnBu0YumjM3I9mxvUYQCp
+        uzojumvhH5g0PyGVJEFQCrAw4B07YOubOrjuSaLqemPmmF9YkCYCXUgKscP522N4v35L4vkTEHj+
+        NkedntRt9ZQu5M8P8rBNR3e9ieulPjSDY6y+zix6w5lHuWNocqsN8M2D0HPcz8yach+fgYMW6WZ6
+        oOEBIHhxRDKVWi35Ih22t8OQo05Hbvf7sMmh1+HUNx04aMoMw4P/NYzc4zyQNdfhpEjYxGJfGOYs
+        uNFYYDEnYDmkNoZPX8yJ1pbaeLqTK1ipKZJCuxdd2oLzgX1r9rGZab3jts0Df81tSTRLPSJSiiNZ
+        5w1d4waeJh7XPs7Wl2i2rd6PT+vLuoKn8fwh2jSe1/sdtV2e7XJscW0z4tKafkQfBy2560iSnetA
+        EGp7clfzxJ8ObTNbgoUzELBysj4lW1KS9in4gliKlVnLEndEPA61C/O77sWGJWZqmJY0LDWiZZhA
+        O0Rk8UiMOInu14tkRRYJ0aNkHcZz4j4+xvdRsrokfAazKG5l00vClstFPF+/RvM1zhyuGxB98bqM
+        5qsQzL8RliTh/ClC61WdeV2Qo3gezu/jcEb8dbjO14bzB8I3z/FdvF6JWDAGYT5i4znAot0x4XM+
+        lWlPeTJd6Q1EUch7GJezgSAKu4EitagisFjY0yJ4hLPwmAVBG/yafOI3aFNSJ0GAqncM5hloMoVu
+        McFat1C0RqaeUw75Z+6xMffJnyhgf8GysoRlm5Pin1CRM0EAPSsqTBAKTUtDgDRADvZEDc1A1yDF
+        qbARFDYCwobjqbaJQiY7JJOdAZpCMvKiTKsSfMMNCKKGldhvK4Tdr/NBTO4uoELicDvLLiItVE4U
+        tmpDcjlIjyITGCKDbZ3GwBGAyGDMW53JeXFojE8gNvg50xuh2CQVPJjZkzxRQD36HwNA4Wjui046
+        VpawdACzjA+Y5kyofp9y0Bock9MRzDBWBo5ELUW56Ny+LGjvBXUuc8GvM39qSJ6T6PHXD4dmHzRj
+        cf+Wtq9MKHmMZ9GAHBqpzVBT7xIti70S6NHI+TXt9xtyJfrWseijTb9P5e+HX9iV4m8dxl9Y/SzA
+        2GOTK1OvALQrAC+L29niadH4unzKXHJf98wJttmhoypVaXGJp73jKc2fcRSyJDd8/aoCo9TA0O21
+        0disHuqAroeeRcAbt1na6EfJ9jyV6JQS3Z7NmYQGH1UIO6cIbx+ix8bmdXaUEjyajpnK8I+Rbj2W
+        aDt1tFu7M4ktNqwQd08Sz8K7k8TgkVs/Cps7K8F2a2FzuzNh4UtfBfbiJOwyiU7CgkcfNmT/5YBz
+        nyXmi1rm3O5nma9tqwLbr8B6hWAe8JkGZwOSFXG+xxE471BM+zse7ywF5dc6r0LIUoVi9zXv1ouW
+        i2Td2MxWm/Ogal2WLzxpB1lr+p7HJldvbP958Xfj6+o8xtxJmaq4x/PJd+Wo3t1JlrH71ZkohZ8y
+        TXGrF/PvClS9/kbxDL5R+2+vr2Hy7Zh2/DjXZjVrVlyWEZVSGZbN8NfqDrVU1d9x5bE/CJAeejtD
+        h37zXaeauOodY0fr0IrnLysousX8vKzt+yozFtfLvs3P0sG38ypc9U6pfa2wuUtmjX/i5XmsJ12X
+        0Ytb5uSSd+2P3smfGrdQpO/TInVey+y92p8nqWV9o/yIw12v1Bl/J43NwxdPahNfSanN9P2U2kxf
+        Fov/AnSFX/M0FgAA
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1551'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Feb 2025 16:55:12 GMT
+      Last-Modified:
+      - Mon, 16 Dec 2024 19:34:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-id-2:
+      - 36KuPmr3UWIQ8x31DyNQbm1OVx9hB40N0dw451XQLYA4IrIsvW2q02kCDDjAMIZPKkuwZB1/wS0=
+      x-amz-meta-mode:
+      - '33188'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - 5S9961E5DEA95VYH
+      x-amz-server-side-encryption:
+      - AES256
+      x-amz-version-id:
+      - Em.xpqQlD0bTs0G3LJTAM3AKc2Z7jmV.
+    status:
+      code: 200
+      message: OK
+- request:
+    body: null
+    headers:
+      Accept-Encoding:
+      - gzip, deflate
+      Host:
+      - www.sec.gov
+    method: GET
+    uri: https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/R1.htm
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAAA+xaa3PaRhT9XH7FHbWN7YwBSQb8EpohQskwsYEa0ibtdDyLtIBioWVWC5hm8t97
+        Vw/b2EQmnXQGJfABYe25y96z5x7tLjaaHevdpd3umwWj/6Frm+8vLwpGz/7tnd22bPO0YLxuXdjt
+        xqVtXmmlsZgUjKbds65a3X6r0zZbTbtxBu9fXV1A2hH2Y7+X3SHYlxdKXLwIT/jUNMrxtWD4XnAD
+        nPp1JRRLn4ZjSoUCYjmldUXQW1F2wlCBMafDuuIFjj9zaZnTKeOiJFuwh9Dh3lQ8DPlI5iS+q0DI
+        nbrSG7NF6SOiyy+hyaDNBFzRCZtT6I+9ECw2mdBAwMuyUY7jzOxezcJP8Ws4CxzhsQAEG4182kZc
+        zxtgTiPYpwfwKcV5Q/y7FNw3l6JsS64XTn2yrNf3AhbQvQcRWei9gc+cm73zFPsZqB9S+ASZQdE3
+        nMPnu6i7ZAtGOZmdAXOXktIpCSAKrytJ/BnI+HPFnB+V9EqpgsEIMg1BBj4FxydhWFfiiVFgwLhL
+        eV1RFXCo7yPSwQHVFV0Bz8V5dCeV6oleramntcppVVflNAou38ZpV8LHWCZDg7qiKcDZIv1sGq43
+        T4e38FwxPgNdVae3ODojFJwFI9PCyeXGgKPSkjtGGaOk8Mar3zOO+zOb1CmBdnSIXemVFXA5Hhq/
+        zzIar5v+PcWhJqOJEy8OmBBscgbRmGBOfG+EIxdsit9F0jCSyvpeWGdz5rn76gEGMdS659wk2g3x
+        rXG1DwLlegh7Lh1i5LVLvesmc2ZSvH0U6t4hLLzAZQvAHsy0BWSTUSYyHXdl4FLWinlSfGvEcxlP
+        aSHBPUmbbVHaDczMldm99sloNe+7JpBtGYkPCVbNZqlv44x3KfeYawduk4gvTX2MAQSBRGWQcSf/
+        WP+5E4Qd4BNl+dpDE55NBpSvEhK3gmyGuD2DClXViqqua8f500ac5xUdeeh6JBBtMqFrmbiHgMRk
+        sGF1rAZYnQv5lldZWFgLnPitwKW3b+lyLSMJBiIQICpTIfjStaPKhoWyfRLpk9uWixl7Q88hcgWT
+        UTWIhVXw8zVUPSmqNf2kUqvmVTOtwGEclzNRwj2B7mmxGUpkaTF3fU2tRBxCFAOMQxIHMjDLge28
+        iqnhupyGYXK58AKqrSUoARymH0BCoRNksYKtBcCXxRxStJhPoOuTf0heVZVkbuHHDu+zRZBNlMRJ
+        CUlkBkkN4aOTb0jK1uonKpgO73I2x53e+hq7Y+auulJ4Bj1vGjmXS5eFgvh/etMves8dLzEUEPuc
+        3xypR9pR/iQjS6LBKXlKRVQssum5zPcrauUgf5K4QAv0u2Pchq97WEetEDU//3iuHdeKuqZr+Zv+
+        P7gnBA3kkc0sSJYj4SoTCQRWMd9mI7hNeugxhHnCC0aX6IXcI/4qD/ftkAK+v91wl9P4+M6h0TEI
+        7v0p7wyHj8sDcUXnARBiJETQ708bj2hpheGM8s3JifH/A0fbJJ340WlPKB9hjbzhbCHGSBqOf/0O
+        MUVCDIUE+22IGW8JMbOwOCJkeh2tr6QWLNlzZ9gTzLlp3Hph/YZdS2nJTRHeUkt6tUv478Sf0Uv6
+        9LEUQyHCHsIvEg6Ihyggg7oXP2s19Tx/oupRZ4bPn6WmD/ryJ45VNqJbwIag6fuDA0jBWccvEX/R
+        FugLHObOm/qcuFhGveVkwB49spImiNsyaHm74VnUNkrDvnXGJBjRp4dzKQJSyHOHc+0PvQ1PDXLl
+        L8iDVjo5rraZoGFzRnVVr60zlwj0K0QwQJw8u67tTOVZU4l5i0zlEXc/qJlsmvk2imJnJxvYiVo6
+        rqrP2UkE2tnJV9tJzNvOTh7YiZVfVez8ZKPliaY/XJ4cr1+eIOiRnxzv/GSD5Ynk7amfbPiD/Hfo
+        Jzn8V4SdnXzV8mTVTk7XL0+e2snpzk42WJ6st5PTH9ZOTjf8QXQbVbHzk//iJ9o6Q0EgqCUspOqj
+        wtDgrxj/985edvby9fbyKr+q2GJ7+RcAAP//7J1Lc9s2EIDv+RWYXtJORb1IuY6a8YwfScbjSeLG
+        PbRHiIQszFAkS4CWlV/fXYCSSQqKoSSTSCJ8sCUKz+Xi8y6w4u4TXoJ+ZTfF75vNFShUN1f8vuOJ
+        BU9Qbhs8Adm1lCd+3/HkuHky6A6ru7O+0VpRhRo8GTieWOymDE27s75l8NcR8uQAw94cTnbAiV/3
+        fvyhCSf+5m6KP3Q4eRYnZrm1FSWWM99HhXAosfJ0/GoYiu+bPR2/GYbi+w4lFp6ObwpD8S2/lXCE
+        ODnA72M4nOyEk1Ft42QLTkYbGycOJzY4GRk3TlqME3fOc9w8GXRPap7OyLxxcrJhsY8cTyw2Tk5M
+        Bzv+AX6l/TvxxHLm+6gUDid2UW0182RL0P1gwzxxUbJWUW1G86S1UbK2M99HpXA4sfJ2Xo2exYkq
+        5HDyFd7OK+OxTotx4ryd4+aJ39iMNQbd+4bNWBd0b3OuY5JbW1niAu6PGyX97mnV0wm2RLCdNj2d
+        wEWw2ZgmpyZPJ2htBFvgItiOnCeDbr/Gky0RbP0NnrgINpudk76RJ62NYLOd+T4qhcOJladTOycO
+        ArOns3FOHAQOJxaejklubUXJAT7C2qFkJ5TUnnwyMoac+JtPPhm5kBMblJjk1lKU2M58HxXix6Gk
+        pzLmwItKEptmjp0XZVqdRh6djEaRyqPTzKuD70upFHL2iU2vqKS/bGldpeDZlkpF9Z2fVSY14xFT
+        ci9bC9M4zcdkMeMSG7O+B9gO3AMU6T9r6a2VA3vUeX3KbjET0XoG5cTHZKiS/LyA0Vj3+5SZSd9/
+        dVM9csWmPOH4ZGA1GJXuJzu7SNOY0YRMQRRQmkoCFWQOC3sxYwlcYTrJVZgmEp+TSlF2gmQ5e+Bp
+        IeKlN+Uxi/C55DQMWSbhtSgmcy4E9NR93cvOdGqhb5/C7wTuM8vxka1iNYVt+gQz+5CSaD1lAn3y
+        GFXsOw/piklo+Pnx7KreWkdeKCUp8zmpZTiupHdaLcZVYihUUA/bYOMkXeQ0g4439L3BqFoL5Xi8
+        nN/P5JgEoHvGRmsjUp+RW5AjfzSMTo3A1OlTK7h2Vc4mU/XHSR7z8USr6TX849fJnb7U3gWNKSjJ
+        1iYT+uX6ZQ6hbdWjQie8MEFupVirbFrrBb+G4A/kXPXB8S3HnHpIfghyQGMnVCaOA9NPB1NVQQ+T
+        S0maz8Fa+8yiO5nDEB2gdgGUMbFby0n1FiwptLreXL07/1QxpVRiToH4ghJzcurdjFW5SGWFmarX
+        OhtlZ+M6o6CrTEjCHtCG08VY9CeZ2nX2wRuc697A2EPfCBvXtWkckxQ+yTdq6wpgedRHh9Wx15wm
+        QhMwU3e/S/7G9nE9yVUNNQeQ17/w471/711dOYNyH7htXLeHCXBUMQftr4E2TqTlrEZiIeuQV9Eq
+        A+mEIeIyTNIVgTP8qyjCGaGCDPreTQd//9Uhweno4vbjXYcwGf6mybeurxqEjmM+5+hNy1SxUMCK
+        wJ0h8MyhMXWlyFZAvXtz2eRvh5RsX4BSkJcfkdEvHT73CZ/bmLPP1ITq4ydNw1KOnrvQc2v+yJaj
+        tJYgc0BW0DyXMumQi4LHak8eFRwzIeaMrdL4Op79dJ5t1elDg5vz6b8z4J6yvrYcb6i8K6+2nuLW
+        8Wu/+PWkso5eLadXLQlxywGGIlhvF2Y65TK8+8wzdaziOLZvHKspr0NZy1HWyDTfcphVrTEh1UFJ
+        rnfsQDZuj2zvWNbQ3kOjmdozq0/BoWx3lF2yROY0vk4i9njDli1n2DkpEv5fwfBEIeL3XOIhgMcx
+        jXlUnhPIFAQJQuPTJcE/kjOhY/xm9EGd5UJREH0Yp6KAdUYWXM4UFKGpLrlWsYChSsccLwmdTDDo
+        j+KZBBXk8vrmZ5JyXZgMxmQmZTbu9RaLRRcth26a3/eG/b7fy9OY9TKYGkxfqTpUez3Jz4h3W0xi
+        LvDcGuaqL6n/CuuY1/NQlpcLjB4nw6Cv39+xUNF5MCzfFxNRXpp46lpbad1YoIeI6bA+BYfp3TH9
+        Zs7ye2jsXZ4u5OwynWc0aTusQZ94qIJZpiRn91xg+Iskc8akPstlpdDIvZIaUhfFRmAMErSDOtQ6
+        1FZRa1xkhwZcF9r9jah9CxacXjMt5yssgFXsC1q1JFFCKUMKOYsjjFNMF4IUGVrFgz8IoCenIbBV
+        6FKZUnIyp0v1VRfKgTqeT5RlLXREpWBgbqPy6dYbZU9rZdMMh0hjIorpZrtBpfsOoUlUxlbCQAWh
+        OXaVwedoaSuTHMS2zGbMfZ3mGwn8PwAAAP//7J3fT6NAEID/FR41uRIWWj1ffDE+NLkfxmvunhGo
+        NlehgWu0//3N7C64S8Faa67szbxaassO39dhdnb5SAO/sOeadjHPnTffnr27v3eneVKUq0J9Z1mc
+        uirWcOOw4Ymiy9lTMWrsphvL5cKbMtPZIaa5VuU1UYOHFdmFObKsu+Ho7tVL3kUDZul9XJonwiLc
+        X4S3zb0sRo26+fA+/hm85+XG/JIsvG7qhTMv62CwhlqtsmQBaV8K3vMgd5RpIWjzE45Q8oDl1xKS
+        zkUJR9xt5OKYSpdtrVItFwe4OHDZR6Vrcua5/4+y8yx+nqr5Hyw+wvfmWoHWNIyMZw+Np/VyMpt+
+        O4V78mVVeL/h+s/R03HuXT+ulsUGDuh527V8G3x0XM/LXehpuXrNTrW4z5XHUdvT2x+sbda2qe0e
+        XF3zt0yuNS3TlL29j7e/FEm8vHmA11jVYCk5HN4Kx6MuumILqkqpuTowBHW1r1jXbMXZ5uHWguDg
+        BAzCg8tap9iDVM6yHD75+3xO3mJv2GKt3tKjLhPAAQvcby1V678ruA6q+cbcgaOA/OtepaDN9hpN
+        X0EsN2gbJUZQZB8XZKYqs4DX12W1xmPh39+u4UoRUTYanySnkL5C3NSuIEYyRzxZjbKtbHWc0ExW
+        d9Hu5i8AdyEcLn5WvmPKH6cjue8vK79D+eN0S/nhHSvf5pxlT0b27Z3EiSu+2To91punKxlnOFdX
+        6aEibtCOCi9Nf7bRcc2acgGbPgd5AmzO95jT3HKfuD3NFbiNUUAQqu8hbgyqWiBqsbJPWz5NxUjQ
+        VqrJlItalW1o9UlgLx2rdS+1FnA5L7Cl9GssF0otiYv1KJWHqomC96jD0FVtiEci5FpDZ60h3lK7
+        INoLsU20a1rnGsO7dW49lou4yevnkFVyMGSlIQdRQ3DVPtExbhFd4RoxbEHIvUzrhvsihqAx60p2
+        zWCYmP4xT4Atto/FfsGNCeRTV9b0C3GbHSUvfVKB2DkRNg4nRl6qby1xs5z/NDO1z9DOTaNWbgpj
+        QzMR7aTYNZNzLvoui7/pUcNXcmcs+afADyc3cfkTW/3V04YJ6d5C+XjMHh6zfw73AWDvonAXxQcx
+        7D678Osm/M/nk5fHhIdnDO6Awe0PGFNLidoAnz/P1LpDbU/AmFpK1ApfhKa6z5naYVPbEzCmlhK1
+        QesiuGBqh01tT8CYWtLUCsbWMWwFc0uR23Fg3ChFAWM7dGw7A8bUUqJW+KFZ3oj4x3bg1PYEjKml
+        RG1kZ1xRyNQOm9qegDG1lKgN/MicAIwipnbY1PYEjKmlRe3Euk1iagdPbWfAmFpK1Ar/zEq4Jkzt
+        sKntCRhTS4taYambu6MGT21nwJhaStQG/sWEqXWI2p6AMbWUqI1axQ3uaTwKtX8BAAD//yNlDBlr
+        hI3m2pGUaw30LJAbXCajqywGea7FEWGjuXYk5VpDPQOURDC6ymKQ51ocETaaa0dSrjVGnUgwMRnN
+        tYM71+KIsNFcO7JyLcqGTdPR+dpBn2uxRthorqVproUpACVHEJ1RkpsDokNcI0JAtIu/c6ivqx+Q
+        DQAQ6ApYaiQBAA==
+    headers:
+      Accept-Ranges:
+      - bytes
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '4399'
+      Content-Type:
+      - text/html
+      Date:
+      - Mon, 17 Feb 2025 16:55:13 GMT
+      Last-Modified:
+      - Mon, 16 Dec 2024 19:34:14 GMT
+      Strict-Transport-Security:
+      - max-age=31536000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      X-Content-Type-Options:
+      - nosniff
+      X-Frame-Options:
+      - SAMEORIGIN
+      X-XSS-Protection:
+      - 1; mode=block
+      x-amz-id-2:
+      - E26geXEJKqcpKRmxQRW43mwPREtnu0++BGRkV1iaIm+Z/8RtQCrvg0B8lqyUjeoAu3wjcZfwbe8=
+      x-amz-meta-mode:
+      - '33188'
+      x-amz-replication-status:
+      - COMPLETED
+      x-amz-request-id:
+      - 5S93Q8BMTVEG3CVQ
+      x-amz-server-side-encryption:
+      - AES256
+      x-amz-version-id:
+      - poa5Dfjus0LpfUlH7sTIt4TIBlhRg.Ab
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/openbb_platform/providers/sec/tests/test_sec_fetchers.py
+++ b/openbb_platform/providers/sec/tests/test_sec_fetchers.py
@@ -10,6 +10,7 @@ from openbb_sec.models.compare_company_facts import SecCompareCompanyFactsFetche
 from openbb_sec.models.equity_ftd import SecEquityFtdFetcher
 from openbb_sec.models.equity_search import SecEquitySearchFetcher
 from openbb_sec.models.etf_holdings import SecEtfHoldingsFetcher
+from openbb_sec.models.sec_filing import SecFilingFetcher
 from openbb_sec.models.form_13FHR import SecForm13FHRFetcher
 from openbb_sec.models.insider_trading import SecInsiderTradingFetcher
 from openbb_sec.models.institutions_search import SecInstitutionsSearchFetcher
@@ -205,5 +206,18 @@ def test_sec_management_discussion_analysis_fetcher(credentials=test_credentials
     }
 
     fetcher = SecManagementDiscussionAnalysisFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_sec_filing_fetcher(credentials=test_credentials):
+    """Test the SEC Filing fetcher."""
+    params = {
+        "url": "https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/",
+        "use_cache": False,
+    }
+
+    fetcher = SecFilingFetcher()
     result = fetcher.test(params, credentials)
     assert result is None


### PR DESCRIPTION
1. **Why**?:

    - We need a reliable way to open any filing and read the associated metadata, and parse it for URLs to the attachments.

2. **What**?:

    - Adds endpoint:
      - `obb.regulators.sec.filing_headers`
        - Accepts a URL as input.
        - Optional `use_cache` to avoid downloading the same files repeatedly (they will never change)
    - An importable worker model can be used independently:
      - `from openbb_sec.models.sec_filing import SecBaseFiling`
      - This contains all the same fields and params as the endpoint and returned data, but here they are `computed_fields` and there are methods handling the I/O and parsing.
      - `SecBaseFiling` will be used as the base class for future functionality, like 10-K/Q

3. **Impact**:
    - Improves the general functionality by providing tooling to do low-level work on SEC filings.
    - As a Workspace widget, the data is only the list of attachments.
    - This endpoint can be used to get the list of "Notes Due" for a company.

4. **Testing Done**:

    - Try it with literally any, or component of, filing's URL


```python
res = obb.regulators.sec.filing_headers(url="https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/e24475_ko-8k.htm")
```

Workspace Widget:

<img width="702" alt="Screenshot 2025-02-17 at 9 37 19 AM" src="https://github.com/user-attachments/assets/2d428b88-dd60-440b-badd-208ce3195217" />


```python
res.results.model_dump()
```

```sh
{'base_url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/',
 'name': 'COCA COLA CO',
 'cik': '0000021344',
 'trading_symbols': ['KO',
  'KO26',
  'KO26C',
  'KO27',
  'KO29A',
  'KO29B',
  'KO30B',
  'KO31',
  'KO32',
  'KO33',
  'KO33A',
  'KO35',
  'KO36',
  'KO36A',
  'KO37',
  'KO40B',
  'KO41',
  'KO44',
  'KO53'],
 'sic': 'BEVERAGES [2080]',
 'sic_organization_name': '04 Manufacturing',
 'filing_date': datetime.date(2024, 12, 16),
 'period_ending': datetime.date(2024, 12, 13),
 'fiscal_year_end': '12-31',
 'document_type': '8-K',
 'has_cover_page': True,
 'description': 'Departure of Directors or Certain Officers; Election of Directors; Appointment of Certain Officers; Financial Statements and Exhibits',
 'cover_page': {'Document Type': '8-K',
  'Amendment Flag': 'false',
  'Document Period End Date': 'Dec. 13, 2024',
  'Entity File Number': '001-02217',
  'Entity Registrant Name': 'COCA COLA CO',
  'Entity Central Index Key': '0000021344',
  'Entity Tax Identification Number': '58-0628465',
  'Entity Incorporation, State or Country Code': 'DE',
  'Entity Address, Address Line One': 'One  Coca-Cola Plaza',
  'Entity Address, City or Town': 'Atlanta',
  'Entity Address, State or Province': 'GA',
  'Entity Address, Postal Zip Code': '30313',
  'City Area Code': '(404)',
  'Local Phone Number': '676-2121',
  'Written Communications': 'false',
  'Soliciting Material': 'false',
  'Pre-commencement Tender Offer': 'false',
  'Pre-commencement Issuer Tender Offer': 'false',
  'Entity Emerging Growth Company': 'false',
  'SIC': 'BEVERAGES [2080]',
  'SIC Organization Name': '04 Manufacturing',
  '12(b) Securities': [{'Title': 'Common  Stock, $0.25 Par Value',
    'Symbol': 'KO',
    'Exchange': 'NYSE'},
   {'Title': '1.875%  Notes Due 2026', 'Symbol': 'KO26', 'Exchange': 'NYSE'},
   {'Title': '0.750%  Notes Due 2026', 'Symbol': 'KO26C', 'Exchange': 'NYSE'},
   {'Title': '1.125%  Notes Due 2027', 'Symbol': 'KO27', 'Exchange': 'NYSE'},
   {'Title': '0.125%  Notes Due 2029', 'Symbol': 'KO29B', 'Exchange': 'NYSE'},
   {'Title': '0.400%  Notes Due 2030', 'Symbol': 'KO30B', 'Exchange': 'NYSE'},
   {'Title': '1.250%  Notes Due 2031', 'Symbol': 'KO31', 'Exchange': 'NYSE'},
   {'Title': '3.125% Notes Due 2032', 'Symbol': 'KO32', 'Exchange': 'NYSE'},
   {'Title': '0.375%  Notes Due 2033', 'Symbol': 'KO33', 'Exchange': 'NYSE'},
   {'Title': '0.500%  Notes Due 2033', 'Symbol': 'KO33A', 'Exchange': 'NYSE'},
   {'Title': '1.625%  Notes Due 2035', 'Symbol': 'KO35', 'Exchange': 'NYSE'},
   {'Title': '1.100%  Notes Due 2036', 'Symbol': 'KO36', 'Exchange': 'NYSE'},
   {'Title': '0.950%  Notes Due 2036', 'Symbol': 'KO36A', 'Exchange': 'NYSE'},
   {'Title': '3.375% Notes Due 2037', 'Symbol': 'KO37', 'Exchange': 'NYSE'},
   {'Title': '0.800%  Notes Due 2040', 'Symbol': 'KO40B', 'Exchange': 'NYSE'},
   {'Title': '1.000%  Notes Due 2041', 'Symbol': 'KO41', 'Exchange': 'NYSE'},
   {'Title': '3.500% Notes Due 2044', 'Symbol': 'KO44', 'Exchange': 'NYSE'},
   {'Title': '3.750% Notes Due 2053', 'Symbol': 'KO53', 'Exchange': 'NYSE'}]},
 'document_urls': [{'type': '8-K',
   'sequence': '1',
   'filename': 'e24475_ko-8k.htm',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/e24475_ko-8k.htm'},
  {'type': 'EX-99.1',
   'sequence': '2',
   'filename': 'e24475_ex99-1.htm',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/e24475_ex99-1.htm'},
  {'type': 'GRAPHIC',
   'sequence': '3',
   'filename': 'ko_logo.jpg',
   'description': 'GRAPHIC',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/ko_logo.jpg'},
  {'type': 'EX-101.SCH',
   'sequence': '4',
   'filename': 'ko-20241213.xsd',
   'description': 'XBRL SCHEMA FILE',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/ko-20241213.xsd'},
  {'type': 'EX-101.DEF',
   'sequence': '5',
   'filename': 'ko-20241213_def.xml',
   'description': 'XBRL DEFINITION FILE',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/ko-20241213_def.xml'},
  {'type': 'EX-101.LAB',
   'sequence': '6',
   'filename': 'ko-20241213_lab.xml',
   'description': 'XBRL LABEL FILE',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/ko-20241213_lab.xml'},
  {'type': 'EX-101.PRE',
   'sequence': '7',
   'filename': 'ko-20241213_pre.xml',
   'description': 'XBRL PRESENTATION FILE',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/ko-20241213_pre.xml'},
  {'type': 'XML',
   'sequence': '9',
   'filename': 'R1.htm',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/R1.htm'},
  {'type': 'EXCEL',
   'sequence': '10',
   'filename': 'Financial_Report.xlsx',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/Financial_Report.xlsx'},
  {'type': 'XML',
   'sequence': '11',
   'filename': 'Show.js',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/Show.js'},
  {'type': 'XML',
   'sequence': '12',
   'filename': 'report.css',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/report.css'},
  {'type': 'XML',
   'sequence': '14',
   'filename': 'FilingSummary.xml',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/FilingSummary.xml'},
  {'type': 'JSON',
   'sequence': '16',
   'filename': 'MetaLinks.json',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/MetaLinks.json'},
  {'type': 'ZIP',
   'sequence': '17',
   'filename': '0001552781-24-000634-xbrl.zip',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/0001552781-24-000634-xbrl.zip'},
  {'type': 'XML',
   'sequence': '18',
   'filename': 'e24475_ko-8k_htm.xml',
   'description': 'IDEA: XBRL DOCUMENT',
   'url': 'https://www.sec.gov/Archives/edgar/data/21344/000155278124000634/e24475_ko-8k_htm.xml'}]}
```

