### PR TITLE
[BugFix] API: Reverse Output Of Wrapper Checking Object To Pass Custom Response Model

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -247,9 +247,10 @@ def build_api_wrapper(
         execute = partial(command_runner.run, path, user_settings)
         output = await execute(*args, **kwargs)
 
-        if no_validate is True:
-            return output
-        return validate_output(output)
+        if isinstance(output, OBBject) and not no_validate:
+            return validate_output(output)
+
+        return output
 
     return wrapper
 


### PR DESCRIPTION
1. **Why**?:

    - This PR corrects the API command wrapper for the desired behavior.
      - `no_validate=True` in the @command decorator is for discarding all output response models entirely.
        - Setting as True will defeat the automatic generation of `columnsDefs` by `openbb-platform-api` 
      - The default, False, retains the response models and allows any type to be defined - i.e, `-> dict` or `-> SomeModel` or `-> OBBject`.

2. **What**?:

    - Basically just reverses what the check was to look for instance of `OBBject` before acting.

3. **Impact**:

    - Most notably impacted are the data processing routers.

4. **Testing Done**:

```python
@router.command(methods=["GET"])
async def some_metric(
    symbol: str,
) -> dict:
    """Some metric for a stock."""
    return {
        "label": "P/E",
        "value": 600,
        "delta": "",
    }
```
