### PR TITLE
[Feature] Allow Arbitrary Credentials From `user_settings.json` To Populate Credentials Model

### DIFF
--- a/openbb_platform/core/tests/app/service/test_hub_service.py
+++ b/openbb_platform/core/tests/app/service/test_hub_service.py
@@ -334,7 +334,7 @@ def test_platform2hub():
     assert user_settings.features_keys["polygon_api_key"] == "polygon"
     assert user_settings.features_keys["api_fred_key"] == "fred"
     assert user_settings.features_keys["benzinga_api_key"] == "benzinga"
-    assert "some_api_key" not in user_settings.features_keys
+    assert "some_api_key" in user_settings.features_keys
     assert "defaults" in user_settings.features_settings
 
 


### PR DESCRIPTION
1. **Why**?:

    - Items defined in `user_settings["credentials"]` only populate if they are in the ProviderInterface, this is not ideal.

2. **What**?:

    - Populates the Credentials model with any leftover key:value pairs from `user_settings.json`, if it exists.

3. **Impact**:

    - Improved developer experience, more freedom.
    - Arbitrary keys being defined have no real consequence, but greatly improve the flexibility - like incorporating Hub configurations with completely custom APIs and apps that are authorized by a remote script.

4. **Testing Done**:

![Screenshot 2025-02-21 at 9 42 57 PM](https://github.com/user-attachments/assets/f33279bb-5876-4e26-9a8e-210f4ea9195b)
