### PR TITLE
[BugFix] `openbb-platform-api` - Fix `$.` References Being Deleted Outside Of Loop

### DIFF
--- a/openbb_platform/extensions/platform_api/README.md
+++ b/openbb_platform/extensions/platform_api/README.md
@@ -167,6 +167,8 @@ async def hello_metric() -> MetricResponseModel:
     return MetricResponseModel(label="Good Vibes Score", value=100, delta="1%")
 ```
 
+This type of widget can be created as an array of MetricResponseModels. Adjust the response to be a `list[MetricRespnoseModel]`
+
 ### Query Parameters
 
 Function arguments will populate as widget parameters.

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -278,8 +278,7 @@ def get_widgets_json(
 def import_app(app_path: str, name: str = "app", factory: bool = False):
     """Import the FastAPI app instance from a local file."""
     # pylint: disable=import-outside-toplevel
-    import sys  # noqa
-    from fastapi import FastAPI
+    from fastapi import FastAPI  # noqa
     from fastapi.middleware.cors import CORSMiddleware
     from importlib import util
     from openbb_core.api.app_loader import AppLoader

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -278,7 +278,8 @@ def get_widgets_json(
 def import_app(app_path: str, name: str = "app", factory: bool = False):
     """Import the FastAPI app instance from a local file."""
     # pylint: disable=import-outside-toplevel
-    from fastapi import FastAPI  # noqa
+    import sys  # noqa
+    from fastapi import FastAPI
     from fastapi.middleware.cors import CORSMiddleware
     from importlib import util
     from openbb_core.api.app_loader import AppLoader
@@ -291,12 +292,14 @@ def import_app(app_path: str, name: str = "app", factory: bool = False):
     if not Path(app_path).exists():
         raise FileNotFoundError(f"Error: The app file '{app_path}' does not exist")
 
-    spec = util.spec_from_file_location("app", app_path)
+    spec_name = os.path.basename(app_path).split(".")[0]
+    spec = util.spec_from_file_location(spec_name, app_path)
 
     if spec is None:
         raise RuntimeError(f"Failed to load the file specs for '{app_path}'")
 
     module = util.module_from_spec(spec)  # type: ignore
+    sys.modules[spec_name] = module  # type: ignore
     spec.loader.exec_module(module)  # type: ignore
 
     if not hasattr(module, name):

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -511,7 +511,7 @@ def data_schema_to_columns_defs(  # noqa: PLR0912  # pylint: disable=too-many-br
         prop = target_schema.get("properties", {}).get(key)
         # Handle prop types for both when there's a single prop type or multiple
         if "items" in prop:
-            items = prop.pop("items", {})
+            items = prop.get("items", {})
             items = items.get("anyOf", items)
             prop["anyOf"] = items if isinstance(items, list) else [items]
             types = [

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -308,13 +308,14 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
                 .strip()
             )
 
+        if widget_config := param["schema"].get("x-widget_config", {}):
+            p["x-widget_config"] = widget_config
+
         return p
 
     p_schema = param.get("schema", {})
     p["value"] = p_schema.get("default", None)
-
     p = set_parameter_options(p, p_schema, providers)
-
     p = set_parameter_type(p, p_schema)
 
     if title := p_schema.get("title", ""):
@@ -356,7 +357,8 @@ def get_query_schema_for_widget(
     params = command.get("parameters", [])
     route_params: list[dict] = []
     providers: list[str] = extract_providers(params)
-
+    if not providers:
+        providers = ["custom"]
     for param in params:
         if param["name"] in ["sort", "order"]:
             continue
@@ -365,7 +367,8 @@ def get_query_schema_for_widget(
             continue
 
         p = process_parameter(param, providers)
-        p["show"] = True
+        if "show" not in p:
+            p["show"] = True
         route_params.append(p)
 
     return route_params, has_chart

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -159,7 +159,8 @@ def set_parameter_options(p: dict, p_schema: dict, providers: list[str]) -> dict
                 available_providers.add(provider)
             if provider in p_schema:
                 provider_choices = p_schema[provider].get("choices", [])
-                widget_configs[provider] = p_schema[provider].get("x-widget_config", {})
+                if widget_def := p_schema[provider].get("x-widget_config"):
+                    widget_configs[provider] = widget_def
             elif len(providers) == 1 and "enum" in p_schema:
                 provider_choices = p_schema["enum"]
                 p_schema.pop("enum")

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
@@ -159,10 +159,9 @@ def modify_query_schema(query_schema: list[dict], provider_value: str):
 
         if "x-widget_config" in _item:
             provider_value_widget_config = _item.pop("x-widget_config")
+            _item.update(provider_value_widget_config)
 
-        if provider_value in provider_value_widget_config and bool(
-            provider_value_widget_config[provider_value]
-        ):
+        if provider_value in provider_value_widget_config:
 
             if provider_value_widget_config[provider_value].get("exclude"):
                 continue

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
@@ -380,11 +380,10 @@ def build_json(  # noqa: PLR0912  # pylint: disable=too-many-branches
                 for key, value in data_config.copy().items():
                     if key.startswith("$."):
                         var_key[key] = value
-                        _ = data_config.pop(key)
 
                 widget_config["data"] = deep_merge_configs(
                     widget_config["data"],
-                    data_config,
+                    {k: v for k, v in data_config.items() if not k.startswith("$.")},
                 )
 
             if var_key:

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/widgets.py
@@ -161,7 +161,10 @@ def modify_query_schema(query_schema: list[dict], provider_value: str):
             provider_value_widget_config = _item.pop("x-widget_config")
             _item.update(provider_value_widget_config)
 
-        if provider_value in provider_value_widget_config:
+        if (
+            provider_value_widget_config
+            and provider_value in provider_value_widget_config
+        ):
 
             if provider_value_widget_config[provider_value].get("exclude"):
                 continue

--- a/openbb_platform/extensions/platform_api/pyproject.toml
+++ b/openbb_platform/extensions/platform_api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-platform-api"
-version = "1.1.3"
+version = "1.1.4"
 description = "OpenBB Platform API: Launch script and widgets builder for the OpenBB Platform API and Workspace Backend Connector."
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"


### PR DESCRIPTION
1. **Why**?:

    - Self-inflicted wound, the intention was to delete `$.` references after being transferred to the correct place. The reality was the it was being removed from the schema entirely, so the next iteration of that widget definition was missing those components.

2. **What**?:

    - Use dict comprehension instead of removing key from original.

3. **Impact**:

    - When more than 1 PDF widget was created, this became an issue.

    > [!TIP]
    > Refer to the Impact Analysis confluence (internal) document for more information.

4. **Testing Done**:

    - Make multiple PDF widgets in a custom backend.
