### PR TITLE
[BugFix] Downgrade Plotly To 5.24.1 For JSON Output Formatting

### DIFF
--- a/openbb_platform/obbject_extensions/charting/poetry.lock
+++ b/openbb_platform/obbject_extensions/charting/poetry.lock
@@ -787,33 +787,6 @@ files = [
 typing-extensions = {version = ">=4.1.0", markers = "python_version < \"3.11\""}
 
 [[package]]
-name = "narwhals"
-version = "1.26.0"
-description = "Extremely lightweight compatibility layer between dataframe libraries"
-optional = false
-python-versions = ">=3.8"
-groups = ["main"]
-files = [
-    {file = "narwhals-1.26.0-py3-none-any.whl", hash = "sha256:4af8bbdea9e45638bb9a981568a8dfa880e40eb7dcf740d19fd32aea79223c6f"},
-    {file = "narwhals-1.26.0.tar.gz", hash = "sha256:b9d7605bf1d97a9d87783a69748c39150964e2a1ab0e5a6fef3e59e56772639e"},
-]
-
-[package.extras]
-core = ["duckdb", "pandas", "polars", "pyarrow", "pyarrow-stubs"]
-cudf = ["cudf (>=24.10.0)"]
-dask = ["dask[dataframe] (>=2024.8)"]
-dev = ["covdefaults", "hypothesis", "pre-commit", "pytest", "pytest-cov", "pytest-env", "pytest-randomly", "typing-extensions"]
-docs = ["black", "duckdb", "jinja2", "markdown-exec[ansi]", "mkdocs", "mkdocs-autorefs", "mkdocs-material", "mkdocstrings[python]", "pandas", "polars (>=1.0.0)", "pyarrow"]
-duckdb = ["duckdb (>=1.0)"]
-extra = ["scikit-learn"]
-ibis = ["ibis-framework (>=6.0.0)", "packaging", "pyarrow-hotfix", "rich"]
-modin = ["modin"]
-pandas = ["pandas (>=0.25.3)"]
-polars = ["polars (>=0.20.3)"]
-pyarrow = ["pyarrow (>=11.0.0)"]
-pyspark = ["pyspark (>=3.5.0)"]
-
-[[package]]
 name = "nbformat"
 version = "5.10.4"
 description = "The Jupyter Notebook format"
@@ -1109,22 +1082,19 @@ type = ["mypy (>=1.11.2)"]
 
 [[package]]
 name = "plotly"
-version = "6.0.0"
+version = "5.24.1"
 description = "An open-source, interactive data visualization library for Python"
 optional = false
 python-versions = ">=3.8"
 groups = ["main"]
 files = [
-    {file = "plotly-6.0.0-py3-none-any.whl", hash = "sha256:f708871c3a9349a68791ff943a5781b1ec04de7769ea69068adcd9202e57653a"},
-    {file = "plotly-6.0.0.tar.gz", hash = "sha256:c4aad38b8c3d65e4a5e7dd308b084143b9025c2cc9d5317fc1f1d30958db87d3"},
+    {file = "plotly-5.24.1-py3-none-any.whl", hash = "sha256:f67073a1e637eb0dc3e46324d9d51e2fe76e9727c892dde64ddf1e1b51f29089"},
+    {file = "plotly-5.24.1.tar.gz", hash = "sha256:dbc8ac8339d248a4bcc36e08a5659bacfe1b079390b8953533f4eb22169b4bae"},
 ]
 
 [package.dependencies]
-narwhals = ">=1.15.1"
 packaging = "*"
-
-[package.extras]
-express = ["numpy"]
+tenacity = ">=6.2.0"
 
 [[package]]
 name = "posthog"
@@ -1917,6 +1887,22 @@ develop = ["colorama", "cython (>=3.0.10)", "cython (>=3.0.10,<4)", "flake8", "i
 docs = ["ipykernel", "jupyter-client", "matplotlib", "nbconvert", "nbformat", "numpydoc", "pandas-datareader", "sphinx"]
 
 [[package]]
+name = "tenacity"
+version = "9.0.0"
+description = "Retry code until it succeeds"
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "tenacity-9.0.0-py3-none-any.whl", hash = "sha256:93de0c98785b27fcf659856aa9f54bfbd399e29969b0621bc7f762bd441b4539"},
+    {file = "tenacity-9.0.0.tar.gz", hash = "sha256:807f37ca97d62aa361264d497b0e31e92b8027044942bfa756160d908320d73b"},
+]
+
+[package.extras]
+doc = ["reno", "sphinx"]
+test = ["pytest", "tornado (>=4.5)", "typeguard"]
+
+[[package]]
 name = "traitlets"
 version = "5.14.3"
 description = "Traitlets Python configuration system"
@@ -2220,4 +2206,4 @@ pywry = ["pywry"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9,<3.13"
-content-hash = "ead55321d25860744beb058b9812456a1cd3e5be025e5791cf3687651c784ee0"
+content-hash = "aafd177f6d5704ecfc944f53fab6d31417de9aa31c54ecaa5974a90a9b5c5cc5"

--- a/openbb_platform/obbject_extensions/charting/pyproject.toml
+++ b/openbb_platform/obbject_extensions/charting/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-charting"
-version = "2.3.1"
+version = "2.3.2"
 description = "Charting extension for OpenBB"
 authors = ["OpenBB Team <hello@openbb.co>"]
 license = "AGPL-3.0-only"
@@ -11,7 +11,7 @@ packages = [{ include = "openbb_charting" }]
 python = ">=3.9,<3.13"  # scipy forces python <4.0 explicitly
 openbb-core = "^1.4.0"
 pandas-ta-openbb = "^0.4.20"
-plotly = "^6.0.0"
+plotly = "^5.24.1"
 pywry = { version = "^0.6.2", optional = true }
 nbformat = "^5.10.0"
 


### PR DESCRIPTION
1. **Why**?:

    - In Plotly 6, when a Figure is serialized as JSON and converted back to a Figure, the chart may-or-may-not display with the content on the top layer.
    - The "data" is now a different format, something is getting lost in translation while rendering in the browser.
    - I'm pretty sure that I checked for this exact scenario when bumping to V6, and it appears to be some sort of conditional element to it, so I'm not entirely sure why it is like it is.

2. **What**?:

    - Downgrades to 5.24.1 to ensure compatibility and consistent output.
    - Will monitor for changes..

![image](https://github.com/user-attachments/assets/d348a0ca-2557-4a40-bc12-68a3c1f7c2e4)

4. **Testing Done**:

<img width="1538" alt="Screenshot 2025-03-04 at 2 04 28 PM" src="https://github.com/user-attachments/assets/7a51457e-d586-46e7-91c2-bf49bb9e5d9f" />

You can make this chart by adding this to the `user_settings.json`

```json
{
    "defaults": {
        "commands": {
            "/equity/price/historical": {
                "provider": "yfinance",
                "chart": true,
                "chart_params": {
                    "heikin_ashi": true,
                    "indicators": {
                        "sma": {
                            "length": [
                                21,
                                50
                            ]
                        },
                        "ema": {
                            "length": 150
                        }
                    }
                }
            }
        }
    }
}
```

