### PR TITLE
[BugFix] `obb.regulators.sec.filing_headers` Fix Accessing Local Before Assignment

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/models/sec_filing.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/sec_filing.py
@@ -547,6 +547,7 @@ class SecBaseFiling(Data):  # pylint: disable=too-many-instance-attributes
         # pylint: disable=import-outside-toplevel
         from pandas import MultiIndex, to_datetime
 
+        symbols_list: list = []
         try:
             response = self.download_file(self._cover_page_url, True, self._use_cache)
             if not response:
@@ -642,7 +643,7 @@ class SecBaseFiling(Data):  # pylint: disable=too-many-instance-attributes
                     )
                     symbols_dict = dict(zip(symbol_names, trading_symbols))
                     exchanges_dict = dict(zip(symbol_names, exchange_names))
-                    symbols_list: list = []
+
                     for k, v in symbols_dict.items():
                         symbols_list.append(
                             {


### PR DESCRIPTION
1. **Why**?:

    - Filings having no associations with trading symbols were failing because the local was assigned in an indented block.

2. **What**?:

    - Moves the assignment of local to the top of the block.


3. **Impact**:

    - Recreate with a filing like a S-1 - https://www.sec.gov/Archives/edgar/data/2011286/000162828025011468/0001628280-25-011468-index.htm

4. **Testing Done**:

    - After:

<img width="984" alt="Screenshot 2025-03-11 at 8 54 14 AM" src="https://github.com/user-attachments/assets/49732ad7-39de-4d9d-aa05-9fe3a6858bb9" />
