### PR TITLE
[BugFix] Move `showwarning` To Outside `catch_warnings` Context Block

### DIFF
--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -301,6 +301,8 @@ class StaticCommandRunner:
 
         user_settings = execution_context.user_settings
         system_settings = execution_context.system_settings
+        raised_warnings: list = []
+        custom_headers: Optional[dict[str, Any]] = None
 
         try:
             with catch_warnings(record=True) as warning_list:

--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -302,34 +302,34 @@ class StaticCommandRunner:
         user_settings = execution_context.user_settings
         system_settings = execution_context.system_settings
 
-        with catch_warnings(record=True) as warning_list:
-            # If we're on Jupyter we need to pop here because we will lose "chart" after
-            # ParametersBuilder.build. This needs to be fixed in a way that chart is
-            # added to the function signature and shared for jupyter and api
-            # We can check in the router decorator if the given function has a chart
-            # in the charting extension then we add it there. This way we can remove
-            # the chart parameter from the commands.py and package_builder, it will be
-            # added to the function signature in the router decorator
-            chart = kwargs.pop("chart", False)
+        try:
+            with catch_warnings(record=True) as warning_list:
+                # If we're on Jupyter we need to pop here because we will lose "chart" after
+                # ParametersBuilder.build. This needs to be fixed in a way that chart is
+                # added to the function signature and shared for jupyter and api
+                # We can check in the router decorator if the given function has a chart
+                # in the charting extension then we add it there. This way we can remove
+                # the chart parameter from the commands.py and package_builder, it will be
+                # added to the function signature in the router decorator
+                chart = kwargs.pop("chart", False)
 
-            kwargs = ParametersBuilder.build(
-                args=args,
-                execution_context=execution_context,
-                func=func,
-                kwargs=kwargs,
-            )
+                kwargs = ParametersBuilder.build(
+                    args=args,
+                    execution_context=execution_context,
+                    func=func,
+                    kwargs=kwargs,
+                )
 
-            # If we're on the api we need to remove "chart" here because the parameter is added on
-            # commands.py and the function signature does not expect "chart"
-            kwargs.pop("chart", None)
-            # We also pop custom headers
-            model_headers = system_settings.api_settings.custom_headers or {}
-            custom_headers = {
-                name: kwargs.pop(name.replace("-", "_"), default)
-                for name, default in model_headers.items() or {}
-            } or None
+                # If we're on the api we need to remove "chart" here because the parameter is added on
+                # commands.py and the function signature does not expect "chart"
+                kwargs.pop("chart", None)
+                # We also pop custom headers
+                model_headers = system_settings.api_settings.custom_headers or {}
+                custom_headers = {
+                    name: kwargs.pop(name.replace("-", "_"), default)
+                    for name, default in model_headers.items() or {}
+                } or None
 
-            try:
                 obbject = await cls._command(func, kwargs)
                 # The output might be from a router command with 'no_validate=True'
                 # It might be of a different type than OBBject.
@@ -350,32 +350,33 @@ class StaticCommandRunner:
                     if chart and obbject.results:
                         cls._chart(obbject, **kwargs)
 
-                if warning_list:
+                raised_warnings = warning_list if warning_list else []
+        finally:
+            if raised_warnings:
+                if isinstance(obbject, OBBject):
+                    obbject.warnings = []
+                for w in raised_warnings:
                     if isinstance(obbject, OBBject):
-                        obbject.warnings = []
-                    for w in warning_list:
-                        if isinstance(obbject, OBBject):
-                            obbject.warnings.append(cast_warning(w))
-                        if user_settings.preferences.show_warnings:
-                            showwarning(
-                                message=w.message,
-                                category=w.category,
-                                filename=w.filename,
-                                lineno=w.lineno,
-                                file=w.file,
-                                line=w.line,
-                            )
-            finally:
-                ls = LoggingService(system_settings, user_settings)
-                ls.log(
-                    user_settings=user_settings,
-                    system_settings=system_settings,
-                    route=route,
-                    func=func,
-                    kwargs=kwargs,
-                    exec_info=exc_info(),
-                    custom_headers=custom_headers,
-                )
+                        obbject.warnings.append(cast_warning(w))
+                    if user_settings.preferences.show_warnings:
+                        showwarning(
+                            message=w.message,
+                            category=w.category,
+                            filename=w.filename,
+                            lineno=w.lineno,
+                            file=w.file,
+                            line=w.line,
+                        )
+            ls = LoggingService(system_settings, user_settings)
+            ls.log(
+                user_settings=user_settings,
+                system_settings=system_settings,
+                route=route,
+                func=func,
+                kwargs=kwargs,
+                exec_info=exc_info(),
+                custom_headers=custom_headers,
+            )
 
         return obbject
 

--- a/openbb_platform/core/openbb_core/app/model/preferences.py
+++ b/openbb_platform/core/openbb_core/app/model/preferences.py
@@ -22,7 +22,7 @@ class Preferences(BaseModel):
         validate_default=True,
     )
     request_timeout: PositiveInt = 60
-    show_warnings: bool = True
+    show_warnings: bool = False
     table_style: Literal["dark", "light"] = "dark"
     user_styles_directory: str = str(Path.home() / "OpenBBUserData" / "styles" / "user")
 

--- a/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
+++ b/openbb_platform/providers/biztoc/openbb_biztoc/models/world_news.py
@@ -52,7 +52,11 @@ class BiztocWorldNewsData(WorldNewsData):
         # pylint: disable=import-outside-toplevel
         from pandas import to_datetime
 
-        return to_datetime(v).strftime("%Y-%m-%d %H:%M:%S")
+        return (
+            to_datetime(v, utc=True)
+            .tz_convert("America/New_York")
+            .strftime("%Y-%m-%d %H:%M:%S%z")
+        )
 
     @field_validator("title")
     @classmethod
@@ -129,24 +133,9 @@ class BiztocWorldNewsFetcher(
             )
         else:
             url1 = base_url + "news/latest"
-            url2 = base_url + "news/topics"
             response = await amake_request(
                 url1, headers=headers, response_callback=response_callback
             )
-            response2 = await amake_request(
-                url2, headers=headers, response_callback=response_callback
-            )
-            if response2:
-                for topic in response2:
-                    stories = topic.get("stories", [])
-                    if stories:
-                        response.extend(  # type: ignore
-                            {
-                                "text" if k == "body_preview" else k: v
-                                for k, v in story.items()
-                            }
-                            for story in stories
-                        )
 
         return response  # type: ignore
 


### PR DESCRIPTION
1. **Why**?:

    - Resolves #7042
    - Symptoms are a hung interpreter when warnings are cast in `CommandRunner`.
      - Seems to be an issue with Colab, specifically.

2. **What**?:

    - Moves the handling for `showwarning`, and appending the list of warnings to the `OBBject`, to outside of the `catch_warnings` context block.

3. **Impact**:

    - No changes expected.
    - Sets `show_warning` user preference to default as `False`.


4. **Testing Done**:

    - You can test by editing code in a remote Colab environment.
    - Ran the `openbb-core` tests.

![Screenshot 2025-03-11 at 11 01 21 AM](https://github.com/user-attachments/assets/9af99b18-0dcf-4b31-a8f4-ef0e20b5ceef)
