### PR TITLE
[BugFix] Prevent Command Runner From Validating `Depends` Parameters.

### DIFF
--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -174,6 +174,7 @@ class ParametersBuilder:
                 ... if p.default is Parameter.empty else p.default,
             )
             for n, p in sig.parameters.items()
+            if "Depends" not in str(p)
         }
         # We allow extra fields to return with model with 'cc: CommandContext'
         config = ConfigDict(extra="allow", arbitrary_types_allowed=True)
@@ -321,7 +322,7 @@ class StaticCommandRunner:
                     func=func,
                     kwargs=kwargs,
                 )
-
+                kwargs = kwargs if kwargs is not None else {}
                 # If we're on the api we need to remove "chart" here because the parameter is added on
                 # commands.py and the function signature does not expect "chart"
                 kwargs.pop("chart", None)


### PR DESCRIPTION
1. **Why**?:

    - Command runner generates a `key error` when a custom router extension adds a `Depends` positional argument. 
    - After `ParametersBuilder.build`, "kwargs" might be of `NoneType` and the next line creates a `key error` trying to access it like a dictionary.

2. **What**?:

    - Ignore the parameter if "Depends" is in the Annotation.

    - Adds a check on `kwargs` before proceeding with, `kwargs.pop("chart", None)`

3. **Impact**:

    - Impacts custom router extensions, and toolkit extensions.

4. **Testing Done**:

You need to create an OpenBB router extension, or modify one of the existing toolkit extensions to replicate a function with no parameters and a Depends positional argument. 

Before:

<img width="1263" alt="Screenshot 2025-03-15 at 6 00 23 PM" src="https://github.com/user-attachments/assets/d62a1b57-0cfa-47e7-a4c0-f0fa3ac03db9" />

After:

<img width="831" alt="Screenshot 2025-03-15 at 6 02 38 PM" src="https://github.com/user-attachments/assets/657bbe52-63a8-415e-9b61-375d86c87825" />


    - Example: "Validated with historical market data and simulated scenarios."

5. **Reviewer Notes** (optional):

    - Any specific focus areas for review?

    - Example: "Please check algorithm compatibility with existing data models."

6. **Any other information** (optional)
