### PR TITLE
[BugFix] Fixes Docstring Generator Broken By #7066

### DIFF
--- a/.github/scripts/noxfile.py
+++ b/.github/scripts/noxfile.py
@@ -39,9 +39,10 @@ def unit_test_cli(session):
         "python",
         str(PLATFORM_DIR / "dev_install.py"),
         "-e",
-        "all",
+        "--cli",
         external=True,
     )
+    session.run("openbb-build")
     session.install("pytest")
     session.install("pytest-cov")
     session.run("pytest", CLI_TESTS, f"--cov={CLI_DIR}")

--- a/.github/scripts/noxfile.py
+++ b/.github/scripts/noxfile.py
@@ -39,10 +39,9 @@ def unit_test_cli(session):
         "python",
         str(PLATFORM_DIR / "dev_install.py"),
         "-e",
-        "--cli",
+        "all",
         external=True,
     )
-    session.run("openbb-build")
     session.install("pytest")
     session.install("pytest-cov")
     session.run("pytest", CLI_TESTS, f"--cov={CLI_DIR}")

--- a/cli/openbb_cli/argparse_translator/argparse_translator.py
+++ b/cli/openbb_cli/argparse_translator/argparse_translator.py
@@ -198,8 +198,7 @@ class ArgparseTranslator:
             # Special handling for boolean literals
             if all(isinstance(choice, bool) for choice in choices):
                 return bool, ()
-            else:
-                param_type = type(choices[0])  # type: ignore
+            param_type = type(choices[0])  # type: ignore
 
         if type_origin is list:
             param_type = get_args(param_type)[0]
@@ -209,8 +208,7 @@ class ArgparseTranslator:
                 # Special handling for boolean literals in lists
                 if all(isinstance(choice, bool) for choice in choices):
                     return bool, ()
-                else:
-                    param_type = type(choices[0])  # type: ignore
+                param_type = type(choices[0])  # type: ignore
 
         if type_origin is Union:
             union_args = get_args(param_type)
@@ -228,10 +226,9 @@ class ArgparseTranslator:
                 # Check if all choices are boolean
                 if all(isinstance(choice, bool) for choice in literal_choices):
                     return bool, ()
-                else:
-                    # We have Literal types in the Union, use their choices
-                    choices = tuple(literal_choices)
-                    param_type = type(choices[0])  # type: ignore
+                # We have Literal types in the Union, use their choices
+                choices = tuple(literal_choices)
+                param_type = type(choices[0])  # type: ignore
             elif str in union_args:
                 param_type = str
 
@@ -248,8 +245,7 @@ class ArgparseTranslator:
                         # Special handling for boolean literals
                         if all(isinstance(choice, bool) for choice in choices):
                             return bool, ()
-                        else:
-                            param_type = type(choices[0])  # type: ignore
+                        param_type = type(choices[0])  # type: ignore
                 elif len(args) > 1:
                     # Handle Union with multiple types (not just Optional)
                     # Try to extract Literal types again from the filtered args
@@ -262,9 +258,8 @@ class ArgparseTranslator:
                         # Check if all choices are boolean
                         if all(isinstance(choice, bool) for choice in literal_choices):
                             return bool, ()
-                        else:
-                            choices = tuple(set(literal_choices))
-                            param_type = type(choices[0])  # type: ignore
+                        choices = tuple(set(literal_choices))
+                        param_type = type(choices[0])  # type: ignore
 
         # if there are custom choices, override
         custom_choices = self._get_argument_custom_choices(param)

--- a/cli/openbb_cli/argparse_translator/argparse_translator.py
+++ b/cli/openbb_cli/argparse_translator/argparse_translator.py
@@ -219,7 +219,7 @@ class ArgparseTranslator:
                 return bool, ()
 
             # Check if Union contains Literal types and extract all choices
-            literal_choices = []
+            literal_choices: list = []
             for arg in union_args:
                 if get_origin(arg) is Literal:
                     literal_choices.extend(get_args(arg))
@@ -269,7 +269,7 @@ class ArgparseTranslator:
         # if there are custom choices, override
         custom_choices = self._get_argument_custom_choices(param)
         if custom_choices and param_type is not bool:
-            choices = custom_choices
+            choices = tuple(custom_choices)
 
         return param_type, choices
 

--- a/cli/openbb_cli/argparse_translator/argparse_translator.py
+++ b/cli/openbb_cli/argparse_translator/argparse_translator.py
@@ -178,14 +178,13 @@ class ArgparseTranslator:
         """Return the argparse action type for the given parameter."""
         param_type = self.type_hints[param.name]
         type_origin = get_origin(param_type)
-
-        if param_type == bool or (
+        if param_type is bool or (
             type_origin is Union and bool in get_args(param_type)
         ):
             return "store_true"
         return "store"
 
-    def _get_type_and_choices(
+    def _get_type_and_choices(  # noqa: PLR0912 # pylint: disable=too-many-return-statements, too-many-branches, too-many-statements
         self, param: inspect.Parameter
     ) -> Tuple[Type[Any], Tuple[Any, ...]]:
         """Return the type and choices for the given parameter."""
@@ -196,37 +195,81 @@ class ArgparseTranslator:
 
         if type_origin is Literal:
             choices = get_args(param_type)
-            param_type = type(choices[0])  # type: ignore
+            # Special handling for boolean literals
+            if all(isinstance(choice, bool) for choice in choices):
+                return bool, ()
+            else:
+                param_type = type(choices[0])  # type: ignore
 
         if type_origin is list:
             param_type = get_args(param_type)[0]
 
             if get_origin(param_type) is Literal:
                 choices = get_args(param_type)
-                param_type = type(choices[0])  # type: ignore
+                # Special handling for boolean literals in lists
+                if all(isinstance(choice, bool) for choice in choices):
+                    return bool, ()
+                else:
+                    param_type = type(choices[0])  # type: ignore
 
         if type_origin is Union:
             union_args = get_args(param_type)
-            if str in union_args:
+            # Check if Union contains bool type
+            if bool in union_args and (str in union_args or len(union_args) == 2):
+                return bool, ()
+
+            # Check if Union contains Literal types and extract all choices
+            literal_choices = []
+            for arg in union_args:
+                if get_origin(arg) is Literal:
+                    literal_choices.extend(get_args(arg))
+
+            if literal_choices:
+                # Check if all choices are boolean
+                if all(isinstance(choice, bool) for choice in literal_choices):
+                    return bool, ()
+                else:
+                    # We have Literal types in the Union, use their choices
+                    choices = tuple(literal_choices)
+                    param_type = type(choices[0])  # type: ignore
+            elif str in union_args:
                 param_type = str
 
             # check if it's an Optional, which would be a Union with NoneType
             if type(None) in get_args(param_type):
                 # remove NoneType from the args
-                args = [arg for arg in get_args(param_type) if arg != type(None)]
+                args = [arg for arg in get_args(param_type) if arg is not None]
                 # if there is only one arg left, use it
-                if len(args) > 1:
-                    raise ValueError(
-                        "Union with NoneType should have only one type left"
-                    )
-                param_type = args[0]
+                if len(args) == 1:
+                    param_type = args[0]
 
-                if get_origin(param_type) is Literal:
-                    choices = get_args(param_type)
-                    param_type = type(choices[0])  # type: ignore
+                    if get_origin(param_type) is Literal:
+                        choices = get_args(param_type)
+                        # Special handling for boolean literals
+                        if all(isinstance(choice, bool) for choice in choices):
+                            return bool, ()
+                        else:
+                            param_type = type(choices[0])  # type: ignore
+                elif len(args) > 1:
+                    # Handle Union with multiple types (not just Optional)
+                    # Try to extract Literal types again from the filtered args
+                    literal_choices = []
+                    for arg in args:
+                        if get_origin(arg) is Literal:
+                            literal_choices.extend(get_args(arg))
+
+                    if literal_choices:
+                        # Check if all choices are boolean
+                        if all(isinstance(choice, bool) for choice in literal_choices):
+                            return bool, ()
+                        else:
+                            choices = tuple(set(literal_choices))
+                            param_type = type(choices[0])  # type: ignore
 
         # if there are custom choices, override
-        choices = self._get_argument_custom_choices(param) or choices  # type: ignore
+        custom_choices = self._get_argument_custom_choices(param)
+        if custom_choices and param_type is not bool:
+            choices = custom_choices
 
         return param_type, choices
 
@@ -329,13 +372,21 @@ class ArgparseTranslator:
 
             required = not self._param_is_default(param)
 
+            # Get the appropriate action based on the parameter type
+            action = self._get_action_type(param)
+
+            # For boolean parameters with action="store_true", we should not use any choices
+            if param_type is bool:
+                choices = ()
+                action = "store_true"
+
             argument = ArgparseArgumentModel(
                 name=param.name,
                 type=param_type,
                 dest=param.name,
                 default=param.default,
                 required=required,
-                action=self._get_action_type(param),
+                action=action,
                 help=self._get_argument_custom_help(param),
                 nargs=self._get_nargs(param),
                 choices=choices,

--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -210,39 +210,32 @@ def build_api_wrapper(
         )
 
         if defaults:
-            provider_choices = getattr(kwargs.get("provider_choices"), "__dict__", {})
             _provider = defaults.pop("provider", None)
+            standard_params = getattr(
+                kwargs.pop("standard_params", None), "__dict__", {}
+            )
+            extra_params = getattr(kwargs.pop("extra_params", None), "__dict__", {})
 
-            if (
-                _provider
-                and isinstance(_provider, list)
-                and _provider[0] == provider_choices.get("provider")
-            ):
-                standard_params = getattr(
-                    kwargs.pop("standard_params", None), "__dict__", {}
-                )
-                extra_params = getattr(kwargs.pop("extra_params", None), "__dict__", {})
+            if "chart" in defaults:
+                kwargs["chart"] = defaults.pop("chart", False)
 
-                if "chart" in defaults:
-                    kwargs["chart"] = defaults.pop("chart", False)
+            if "chart_params" in defaults:
+                extra_params["chart_params"] = defaults.pop("chart_params", {})
 
-                if "chart_params" in defaults:
-                    extra_params["chart_params"] = defaults.pop("chart_params", {})
+            for k, v in defaults.items():
+                if k in standard_params and standard_params[k] is None:
+                    standard_params[k] = v
+                elif (k in standard_params and standard_params[k] is not None) or (
+                    k in extra_params and extra_params[k] is not None
+                ):
+                    continue
+                elif k not in extra_params or (
+                    k in extra_params and extra_params[k] is None
+                ):
+                    extra_params[k] = v
 
-                for k, v in defaults.items():
-                    if k in standard_params and standard_params[k] is None:
-                        standard_params[k] = v
-                    elif (k in standard_params and standard_params[k] is not None) or (
-                        k in extra_params and extra_params[k] is not None
-                    ):
-                        continue
-                    elif k not in extra_params or (
-                        k in extra_params and extra_params[k] is None
-                    ):
-                        extra_params[k] = v
-
-                kwargs["standard_params"] = standard_params
-                kwargs["extra_params"] = extra_params
+            kwargs["standard_params"] = standard_params
+            kwargs["extra_params"] = extra_params
 
         execute = partial(command_runner.run, path, user_settings)
         output = await execute(*args, **kwargs)

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1,11 +1,11 @@
 """Package Builder Class."""
 
-# pylint: disable=too-many-lines
+# pylint: disable=too-many-lines,too-many-locals,too-many-nested-blocks,too-many-statements,too-many-branches
 import builtins
 import inspect
 import re
 import shutil
-from dataclasses import Field as DCField
+import sys
 from functools import partial
 from inspect import Parameter, _empty, isclass, signature
 from json import dumps, load
@@ -221,7 +221,7 @@ class PackageBuilder:
 
         self.console.log(str(package_path))
         with package_path.open("w", encoding="utf-8", newline="\n") as file:
-            file.write(code.replace("typing.", ""))
+            file.write(code.replace("typing.", "").replace("List", "list"))
 
     @staticmethod
     def _read(path: Path) -> dict:
@@ -308,9 +308,9 @@ class ImportDefinition:
                 continue
 
             # Only include types that have a module and are not builtins
-            if (
-                hasattr(hint_type, "__module__") and hint_type.__module__ != "builtins"
-            ) or (isinstance(hint_type, str)):
+            if ((hasattr(hint_type, "__module__") and
+                hint_type.__module__ != "builtins") or
+                (isinstance(hint_type, str))):
                 new_hint_type_list.append(hint_type)
 
         new_hint_type_list = list(set(new_hint_type_list))
@@ -334,6 +334,14 @@ class ImportDefinition:
 
         for parameter in parameter_map.values():
             hint_type_list.append(parameter.annotation)
+
+            # Extract dependencies from Annotated metadata
+            if isinstance(parameter.annotation, _AnnotatedAlias):
+                for meta in parameter.annotation.__metadata__:
+                    # Check if this is a Depends object
+                    if hasattr(meta, "dependency"):
+                        # Add the dependency function to hint_type_list
+                        hint_type_list.append(meta.dependency)
 
         if return_type:
             hint_type = (
@@ -366,7 +374,11 @@ class ImportDefinition:
                 function_hint_type_list = cls.get_function_hint_type_list(route=route)  # type: ignore
                 hint_type_list.extend(function_hint_type_list)
 
-        hint_type_list = list(set(hint_type_list))
+        hint_type_list = [
+            d
+            for d in list(set(hint_type_list))
+            if d not in [int, list, str, dict, float, set]
+        ]
         return hint_type_list
 
     @classmethod
@@ -391,7 +403,7 @@ class ImportDefinition:
         code += "\nfrom pydantic import BaseModel"
         code += "\nfrom inspect import Parameter"
         code += "\nimport typing"
-        code += "\nfrom typing import TYPE_CHECKING, ForwardRef, List, Dict, Union, Optional, Literal, Any"
+        code += "\nfrom typing import TYPE_CHECKING, ForwardRef, Union, Optional, Literal, Any"
         code += "\nfrom annotated_types import Ge, Le, Gt, Lt"
         code += "\nfrom warnings import warn, simplefilter"
         code += "\nfrom typing_extensions import Annotated, deprecated"
@@ -399,6 +411,8 @@ class ImportDefinition:
         code += "\nfrom openbb_core.app.static.utils.filters import filter_inputs\n"
         code += "\nfrom openbb_core.app.deprecation import OpenBBDeprecationWarning\n"
         code += "\nfrom openbb_core.app.model.field import OpenBBField"
+        code += "\nfrom fastapi import Depends"
+
         module_list = [
             hint_type.__module__ if hasattr(hint_type, "__module__") else hint_type
             for hint_type in hint_type_list
@@ -410,7 +424,72 @@ class ImportDefinition:
         for module in module_list:
             code += f"import {module}\n"
 
-        return code
+        # Group types by module and capture the return types for the imports.
+        module_types: dict = {}
+        for hint_type in hint_type_list:
+            if hasattr(hint_type, "__module__") and hint_type.__module__ != "builtins":
+                module = hint_type.__module__
+
+                # Extract only the base type name without generic parameters
+                if hasattr(hint_type, "__origin__"):
+                    # This is a generic type like List[...] or Dict[...]
+                    type_name = (
+                        hint_type.__origin__.__name__
+                        if hasattr(hint_type.__origin__, "__name__")
+                        else str(hint_type.__origin__)
+                    )
+                else:
+                    # Extract the base name before any square brackets
+                    raw_type_name = getattr(
+                        hint_type,
+                        "__name__",
+                        str(hint_type).rsplit(".", maxsplit=1)[-1],
+                    )
+                    type_name = (
+                        raw_type_name.split("[")[0]
+                        if "[" in raw_type_name
+                        else raw_type_name
+                    )
+
+                # Skip built-in types when adding to typing module
+                if (
+                    module == "typing" and type_name in dir(__builtins__)
+                ) or type_name in ["Dict", "List", "int", int, "float", float]:
+                    continue
+
+                if module not in module_types:
+                    module_types[module] = set()
+                module_types[module].add(type_name)
+
+        # Generate from-import statements for modules with specific types
+        for module, types in sorted(module_types.items()):
+            if len(types) == 1:
+                type_name = next(iter(types))
+                code += f"\nfrom {module} import {type_name}"
+            else:
+                import_types = [
+                    d
+                    for d in sorted(types)
+                    if d
+                    not in [
+                        "Dict",
+                        "List",
+                        "int",
+                        "float",
+                        "str",
+                        "dict",
+                        "list",
+                        "set",
+                    ]
+                ]
+                if import_types:
+                    code += f"\nfrom {module} import ("
+                    for type_name in import_types:
+                        code += f"\n    {type_name},"
+                    code += "\n)"
+                    code += "\n"
+
+        return code + "\n"
 
 
 class ClassDefinition:
@@ -526,15 +605,22 @@ class MethodDefinition:
     @staticmethod
     def get_default(field: FieldInfo):
         """Get the default value of the field."""
-        field_default = getattr(field, "default", None)
-        if field_default is None or field_default is PydanticUndefined:
+        # First check if field has a default attribute at all
+        if not hasattr(field, "default"):
             return Parameter.empty
 
-        default_default = getattr(field_default, "default", None)
-        if default_default is PydanticUndefined or default_default is Ellipsis:
-            return Parameter.empty
+        # Check for Ellipsis directly in field.default
+        if field.default is Ellipsis:
+            return None
 
-        return default_default
+        if hasattr(field, "default") and hasattr(field.default, "default"):
+            default_val = field.default.default
+            if default_val is PydanticUndefined:
+                return Parameter.empty
+            if default_val is Ellipsis:
+                return None
+            return default_val
+        return field.default
 
     @staticmethod
     def get_extra(field: FieldInfo) -> dict:
@@ -572,14 +658,27 @@ class MethodDefinition:
 
     @staticmethod
     def reorder_params(
-        params: Dict[str, Parameter], var_kw: Optional[List[str]] = None
+        params: Dict[str, Parameter],
+        var_kw: Optional[List[str]] = None,
+        for_docstring: bool = False,
     ) -> "OrderedDict[str, Parameter]":
-        """Reorder the params and make sure VAR_KEYWORD come after 'provider."""
+        """Reorder the params based on context.
+
+        For function signatures: provider is placed last (before VAR_KEYWORD)
+        For docstrings: provider is placed first
+        """
         formatted_keys = list(params.keys())
-        for k in ["provider"] + (var_kw or []):
-            if k in formatted_keys:
-                formatted_keys.remove(k)
-                formatted_keys.append(k)
+
+        if for_docstring and "provider" in formatted_keys:
+            # For docstrings: Place "provider" first
+            formatted_keys.remove("provider")
+            formatted_keys.insert(0, "provider")
+        else:
+            # For function signatures: Place "provider" and VAR_KEYWORD at the end
+            for k in ["provider"] + (var_kw or []):
+                if k in formatted_keys:
+                    formatted_keys.remove(k)
+                    formatted_keys.append(k)
 
         od: OrderedDict[str, Parameter] = OrderedDict()
         for k in formatted_keys:
@@ -615,8 +714,13 @@ class MethodDefinition:
                 formatted[name] = Parameter(name="kwargs", kind=Parameter.VAR_KEYWORD)
                 var_kw.append(name)
             elif name == "provider_choices":
-                fields = param.annotation.__args__[0].__dataclass_fields__
-                field = fields["provider"]
+                if param.annotation != Parameter.empty and hasattr(
+                    param.annotation, "__args__"
+                ):
+                    fields = param.annotation.__args__[0].__dataclass_fields__
+                    field = fields["provider"]
+                else:
+                    continue
                 type_ = getattr(field, "type")
                 default_priority = getattr(type_, "__args__")
                 formatted["provider"] = Parameter(
@@ -634,6 +738,7 @@ class MethodDefinition:
                     ],
                     default=None,
                 )
+
             elif MethodDefinition.is_annotated_dc(param.annotation):
                 fields = param.annotation.__args__[0].__dataclass_fields__
                 for field_name, field in fields.items():
@@ -651,6 +756,41 @@ class MethodDefinition:
                         annotation=updated_type,
                         default=default,
                     )
+
+            if isinstance(param.annotation, _AnnotatedAlias):
+                # Specifically look for Depends dependency rather than any annotation
+                has_depends = any(
+                    hasattr(meta, "dependency")
+                    for meta in param.annotation.__metadata__
+                )
+                if has_depends:
+                    continue
+
+                # If not a dependency, process it as a normal parameter
+                new_type = MethodDefinition.get_expanded_type(name)
+                updated_type = (
+                    param.annotation
+                    if new_type is ...
+                    else Union[param.annotation, new_type]
+                )
+
+                metadata = getattr(param.annotation, "__metadata__", [])
+                description = (
+                    getattr(metadata[0], "description", "") if metadata else ""
+                )
+
+                formatted[name] = Parameter(
+                    name=name,
+                    kind=param.kind,
+                    annotation=Annotated[
+                        updated_type,
+                        OpenBBField(
+                            description=description,
+                        ),
+                    ],
+                    default=MethodDefinition.get_default(param),
+                )
+
             else:
                 new_type = MethodDefinition.get_expanded_type(name)
                 if hasattr(new_type, "__constraints__"):
@@ -663,54 +803,158 @@ class MethodDefinition:
                         else Union[param.annotation, new_type]
                     )
 
+                metadata = getattr(param.annotation, "__metadata__", [])
+                description = (
+                    getattr(metadata[0], "description", "") if metadata else ""
+                )
+
                 formatted[name] = Parameter(
                     name=name,
                     kind=param.kind,
-                    annotation=updated_type,
-                    default=param.default,
+                    annotation=Annotated[
+                        updated_type,
+                        OpenBBField(
+                            description=description,
+                        ),
+                    ],
+                    default=MethodDefinition.get_default(param),
                 )
                 if param.kind == Parameter.VAR_KEYWORD:
                     var_kw.append(name)
 
-        return MethodDefinition.reorder_params(params=formatted, var_kw=var_kw)
+        required_params = OrderedDict()
+        optional_params = OrderedDict()
+
+        for name, param in formatted.items():
+            if param.default == Parameter.empty:
+                required_params[name] = param
+            else:
+                optional_params[name] = param
+
+        # Combine them in the correct order
+        ordered_params = OrderedDict(
+            list(required_params.items()) + list(optional_params.items())
+        )
+
+        return MethodDefinition.reorder_params(params=ordered_params, var_kw=var_kw)
 
     @staticmethod
     def add_field_custom_annotations(
         od: OrderedDict[str, Parameter], model_name: Optional[str] = None
     ):
         """Add the field custom description and choices to the param signature as annotations."""
-        if model_name:
-            available_fields: Dict[str, DCField] = (
-                ProviderInterface().params[model_name]["standard"].__dataclass_fields__
+        if not model_name:
+            return
+
+        provider_interface = ProviderInterface()
+
+        # Get fields from standard model
+        try:
+            available_fields = provider_interface.params[model_name][
+                "standard"
+            ].__dataclass_fields__
+            extra_fields = provider_interface.params[model_name][
+                "extra"
+            ].__dataclass_fields__
+        except (KeyError, AttributeError):
+            return
+
+        # Combined fields
+        all_fields: dict = {}
+        all_fields.update(available_fields)
+        all_fields.update(extra_fields)
+
+        for param, value in od.items():
+            if param not in all_fields:
+                continue
+
+            field_default = all_fields[param].default
+            extra = MethodDefinition.get_extra(all_fields[param])
+            choices = getattr(field_default, "json_schema_extra", {}).get("choices", [])
+            description = getattr(field_default, "description", "")
+
+            # Handle provider-specific choices and add them to the description
+            provider_specific: dict = {}
+            for provider, provider_info in extra.items():
+                if isinstance(provider_info, dict) and "choices" in provider_info:
+                    provider_specific[provider] = provider_info["choices"]
+
+            # Add provider-specific choices to description
+            if provider_specific:
+                # Add each provider's choices on a new line
+                for provider, provider_choices in provider_specific.items():
+                    if provider_choices:
+                        choices_str = ", ".join(f"'{c}'" for c in provider_choices)
+                        description += f"\nChoices for {provider}: {choices_str}"
+
+            # Handle multiple_items_allowed
+            multiple_items_providers: list = []
+            for provider, provider_info in extra.items():
+                if (
+                    isinstance(provider_info, dict)
+                    and provider_info.get("multiple_items_allowed")
+                    or (
+                        isinstance(provider_info, list)
+                        and "multiple_items_allowed" in provider_info
+                    )
+                ):
+                    multiple_items_providers.append(provider)
+
+            if (
+                multiple_items_providers
+                and "Multiple comma separated items allowed for provider(s)"
+                not in description
+            ):
+                description += f"\nMultiple items supported by: {', '.join(multiple_items_providers)}"
+
+            # Process the field type - if it's a Union of many Literals, simplify to base type
+            field_type = all_fields[param].type
+            simplified_type = field_type
+
+            # If there are provider-specific choices, try to simplify the type
+            if (
+                provider_specific
+                and hasattr(field_type, "__origin__")
+                and field_type.__origin__ is Union
+            ):
+                # Check if all union members are Literals
+                all_literals = True
+                for arg in field_type.__args__:
+                    if not (hasattr(arg, "__origin__") and arg.__origin__ is Literal):
+                        all_literals = False
+                        break
+
+                if all_literals:
+                    # Find the base type of the literals (usually str or int)
+                    literal_types = set()
+                    for arg in field_type.__args__:
+                        for lit_val in arg.__args__:
+                            literal_types.add(type(lit_val))
+
+                    # If all literals are of the same type, use that type
+                    if len(literal_types) == 1:
+                        simplified_type = next(iter(literal_types))
+
+            # Create field with enhanced description and possibly simplified type
+            field_kwargs = {
+                "description": description,
+            }
+
+            if choices:
+                field_kwargs["choices"] = choices
+
+            new_value = value.replace(
+                annotation=Annotated[
+                    (
+                        simplified_type
+                        if simplified_type != field_type
+                        else value.annotation
+                    ),
+                    OpenBBField(**field_kwargs),
+                ],
             )
 
-            for param, value in od.items():
-                if param not in available_fields:
-                    continue
-
-                field_default = available_fields[param].default
-                choices = getattr(field_default, "json_schema_extra", {}).get(
-                    "choices", []
-                )
-                description = getattr(field_default, "description", "")
-
-                PartialParameter = partial(
-                    OpenBBField,
-                    description=description,
-                )
-
-                new_value = value.replace(
-                    annotation=Annotated[
-                        value.annotation,
-                        (
-                            PartialParameter(choices=choices)
-                            if choices
-                            else PartialParameter()
-                        ),
-                    ],
-                )
-
-                od[param] = new_value
+            od[param] = new_value
 
     @staticmethod
     def build_func_params(formatted_params: OrderedDict[str, Parameter]) -> str:
@@ -729,6 +973,7 @@ class MethodDefinition:
         func_params = func_params.replace("ForwardRef('DataFrame')", "DataFrame")
         func_params = func_params.replace("ForwardRef('Series')", "Series")
         func_params = func_params.replace("ForwardRef('ndarray')", "ndarray")
+        func_params = func_params.replace("Dict", "dict").replace("List", "list")
         return func_params
 
     @staticmethod
@@ -817,12 +1062,37 @@ class MethodDefinition:
         return code
 
     @staticmethod
-    def build_command_method_body(path: str, func: Callable):
+    def build_command_method_body(
+        path: str,
+        func: Callable,
+        formatted_params: Optional[OrderedDict[str, Parameter]] = None,
+    ):
         """Build the command method implementation."""
+        if formatted_params is None:
+            formatted_params = OrderedDict()
+
         sig = signature(func)
         parameter_map = dict(sig.parameters)
         parameter_map.pop("cc", None)
+
+        # Extract dependencies without disrupting other code paths
+        dependency_calls: list = []
+        dependency_names = set()
+
+        # Process dependencies
+        for name, param in parameter_map.items():
+            if isinstance(param.annotation, _AnnotatedAlias):
+                for meta in param.annotation.__metadata__:
+                    if hasattr(meta, "dependency") and meta.dependency is not None:
+                        dependency_func = meta.dependency
+                        func_name = dependency_func.__name__
+                        dependency_calls.append(f"        {name} = {func_name}()")
+                        dependency_names.add(name)
+
         code = ""
+
+        if dependency_calls:
+            code += "\n".join(dependency_calls) + "\n\n"
 
         if CHARTING_INSTALLED and path.replace("/", "_")[1:] in Charting.functions():
             parameter_map["chart"] = Parameter(
@@ -842,9 +1112,21 @@ class MethodDefinition:
         code += "        return self._run(\n"
         code += f"""            "{path}",\n"""
         code += "            **filter_inputs(\n"
+
+        # Check if we already have a kwargs parameter (VAR_KEYWORD) in formatted_params
+        has_kwargs = any(
+            param.kind == Parameter.VAR_KEYWORD for param in formatted_params.values()
+        )
+        has_extra_params = False
+
         for name, param in parameter_map.items():
             if name == "extra_params":
-                fields = param.annotation.__args__[0].__dataclass_fields__
+                has_extra_params = True
+                fields = (
+                    param.annotation.__args__[0].__dataclass_fields__
+                    if hasattr(param.annotation, "__args__")
+                    else param.annotation
+                )
                 values = {k: k for k in fields}
                 for k in values:
                     if extra := MethodDefinition.get_extra(fields[k]):
@@ -878,6 +1160,10 @@ class MethodDefinition:
 
         if MethodDefinition.is_data_processing_function(path):
             code += "                data_processing=True,\n"
+
+        # Add kwargs parameter
+        if has_kwargs and not has_extra_params:
+            code += "                **kwargs,\n"
 
         code += "            )\n"
         code += "        )\n"
@@ -922,7 +1208,96 @@ class MethodDefinition:
         sig = signature(func)
         parameter_map = dict(sig.parameters)
 
+        # Get the function source code and extract filter_inputs parameters
+        additional_params = {}
+        if hasattr(func, "__code__"):
+            try:
+                func_source = inspect.getsource(func)
+
+                # First, find the filter_inputs block to extract parameter names
+                filter_inputs_match = re.search(
+                    r"filter_inputs\(\s*(.*?)\s*\)", func_source, re.DOTALL
+                )
+                if filter_inputs_match:
+                    filter_inputs_text = filter_inputs_match.group(1)
+                    filter_params = re.findall(r"(\w+)=(\w+)", filter_inputs_text)
+
+                    # Then look for parameter definitions in function body
+                    # Find parameters defined with types in comments or actual code
+                    param_defs = re.findall(
+                        r"(\w+)\s*:\s*(\w+)(?:\s*=\s*([^,\n]+))?", func_source
+                    )
+                    param_dict = {
+                        name: (typ, default) for name, typ, default in param_defs
+                    }
+
+                    # Add missing parameters preserving types when available
+                    for param_name, param_value in filter_params:
+                        if (
+                            param_name != param_value
+                            and param_value not in parameter_map
+                            and param_value not in ["True", "False", "None"]
+                        ):
+
+                            # Use type from param_dict if available, otherwise Any
+                            if param_value in param_dict:
+                                param_type = param_dict[param_value][0]
+                                try:
+                                    # Try to evaluate the type
+                                    annotation = (
+                                        eval(  # noqa: S307  # pylint: disable=eval-used
+                                            param_type
+                                        )
+                                    )
+                                except (NameError, SyntaxError):
+                                    annotation = Any
+
+                                # Get default if available
+                                default_str = param_dict[param_value][1]
+                                try:
+                                    default = (
+                                        eval(  # noqa: S307  # pylint: disable=eval-used
+                                            default_str
+                                        )
+                                        if default_str
+                                        else None
+                                    )
+                                except (NameError, SyntaxError):
+                                    default = None
+                            else:
+                                annotation = Any
+                                default = None
+
+                            # Add parameter with preserved type/default
+                            additional_params[param_value] = Parameter(
+                                name=param_value,
+                                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                                annotation=annotation,
+                                default=default,
+                            )
+            except (OSError, TypeError):
+                pass
+
+        # Add missing parameters to parameter_map
+        for name, param in additional_params.items():
+            if name not in parameter_map:
+                parameter_map[name] = param
+
         formatted_params = cls.format_params(path=path, parameter_map=parameter_map)
+
+        has_var_kwargs = any(
+            param.kind == Parameter.VAR_KEYWORD for param in formatted_params.values()
+        )
+
+        # If not, add **kwargs to formatted_params
+        if not has_var_kwargs:
+            formatted_params["kwargs"] = Parameter(
+                name="kwargs",
+                kind=Parameter.VAR_KEYWORD,
+                annotation=Any,
+                default=Parameter.empty,
+            )
+
         code = cls.build_command_method_signature(
             func_name=func_name,
             formatted_params=formatted_params,
@@ -938,7 +1313,9 @@ class MethodDefinition:
             examples=examples,
         )
 
-        code += cls.build_command_method_body(path=path, func=func)
+        code += cls.build_command_method_body(
+            path=path, func=func, formatted_params=formatted_params
+        )
 
         return code
 
@@ -1084,6 +1461,47 @@ class DocstringGenerator:
         def format_type(type_: str, char_limit: Optional[int] = None) -> str:
             """Format type in docstrings."""
             type_str = str(type_)
+
+            # Check if this is a complex union of literals (provider-specific choices)
+            if (
+                "Union[" in type_str
+                and "Literal[" in type_str
+                and type_str.count("Literal[") > 1
+            ):
+                # For complex Union with multiple Literals, simplify to the base type
+                base_types = set()
+
+                # Extract the base types from literals first
+                literal_pattern = r"Literal\['([^']+)'(?:,\s*'[^']+')*\]"
+                for match in re.finditer(literal_pattern, type_str):
+                    if match.group(1):
+                        try:
+                            val = match.group(1)
+                            if val.isdigit():
+                                base_types.add("int")
+                            elif val.isdecimal():
+                                base_types.add("float")
+                            else:
+                                base_types.add("str")
+                        except (IndexError, AttributeError):
+                            pass
+
+                # Also check for explicit types in the Union
+                if "str" in type_str.split("[", maxsplit=1)[0].split(", "):
+                    base_types.add("str")
+                if "int" in type_str.split("[", maxsplit=1)[0].split(", "):
+                    base_types.add("int")
+                if "float" in type_str.split("[", maxsplit=1)[0].split(", "):
+                    base_types.add("float")
+
+                # Use the base types instead of the complex Union[Literal[...]]
+                if base_types:
+                    if len(base_types) == 1:
+                        type_str = next(iter(base_types))
+                    else:
+                        type_str = f"Union[{', '.join(sorted(base_types))}]"
+
+            # Apply the standard formatting
             type_str = (
                 type_str.replace("<class '", "")
                 .replace("'>", "")
@@ -1093,16 +1511,100 @@ class DocstringGenerator:
                 .replace("datetime.date", "date")
                 .replace("datetime.datetime", "datetime")
             )
+
             if char_limit:
                 type_str = type_str[:char_limit] + (
                     "..." if len(str(type_str)) > char_limit else ""
                 )
             return type_str
 
-        def format_description(description: str) -> str:
+        def format_schema_description(description: str) -> str:
             """Format description in docstrings."""
             description = description.replace("\n", f"\n{create_indent(2)}")
             return description
+
+        def format_description(description: str) -> str:
+            """Format description in docstrings with proper indentation for provider choices."""
+            # Handle semicolon-separated provider descriptions
+            if ";" in description and "(provider:" in description:
+                parts = description.split(";")
+                formatted_parts = []
+
+                # Process the first part (main description)
+                first_part = parts[0].strip()
+
+                # Extract the first sentence from the first part
+                first_sentence = ""
+                remainder = ""
+                if "." in first_part:
+                    first_sentence, remainder = first_part.split(".", 1)
+                    first_sentence = first_sentence.strip()
+                    remainder = remainder.strip()
+
+                    # Add the first sentence to formatted_parts
+                    formatted_parts.append(first_sentence)
+
+                    # Add the remainder of the first part with indentation
+                    if remainder:
+                        formatted_parts.append(f"{create_indent(3)}{remainder}")
+                else:
+                    # If no period in the first part, just add it as is
+                    formatted_parts.append(first_part)
+
+                # Process subsequent parts (provider-specific descriptions)
+                for part in parts[1:]:
+                    part = part.strip()  # noqa: PLW2901
+
+                    # Check if this part starts with the same first sentence
+                    if first_sentence and part.startswith(first_sentence.rstrip(".")):
+                        # Skip the repeated sentence and add only what follows
+                        part_remainder = part[len(first_sentence.rstrip(".")) :].strip()
+                        if part_remainder.startswith("."):
+                            part_remainder = part_remainder[1:].strip()
+                        formatted_parts.append(f"{create_indent(3)}{part_remainder}")
+                    else:
+                        # No repetition, add the entire part with indentation
+                        formatted_parts.append(f"{create_indent(3)}{part.strip()}")
+
+                # Join all parts with semicolons
+                description = ";\n".join(formatted_parts)
+
+            # Handle provider-specific choices
+            if "\nChoices for " in description:
+                # Split into main description and provider choices part
+                parts = description.split("\nChoices for ")
+                main_desc = parts[0].rstrip()
+
+                if len(parts) > 1:
+                    formatted_lines = [main_desc]
+
+                    # Add each provider choice line with proper indentation
+                    for choice_line in parts[1:]:
+                        # Check if the line contains a newline character (due to word wrapping)
+                        if "\n" in choice_line:
+                            # Split the choice line at newlines
+                            choice_parts = choice_line.split("\n")
+                            # Add first part with "Choices for" prefix
+                            formatted_lines.append(
+                                f"{create_indent(3)}Choices for {choice_parts[0]}"
+                            )
+
+                            # Add remaining parts with proper indentation
+                            for part in choice_parts[1:]:
+                                if part.strip():  # Skip empty lines
+                                    formatted_lines.append(
+                                        f"{create_indent(4)}{part.strip()}"
+                                    )
+                        else:
+                            # No line breaks in this choice
+                            formatted_lines.append(
+                                f"{create_indent(3)}Choices for {choice_line}"
+                            )
+
+                    return "\n".join(formatted_lines)
+
+            # Standard behavior for other descriptions - add proper indentation to each line
+            return description.replace("\n", f"\n{create_indent(3)}")
 
         def get_param_info(parameter: Optional[Parameter]) -> Tuple[str, str]:
             """Get the parameter info."""
@@ -1121,13 +1623,25 @@ class DocstringGenerator:
             description = getattr(metadata[0], "description", "") if metadata else ""
             return type_, description  # type: ignore
 
+        provider_param: Union[Parameter, dict] = {}
+        chart_param: Union[Parameter, dict] = {}
+
         # Description summary
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")
             docstring += "\n\n"
+
+            provider_param = explicit_params.pop("provider", {})  # type: ignore
+            chart_param = explicit_params.pop("chart", {})  # type: ignore
         if "parameters" in sections:
             docstring += f"{create_indent(2)}Parameters\n"
             docstring += f"{create_indent(2)}----------\n"
+
+            if provider_param:
+                _, description = get_param_info(provider_param)  # type: ignore
+                provider_param._annotation = str  # type: ignore  # pylint: disable=protected-access
+                docstring += f"{create_indent(2)}provider : str\n"
+                docstring += f"{create_indent(3)}{format_description(description)}\n"
 
             # Explicit parameters
             for param_name, param in explicit_params.items():
@@ -1144,13 +1658,96 @@ class DocstringGenerator:
                     if inspect.isclass(p_type)
                     else p_type
                 )
-
+                type_ = format_type(type_)
                 if "NoneType" in str(type_):
                     type_ = f"Optional[{type_}]".replace(", NoneType", "")
 
                 default = getattr(param, "default", "")
                 description = getattr(default, "description", "")
+
+                # Extract provider-specific choices directly from the provider interface
+                if hasattr(p_type, "__origin__") and p_type.__origin__ is Union:
+                    provider_choices = {}
+
+                    # Get the list of providers for this model directly from provider_interface.model_providers
+                    try:
+                        providers = list(
+                            cls.provider_interface.model_providers.get(model_name)
+                            .__dataclass_fields__.get("provider")
+                            .type.__args__
+                        )
+
+                        # For each provider, extract their specific choices for this parameter from the map
+                        for provider in providers:
+                            if provider == "openbb":
+                                continue
+                            try:
+                                # Directly get provider field info from the map structure
+                                provider_field_info = (
+                                    cls.provider_interface.map.get(model_name, {})
+                                    .get(provider, {})
+                                    .get("QueryParams", {})
+                                    .get("fields", {})
+                                    .get(param_name)
+                                )
+
+                                # If the field exists and has a Literal annotation
+                                if (
+                                    provider_field_info
+                                    and hasattr(provider_field_info, "annotation")
+                                    and hasattr(
+                                        provider_field_info.annotation, "__origin__"
+                                    )
+                                    and provider_field_info.annotation.__origin__
+                                    is Literal
+                                ):
+                                    # Extract literal values as provider choices
+                                    provider_choices[provider] = list(
+                                        provider_field_info.annotation.__args__
+                                    )
+                            except (KeyError, AttributeError):
+                                continue
+                    except (AttributeError, KeyError):
+                        pass
+
+                    # Add provider-specific choices to description
+                    for provider, choices in provider_choices.items():
+                        if choices:
+                            # Format choices with word wrapping for readability
+                            formatted_choices = []
+                            line_length = 0
+                            line_limit = 100  # Max line length
+
+                            for i, choice in enumerate(choices):
+                                choice_str = f"'{choice}'"
+
+                                # If adding this choice would exceed line limit, start a new line
+                                if (
+                                    line_length > 0
+                                    and line_length + len(choice_str) + 2 > line_limit
+                                ):
+                                    # End the current line
+                                    formatted_choices.append("\n")
+                                    line_length = 0
+
+                                # Add comma and space if not the first choice in the line
+                                if i > 0 and line_length > 0:
+                                    formatted_choices.append(", ")
+                                    line_length += 2
+
+                                formatted_choices.append(choice_str)
+                                line_length += len(choice_str)
+
+                            choices_str = "".join(formatted_choices)
+
+                            description += f"\nChoices for {provider}: {choices_str}"
+
                 docstring += f"{create_indent(2)}{param_name} : {type_}\n"
+                docstring += f"{create_indent(3)}{format_description(description)}\n"
+
+            if chart_param:
+                _, description = get_param_info(chart_param)  # type: ignore
+                docstring += f"{create_indent(2)}chart : bool\n"
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
         if "returns" in sections:
@@ -1158,8 +1755,9 @@ class DocstringGenerator:
             docstring += "\n"
             docstring += f"{create_indent(2)}Returns\n"
             docstring += f"{create_indent(2)}-------\n"
-            providers, _ = get_param_info(explicit_params.get("provider"))
-            docstring += cls.get_OBBject_description(results_type, providers)
+            _providers, _ = get_param_info(explicit_params.get("provider"))
+            if _providers:
+                docstring += cls.get_OBBject_description(results_type, _providers)
 
             # Schema
             underline = "-" * len(model_name)
@@ -1170,7 +1768,7 @@ class DocstringGenerator:
                 field_type = cls.get_field_type(field.annotation, field.is_required())
                 description = getattr(field, "description", "")
                 docstring += f"{create_indent(2)}{field.alias or name} : {field_type}\n"
-                docstring += f"{create_indent(3)}{format_description(description)}\n"
+                docstring += f"{create_indent(3)}{format_schema_description(description.strip())}\n"
         return docstring
 
     @classmethod
@@ -1298,7 +1896,8 @@ class DocstringGenerator:
         [List, Dict, Tuple], M -> "Union[List[M], Dict[str, M], Tuple[M]]"
         """
         if s := [
-            f"Dict[str, {model}]" if i == "Dict" else f"{i}[{model}]" for i in items
+            f"{i}[str, {model}]" if i.lower() == "dict" else f"{i}[{model}]"
+            for i in items
         ]:
             return f"Union[{', '.join(s)}]" if len(s) > 1 else s[0]
         return model
@@ -1504,9 +2103,23 @@ class ReferenceGenerator:
             # Determine the field type, expanding it if necessary and if params_type is "Parameters"
             field_type = field_info.annotation
             is_required = field_info.is_required()
-            field_type = DocstringGenerator.get_field_type(
+            field_type_str = DocstringGenerator.get_field_type(
                 field_type, is_required, "website"
             )
+
+            # Handle case where field_type_str contains ", optional" suffix
+            if ", optional" in field_type_str:
+                field_type_str = field_type_str.replace(", optional", "")
+                is_required = False
+
+            # Extract metadata from Annotated types
+            field_metadata = {}
+            if hasattr(field_type, "__metadata__"):
+                for meta in field_type.__metadata__:
+                    if hasattr(meta, "description"):
+                        field_metadata["description"] = meta.description
+                    if hasattr(meta, "choices"):
+                        field_metadata["choices"] = meta.choices
 
             cleaned_description = (
                 str(field_info.description)
@@ -1536,19 +2149,19 @@ class ReferenceGenerator:
                     )
                     # Manually setting to List[<field_type>] for multiple items
                     # Should be removed if TYPE_EXPANSION is updated to include this
-                    field_type = f"Union[{field_type}, List[{field_type}]]"
+                    field_type_str = f"Union[{field_type_str}, List[{field_type_str}]]"
             elif field in expanded_types:
                 expanded_type = DocstringGenerator.get_field_type(
                     expanded_types[field], is_required, "website"
                 )
-                field_type = f"Union[{field_type}, {expanded_type}]"
+                field_type_str = f"Union[{field_type_str}, {expanded_type}]"
 
             default_value = "" if field_info.default is PydanticUndefined else field_info.default  # fmt: skip
 
             provider_field_params.append(
                 {
                     "name": field,
-                    "type": field_type,
+                    "type": field_type_str,
                     "description": cleaned_description,
                     "default": default_value,
                     "optional": not is_required,
@@ -1581,7 +2194,7 @@ class ReferenceGenerator:
         obbject_list = [
             {
                 "name": "results",
-                "type": f"List[{model}]",
+                "type": f"list[{model}]",
                 "description": "Serializable results.",
             },
             {
@@ -1591,7 +2204,7 @@ class ReferenceGenerator:
             },
             {
                 "name": "warnings",
-                "type": "Optional[List[Warning_]]",
+                "type": "Optional[list[Warning_]]",
                 "description": "List of warnings.",
             },
             {
@@ -1601,7 +2214,7 @@ class ReferenceGenerator:
             },
             {
                 "name": "extra",
-                "type": "Dict[str, Any]",
+                "type": "dict[str, Any]",
                 "description": "Extra info.",
             },
         ]
@@ -1622,10 +2235,19 @@ class ReferenceGenerator:
         Returns
         -------
         List[Dict[str, str]]
-            List of dictionaries containing the name,type, description, default
+            List of dictionaries containing the name, type, description, default
             and optionality of each parameter.
         """
-        parameters_list = []
+        parameters_list: list = []
+
+        # Extract only the Parameters section (between "Parameters" and "Returns")
+        params_section = ""
+        if "Parameters" in docstring and "Returns" in docstring:
+            params_section = docstring.split("Parameters")[1].split("Returns")[0]
+        elif "Parameters" in docstring:
+            params_section = docstring.split("Parameters")[1]
+        else:
+            return parameters_list  # No parameters section found
 
         # Define a regex pattern to match parameter blocks
         # This pattern looks for a parameter name followed by " : ", then captures the type and description
@@ -1633,8 +2255,8 @@ class ReferenceGenerator:
             r"\n\s*(?P<name>\w+)\s*:\s*(?P<type>[^\n]+?)(?:\s*=\s*(?P<default>[^\n]+))?\n\s*(?P<description>[^\n]+)"
         )
 
-        # Find all matches in the docstring
-        matches = pattern.finditer(docstring)
+        # Find all matches in the parameters section only
+        matches = pattern.finditer(params_section)
 
         if matches:
             # Iterate over the matches to extract details
@@ -1642,19 +2264,32 @@ class ReferenceGenerator:
                 # Extract named groups as a dictionary
                 param_info = match.groupdict()
 
-                # Determine if the parameter is optional
-                is_optional = "Optional" in param_info["type"]
+                # Clean up and process the type string
+                param_type = param_info["type"].strip()
+
+                # Check for ", optional" in type and handle appropriately
+                is_optional = "Optional" in param_type or ", optional" in param_type
+                if ", optional" in param_type:
+                    param_type = param_type.replace(", optional", "")
 
                 # If no default value is captured, set it to an empty string
                 default_value = (
                     param_info["default"] if param_info["default"] is not None else ""
                 )
-
+                param_type = (
+                    str(param_type)
+                    .replace("openbb_core.provider.abstract.data.Data", "Data")
+                    .replace("List", "list")
+                    .replace("Dict", "dict")
+                    .replace("NoneType", "None")
+                )
                 # Create a new dictionary with fields in the desired order
                 param_dict = {
                     "name": param_info["name"],
-                    "type": param_info["type"],
-                    "description": param_info["description"],
+                    "type": ReferenceGenerator._clean_string_values(param_type),
+                    "description": ReferenceGenerator._clean_string_values(
+                        param_info["description"]
+                    ),
                     "default": default_value,
                     "optional": is_optional,
                 }
@@ -1665,7 +2300,174 @@ class ReferenceGenerator:
         return parameters_list
 
     @staticmethod
-    def _get_post_method_returns_info(docstring: str) -> List[Dict[str, str]]:
+    def _clean_string_values(value: Any) -> Any:
+        """Convert double quotes in string values to single quotes and fix type references.
+
+        Parameters
+        ----------
+        value : Any
+            The value to clean
+
+        Returns
+        -------
+        Any
+            The cleaned value
+        """
+        if isinstance(value, str):
+            # Fix fully qualified Data type references
+            value = re.sub(
+                r"List\[openbb_core\.provider\.abstract\.data\.Data\]",
+                "list[Data]",
+                value,
+            )
+            value = re.sub(
+                r"openbb_core\.provider\.abstract\.data\.Data", "Data", value
+            )
+
+            # Handle Literal types specifically
+            if (
+                "Literal[" in value
+                and "]" in value
+                and "'" not in value
+                and '"' not in value
+            ):
+                # Extract the content between Literal[ and ]
+                start_idx = value.find("Literal[") + len("Literal[")
+                end_idx = value.rfind("]")
+                if start_idx < end_idx:
+                    content = value[start_idx:end_idx]
+                    # Add single quotes around each value
+                    values = [f"'{v.strip()}'" for v in content.split(",")]
+                    # Reconstruct the Literal type
+                    return f"Literal[{', '.join(values)}]"
+
+            # Replace capitalized Dict with lowercase dict
+            value = re.sub(r"\bDict\b", "dict", value)
+
+            # Replace capitalized List with lowercase list
+            value = re.sub(r"\bList\b", "list", value)
+
+            # Replace double quotes with single quotes for other strings
+            return value.replace('"', "'")
+        if isinstance(value, dict):
+            return {
+                k: ReferenceGenerator._clean_string_values(v) for k, v in value.items()
+            }
+        if isinstance(value, list):
+            return [ReferenceGenerator._clean_string_values(item) for item in value]
+
+        return value
+
+    @staticmethod
+    def _get_function_signature_info(func: Callable) -> List[Dict[str, Any]]:
+        """Extract parameter information directly from function signature."""
+        params_info = []
+        sig = signature(func)
+
+        for name, param in sig.parameters.items():
+            # Skip 'self' and context parameters
+            if name in ["self", "cc"]:
+                continue
+
+            # Skip parameters with dependency injections through annotations
+            if isinstance(param.annotation, _AnnotatedAlias) and any(
+                hasattr(meta, "dependency") for meta in param.annotation.__metadata__
+            ):
+                continue
+
+            # Skip parameters with Depends in default values
+            if param.default is not Parameter.empty:
+                default_str = str(param.default)
+                if "Depends" in default_str:
+                    continue
+
+            param_type = param.annotation
+            is_optional = False
+            description = ""
+            choices = None
+            default = param.default if param.default is not Parameter.empty else None
+            json_extra = None
+
+            # Check if type is optional
+            if (
+                hasattr(param_type, "__origin__")
+                and param_type.__origin__ is Union
+                and (type(None) in param_type.__args__ or None in param_type.__args__)
+            ):
+                # Check if None or NoneType is in the union
+                is_optional = True
+                # Extract the actual type (excluding None)
+                non_none_args = [
+                    arg
+                    for arg in param_type.__args__
+                    if arg is not type(None) and arg is not None
+                ]
+                if len(non_none_args) == 1:
+                    param_type = non_none_args[0]
+
+            # Process Annotated types to extract metadata
+            if isinstance(param_type, _AnnotatedAlias):
+                base_type = param_type.__args__[0]
+                for meta in param_type.__metadata__:
+                    if hasattr(meta, "description"):
+                        description = meta.description
+                    if hasattr(meta, "choices"):
+                        choices = meta.choices
+                    if hasattr(meta, "default"):
+                        default = meta.default
+                    if hasattr(meta, "json_schema_extra"):
+                        json_extra = meta.json_schema_extra
+                # Set the actual type to the base type
+                param_type = base_type
+
+            # Handle Query objects passed as parameters or default values.
+            if str(default.__class__).endswith("Query'>") or "Query" in str(
+                default.__class__
+            ):
+                param_type = (
+                    param_type.annotation
+                    if hasattr(param_type, "annotation")
+                    else str(param_type)
+                )
+                description = default.description  # type: ignore
+                json_extra = default.json_schema_extra  # type: ignore
+                default = (
+                    default.default  # type: ignore
+                    if default.default  # type: ignore
+                    not in [Parameter.empty, PydanticUndefined, Ellipsis]
+                    else None
+                )
+
+            # Convert type to string representation
+            type_str = str(param_type)
+            # Clean up type string
+            type_str = (
+                type_str.replace("<class '", "")
+                .replace("'>", "")
+                .replace("typing.", "")
+                .replace("NoneType", "None")
+            )
+
+            # Default value makes the parameter optional
+            if default is not None:
+                is_optional = True
+
+            params_info.append(
+                {
+                    "name": name,
+                    "type": ReferenceGenerator._clean_string_values(description),
+                    "description": ReferenceGenerator._clean_string_values(description),
+                    "default": ReferenceGenerator._clean_string_values(default),
+                    "optional": is_optional,
+                    "choices": choices,
+                    "json_schema_extra": json_extra if json_extra else None,
+                }
+            )
+
+        return params_info
+
+    @staticmethod
+    def _get_post_method_returns_info(docstring: str) -> dict:
         """Get the returns information for the POST method endpoints.
 
         Parameters
@@ -1679,7 +2481,7 @@ class ReferenceGenerator:
             Single element list having a dictionary containing the name, type,
             description of the return value
         """
-        returns_list = []
+        returns_dict: dict = {}
 
         # Define a regex pattern to match the Returns section
         # This pattern captures the model name inside "OBBject[]" and its description
@@ -1699,18 +2501,18 @@ class ReferenceGenerator:
                 else return_type
             )
 
-            returns_list = [
-                {
-                    "name": "results",
-                    "type": return_type,
-                    "description": description,
-                }
-            ]
+            returns_dict = {
+                "name": "results",
+                "type": return_type,
+                "description": description,
+            }
 
-        return returns_list
+        return returns_dict
 
     @classmethod
-    def get_paths(cls, route_map: Dict[str, BaseRoute]) -> Dict[str, Dict[str, Any]]:
+    def get_paths(  # noqa: PLR0912
+        cls, route_map: Dict[str, BaseRoute]
+    ) -> Dict[str, Dict[str, Any]]:
         """Get path reference data.
 
         The reference data is a dictionary containing the description, parameters,
@@ -1746,14 +2548,17 @@ class ReferenceGenerator:
                 "message": MethodDefinition.get_deprecation_message(path),
             }
             # Add endpoint examples
-            examples = openapi_extra.get("examples", [])
+            examples = openapi_extra.pop("examples", [])
             reference[path]["examples"] = cls._get_endpoint_examples(
                 path,
                 route_func,
                 examples,  # type: ignore
             )
-            validate_output = not cls.route_map[path].openapi_extra.get("no_validate")
+            validate_output = not openapi_extra.pop("no_validate", None)
             model_map = cls.pi.map.get(standard_model, {})
+            reference[path]["openapi_extra"] = {
+                k: v for k, v in openapi_extra.items() if v
+            }
 
             # Add data for the endpoints having a standard model
             if route_method == {"GET"} and model_map:
@@ -1815,7 +2620,6 @@ class ReferenceGenerator:
                                 ] = None
 
                 # Add endpoint returns data
-                # Currently only OBBject object is returned
                 if validate_output is False:
                     reference[path]["returns"]["Any"] = {
                         "description": "Unvalidated results object.",
@@ -1826,11 +2630,10 @@ class ReferenceGenerator:
                         cls._get_obbject_returns_fields(standard_model, providers)
                     )
             # Add data for the endpoints without a standard model (data processing endpoints)
-            elif (
-                route_method == {"POST"}
-                or "PUT" in str(route_method)
-                or "PATCH" in str(route_method)
-            ) or (route_method == {"GET"} and not model_map):
+            else:
+                # Get function signature information
+                sig_params = cls._get_function_signature_info(route_func)
+
                 # Non-model method's router `description` attribute is unreliable as it may or
                 # may not contain the "Parameters" and "Returns" sections. Hence, the
                 # endpoint function docstring is used instead.
@@ -1842,10 +2645,28 @@ class ReferenceGenerator:
                 description = docstring.split("Parameters")[0].strip()
                 # Remove extra spaces in between the string
                 reference[path]["description"] = re.sub(" +", " ", description)
-                # Add endpoint parameters fields for non-model methods
-                reference[path]["parameters"]["standard"] = (
-                    cls._get_post_method_parameters_info(docstring)
-                )
+
+                # Combine signature parameters with docstring parameters
+                docstring_params = cls._get_post_method_parameters_info(docstring)
+
+                # Create a merged parameter list with signature info taking precedence
+                merged_params: dict = {}
+                for param in docstring_params:
+                    merged_params[param["name"]] = param
+
+                for param in sig_params:
+                    name = param["name"]
+                    if name in merged_params:
+                        # Update existing param with signature info
+                        for key, value in param.items():
+                            if value and not (key == "description" and not value):
+                                merged_params[name][key] = value
+                    else:
+                        merged_params[name] = param
+
+                # Add endpoint parameters fields from the merged info
+                reference[path]["parameters"]["standard"] = list(merged_params.values())
+
                 # Add endpoint returns data
                 # If the endpoint is not validated, the return type is set to Any
                 if validate_output is False:
@@ -1853,32 +2674,375 @@ class ReferenceGenerator:
                         "description": "Unvalidated results object.",
                     }
                 else:
-                    returns_info = cls._get_post_method_returns_info(docstring)
-                    if returns_info and "OBBject" in returns_info[0]["type"]:
-                        reference[path]["returns"]["OBBject"] = returns_info
-                    else:
-                        r_info = returns_info[0] if returns_info else {}
-                        r_type = r_info.pop("type", "Any")
-                        r_info["name"] = None  # type: ignore
-                        if len(returns_info) == 2:
-                            r_info = returns_info[1]
-                        elif len(returns_info) == 1:
-                            r_info["type"] = "Any"
-                        if r_type:
-                            if "[" in r_type:
-                                c_types = r_type.split("[")[1].split("]")[0]
-                                r_type = r_type.split("[")[0]
-                                r_info["type"] = (
-                                    "[" + c_types + "]" if c_types else "Any"
+                    model_fields: list = []
+                    # First try to get from function signature
+                    returns_info = cls._extract_return_type(route_func)
+
+                    if not returns_info:
+                        # Then try to get return info from docstring
+                        returns_info = cls._get_post_method_returns_info(docstring)
+
+                    return_annotation = inspect.signature(route_func).return_annotation
+
+                    is_generic_obbject = (
+                        isinstance(returns_info, dict)
+                        and "OBBject" in returns_info
+                        and any(
+                            item.get("name") == "results" and "Data" in item.get("type")
+                            for item in returns_info.get("OBBject", [])
+                        )
+                    )
+
+                    # Set returns field directly
+                    reference[path]["returns"] = returns_info
+                    reference[path]["model"] = None
+                    reference[path]["data"] = {}
+
+                    if isinstance(returns_info, str) and "[" in returns_info:
+                        # Extract inner type from container type (e.g., "list[ModelName]")
+                        match = re.search(r"\[(.*?)\]", returns_info)
+                        if match:
+                            inner_type_name = match.group(1)
+                            # Try to find the actual model class
+                            for module in sys.modules.values():
+                                if hasattr(module, inner_type_name):
+                                    model_class = getattr(module, inner_type_name)
+                                    if hasattr(model_class, "model_fields"):
+                                        # Found the model class, extract its fields
+                                        model_fields = []
+                                        for (
+                                            field_name,
+                                            field,
+                                        ) in model_class.model_fields.items():
+                                            if field_name.startswith("_"):
+                                                continue
+
+                                            field_type = (
+                                                DocstringGenerator.get_field_type(
+                                                    field.annotation,
+                                                    not field.is_required(),
+                                                    "website",
+                                                )
+                                            )
+
+                                            model_fields.append(
+                                                {
+                                                    "name": field_name,
+                                                    "type": ReferenceGenerator._clean_string_values(
+                                                        field_type
+                                                    ),
+                                                    "description": (
+                                                        ReferenceGenerator._clean_string_values(
+                                                            field.description
+                                                        )
+                                                        if field.description
+                                                        else ""
+                                                    ),
+                                                    "default": (
+                                                        field.default
+                                                        if field.default
+                                                        and field.default
+                                                        != PydanticUndefined
+                                                        else ""
+                                                    ),
+                                                    "optional": not field.is_required(),
+                                                }
+                                            )
+
+                                        if model_fields:
+                                            list_match = re.search(
+                                                r"list\[(.*?)\]", returns_info
+                                            )
+                                            model_name = (
+                                                list_match.group(1)
+                                                if list_match
+                                                else returns_info
+                                            )
+
+                                            reference[path]["data"][
+                                                model_name
+                                            ] = model_fields
+                                        break
+                    # For Pydantic models, extract the fields
+                    elif (
+                        hasattr(return_annotation, "model_fields")
+                        and not is_generic_obbject
+                    ):
+                        for field_name, field in return_annotation.model_fields.items():
+                            # Skip private fields
+                            if field_name.startswith("_"):
+                                continue
+
+                            field_type = DocstringGenerator.get_field_type(
+                                field.annotation, not field.is_required(), "website"
+                            )
+
+                            model_fields.append(
+                                {
+                                    "name": field_name,
+                                    "type": field_type,
+                                    "description": (
+                                        field.description.replace('"', "'")
+                                        if field.description
+                                        else ""
+                                    ),
+                                    "default": (
+                                        field.default
+                                        if field.default
+                                        and field.default != PydanticUndefined
+                                        else ""
+                                    ),
+                                    "optional": field.is_required(),
+                                }
+                            )
+                    # For results field in OBBject returns, check for actual model type
+
+                    if isinstance(returns_info, dict) and "OBBject" in returns_info:
+                        # For OBBject returns, extract model name from results field type
+                        model_name = None
+                        for item in returns_info["OBBject"]:
+                            if item["name"] == "results":
+                                result_type = item["type"]
+                                # Extract model name from result type (e.g., "list[ModelName]" -> "ModelName")
+                                list_match = re.search(r"list\[(.*?)\]", result_type)
+                                model_name = (
+                                    list_match.group(1) if list_match else result_type
                                 )
-                            reference[path]["returns"][r_type] = r_info
-                        else:
-                            reference[path]["returns"] = returns_info
+
+                                # Don't add data fields for generic types like "Data" or if already in parameters
+                                if model_name and model_name != "Data":
+                                    # Try to find the actual model class
+                                    for (
+                                        module_name,  # pylint: disable=unused-variable
+                                        module,
+                                    ) in sys.modules.items():  # noqa: W0612
+                                        if hasattr(module, model_name):
+                                            model_class = getattr(module, model_name)
+                                            if hasattr(model_class, "model_fields"):
+                                                # Found the model class, extract its fields
+                                                model_fields = []
+                                                for (
+                                                    field_name,
+                                                    field,
+                                                ) in model_class.model_fields.items():
+                                                    if field_name.startswith("_"):
+                                                        continue
+
+                                                    field_type = DocstringGenerator.get_field_type(
+                                                        field.annotation,
+                                                        not field.is_required(),
+                                                        "website",
+                                                    )
+
+                                                    model_fields.append(
+                                                        {
+                                                            "name": field_name,
+                                                            "type": field_type,
+                                                            "description": field.description
+                                                            or "",
+                                                            "default": (
+                                                                field.default
+                                                                if field.default
+                                                                != PydanticUndefined
+                                                                else ""
+                                                            ),
+                                                            "optional": not field.is_required(),
+                                                        }
+                                                    )
+
+                                                if model_fields:
+                                                    reference[path]["data"][
+                                                        model_name
+                                                    ] = model_fields
+                                                break
+                                break
+                    elif isinstance(returns_info, str):
+                        # For string return types like "list[YFinanceUdfSearchResult]"
+                        list_match = re.search(r"list\[(.*?)\]", returns_info)
+                        model_name = list_match.group(1) if list_match else returns_info
+
+                        # Skip basic types
+                        if model_name not in (
+                            "str",
+                            "int",
+                            "float",
+                            "bool",
+                            "Any",
+                            "dict",
+                        ):
+                            # Try to find the model class
+                            for module_name, module in sys.modules.items():
+                                if hasattr(module, model_name):
+                                    model_class = getattr(module, model_name)
+                                    if hasattr(model_class, "model_fields"):
+                                        # Found the model class, extract its fields
+                                        model_fields = []
+                                        for (
+                                            field_name,
+                                            field,
+                                        ) in model_class.model_fields.items():
+                                            if field_name.startswith("_"):
+                                                continue
+
+                                            field_type = (
+                                                DocstringGenerator.get_field_type(
+                                                    field.annotation,
+                                                    not field.is_required(),
+                                                    "website",
+                                                )
+                                            )
+
+                                            model_fields.append(
+                                                {
+                                                    "name": field_name,
+                                                    "type": field_type,
+                                                    "description": field.description
+                                                    or "",
+                                                    "default": (
+                                                        field.default
+                                                        if field.default
+                                                        != PydanticUndefined
+                                                        else ""
+                                                    ),
+                                                    "optional": not field.is_required(),
+                                                }
+                                            )
+
+                                        if model_fields:
+                                            reference[path]["data"][
+                                                model_name
+                                            ] = model_fields
+                                        break
+                    else:
+                        # For direct returns that aren't OBBject
+                        model_name = (
+                            return_annotation.__name__
+                            if hasattr(return_annotation, "__name__")
+                            else "Model"
+                        )
+                        reference[path]["data"] = (
+                            {model_name: model_fields} if model_fields else {}
+                        )
 
         return reference
 
+    @staticmethod
+    def _extract_return_type(func: Callable) -> Union[str, dict]:
+        """Extract return type information from function."""
+        return_annotation = inspect.signature(func).return_annotation
+
+        # If no return annotation, or return annotation is inspect.Signature.empty
+        if return_annotation is inspect.Signature.empty:
+            return {"type": "Any"}
+
+        # Check if the return type is an OBBject
+        type_str = str(return_annotation)
+
+        if "OBBject" in type_str or (
+            hasattr(return_annotation, "__name__")
+            and "OBBject" in return_annotation.__name__
+        ):
+            # Extract the model name from docstring or type annotation
+            result_type = "list[Data]"  # Default fallback
+
+            # Try to extract from type annotation first (more reliable)
+            if hasattr(return_annotation, "__origin__") and hasattr(
+                return_annotation, "__args__"
+            ):
+                # For OBBject[SomeType]
+                inner_type = return_annotation.__args__[0]
+                if hasattr(inner_type, "__name__"):
+                    result_type = inner_type.__name__
+                elif hasattr(inner_type, "_name") and inner_type._name:
+                    result_type = inner_type._name
+
+            # If not found, try to extract from docstring
+            if result_type == "list[Data]":
+                docstring = inspect.getdoc(func) or ""
+                if "Returns" in docstring:
+                    returns_section = docstring.split("Returns")[1].split("\n\n")[0]
+                    # Look for model name in docstring
+                    patterns = [
+                        r"OBBject\[(.*?)\]",  # OBBject[Model]
+                        r"results : ([\w\d_]+)",  # results : Model
+                        r"Returns\s+-------\s+(\w+)",  # Direct return type
+                    ]
+
+                    for pattern in patterns:
+                        model_match = re.search(pattern, returns_section)
+                        if model_match:
+                            result_type = model_match.group(1)
+                            break
+
+            # Ensure result_type doesn't already have a container type
+            if "[" in result_type and "]" not in result_type:
+                result_type += "]"  # Add missing closing bracket
+
+            result_type = ReferenceGenerator._clean_string_values(result_type)
+            # Return the standard OBBject structure with correct result type
+            return {
+                "OBBject": [
+                    {
+                        "name": "results",
+                        "type": (
+                            result_type
+                            if "[" in result_type
+                            else f"list[{result_type}]"
+                        ),
+                        "description": "Serializable results.",
+                    },
+                    {"name": "provider", "type": None, "description": "Provider name."},
+                    {
+                        "name": "warnings",
+                        "type": "Optional[list[Warning_]]",
+                        "description": "List of warnings.",
+                    },
+                    {
+                        "name": "chart",
+                        "type": "Optional[Chart]",
+                        "description": "Chart object.",
+                    },
+                    {
+                        "name": "extra",
+                        "type": "dict[str, Any]",
+                        "description": "Extra info.",
+                    },
+                ]
+            }
+
+        # Clean up return type string
+        type_str = (
+            type_str.replace("<class '", "")
+            .replace("'>", "")
+            .replace("typing.", "")
+            .replace("NoneType", "None")
+        )
+
+        # Basic types handling
+        basic_types = ["int", "str", "dict", "bool", "float", "None", "Any"]
+        if type_str.lower() in [t.lower() for t in basic_types]:
+            return type_str.lower()
+
+        # Check for container types with square brackets
+        container_match = re.search(r"(\w+)\[(.*?)\]", type_str)
+        if container_match:
+            container_type = container_match.group(1)
+            inner_type = container_match.group(2)
+
+            inner_type_name = (
+                inner_type.split(".")[-1] if "." in inner_type else inner_type
+            )
+
+            return f"{container_type}[{inner_type_name}]"
+
+        model_name = (
+            type_str.rsplit(".", maxsplit=1)[-1] if "." in type_str else type_str
+        )
+
+        return model_name
+
     @classmethod
-    def get_routers(cls, route_map: Dict[str, BaseRoute]) -> Dict[str, Dict[str, Any]]:
+    def get_routers(cls, route_map: Dict[str, BaseRoute]) -> dict:
         """Get router reference data.
 
         Parameters
@@ -1892,7 +3056,7 @@ class ReferenceGenerator:
             Dictionary containing the description for each router.
         """
         main_router = RouterLoader.from_extensions()
-        routers = {}
+        routers: dict = {}
         for path in route_map:
             path_parts = path.split("/")
             # We start at 2: ["/", "some_router"] "/some_router"

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1617,7 +1617,7 @@ class DocstringGenerator:
             description = getattr(metadata[0], "description", "") if metadata else ""
             return type_, description  # type: ignore
 
-        provider_param: Union[Parameter, dict] = None
+        provider_param: Union[Parameter, dict] = {}
         chart_param: Union[Parameter, dict] = {}
 
         # Description summary

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1481,11 +1481,11 @@ class DocstringGenerator:
                             pass
 
                 # Also check for explicit types in the Union
-                if "str" in type_str.split("[")[0].split(", "):
+                if "str" in type_str.split("[", maxsplit=1)[0].split(", "):
                     base_types.add("str")
-                if "int" in type_str.split("[")[0].split(", "):
+                if "int" in type_str.split("[", maxsplit=1)[0].split(", "):
                     base_types.add("int")
-                if "float" in type_str.split("[")[0].split(", "):
+                if "float" in type_str.split("[", maxsplit=1)[0].split(", "):
                     base_types.add("float")
 
                 # Use the base types instead of the complex Union[Literal[...]]
@@ -1633,7 +1633,7 @@ class DocstringGenerator:
 
             if provider_param:
                 _, description = get_param_info(provider_param)  # type: ignore
-                provider_param._annotation = str  # type: ignore
+                provider_param._annotation = str  # type: ignore  # pylint: disable=protected-access
                 docstring += f"{create_indent(2)}provider : str\n"
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
@@ -2807,7 +2807,7 @@ class ReferenceGenerator:
                                 if model_name and model_name != "Data":
                                     # Try to find the actual model class
                                     for (
-                                        module_name,
+                                        module_name,  # pylint: disable=unused-variable
                                         module,
                                     ) in sys.modules.items():  # noqa: W0612
                                         if hasattr(module, model_name):

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -875,10 +875,6 @@ class MethodDefinition:
 
             # Add provider-specific choices to description
             if provider_specific:
-                # Add a clean break if needed
-                if not description.endswith("."):
-                    description += "."
-
                 # Add each provider's choices on a new line
                 for provider, provider_choices in provider_specific.items():
                     if provider_choices:
@@ -898,9 +894,11 @@ class MethodDefinition:
                 ):
                     multiple_items_providers.append(provider)
 
-            if multiple_items_providers:
-                if not description.endswith("."):
-                    description += "."
+            if (
+                multiple_items_providers
+                and "Multiple comma separated items allowed for provider(s)"
+                not in description
+            ):
                 description += f"\nMultiple items supported by: {', '.join(multiple_items_providers)}"
 
             # Process the field type - if it's a Union of many Literals, simplify to base type

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -2860,28 +2860,23 @@ class ReferenceGenerator:
                         standard_model, "Data", provider
                     )
 
-                    # Remove choices from 'standard' if choices for a parameter exist
-                    # for both standard and provider, and are the same
-                    standard = [
-                        {d["name"]: d["choices"]}
-                        for d in reference[path]["parameters"]["standard"]
-                        if d.get("choices")
-                    ]
-                    standard = standard[0] if standard else []  # type: ignore
-                    _provider = [
-                        {d["name"]: d["choices"]}
-                        for d in reference[path]["parameters"][provider]
-                        if d.get("choices")
-                    ]
-                    _provider = _provider[0] if _provider else []  # type: ignore
-                    if standard and _provider and standard == _provider:
-                        for i, d in enumerate(
-                            reference[path]["parameters"]["standard"]
+                    # Remove choices from standard parameters if they exist in provider-specific parameters
+                    provider_param_names = {
+                        p["name"] for p in reference[path]["parameters"][provider]
+                    }
+
+                    for i, param in enumerate(
+                        reference[path]["parameters"]["standard"]
+                    ):
+                        param_name = param.get("name")
+                        if (
+                            param_name in provider_param_names
+                            and param.get("choices") is not None
                         ):
-                            if d.get("name") in standard:
-                                reference[path]["parameters"]["standard"][i][
-                                    "choices"
-                                ] = None
+                            # This parameter has a provider-specific version, so remove choices from standard
+                            reference[path]["parameters"]["standard"][i][
+                                "choices"
+                            ] = None
 
                 # Add endpoint returns data
                 if validate_output is False:

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1617,6 +1617,9 @@ class DocstringGenerator:
             description = getattr(metadata[0], "description", "") if metadata else ""
             return type_, description  # type: ignore
 
+        provider_param: dict = {}
+        chart_param: dict = {}
+
         # Description summary
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")
@@ -1747,7 +1750,9 @@ class DocstringGenerator:
             docstring += f"{create_indent(2)}Returns\n"
             docstring += f"{create_indent(2)}-------\n"
             providers, _ = get_param_info(explicit_params.get("provider"))
-            docstring += cls.get_OBBject_description(results_type, providers)
+            docstring += cls.get_OBBject_description(
+                results_type, ",".join(providers) if providers else None
+            )
 
             # Schema
             underline = "-" * len(model_name)

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1706,7 +1706,7 @@ class DocstringGenerator:
                     # Check if annotation is an Annotated type
                     if (
                         hasattr(param_annotation, "__origin__")
-                        and param_annotation.__origin__ is Annotated
+                        and param_annotation.__origin__ is Annotated  # type: ignore
                     ):
                         # Extract metadata from annotation
                         metadata = getattr(param_annotation, "__metadata__", [])

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -2686,13 +2686,13 @@ class ReferenceGenerator:
 
                 # Fix: A parameter is optional if it has a default value OR if is_required=False
                 # Currently we're only checking is_required, which is incorrect
-                has_default = hasattr(default, "default") and default.default not in [
+                has_default = hasattr(default, "default") and default.default not in [  # type: ignore
                     Parameter.empty,
                     PydanticUndefined,
                     Ellipsis,
                 ]
                 is_optional = has_default or (
-                    hasattr(default, "is_required") and default.is_required is False
+                    hasattr(default, "is_required") and default.is_required is False  # type: ignore
                 )
 
                 default = (

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1617,23 +1617,23 @@ class DocstringGenerator:
             description = getattr(metadata[0], "description", "") if metadata else ""
             return type_, description  # type: ignore
 
-        provider_param: dict = {}
-        chart_param: dict = {}
+        provider_param: Union[Parameter, dict] = None
+        chart_param: Union[Parameter, dict] = {}
 
         # Description summary
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")
             docstring += "\n\n"
 
-            provider_param = explicit_params.pop("provider", {})
-            chart_param = explicit_params.pop("chart", {})
+            provider_param = explicit_params.pop("provider", {})  # type: ignore
+            chart_param = explicit_params.pop("chart", {})  # type: ignore
         if "parameters" in sections:
             docstring += f"{create_indent(2)}Parameters\n"
             docstring += f"{create_indent(2)}----------\n"
 
             if provider_param:
-                _, description = get_param_info(provider_param)
-                provider_param._annotation = str
+                _, description = get_param_info(provider_param)  # type: ignore
+                provider_param._annotation = str  # type: ignore
                 docstring += f"{create_indent(2)}provider : str\n"
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
@@ -1740,7 +1740,7 @@ class DocstringGenerator:
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
             if chart_param:
-                _, description = get_param_info(chart_param)
+                _, description = get_param_info(chart_param)  # type: ignore
                 docstring += f"{create_indent(2)}chart : bool\n"
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
@@ -1749,10 +1749,9 @@ class DocstringGenerator:
             docstring += "\n"
             docstring += f"{create_indent(2)}Returns\n"
             docstring += f"{create_indent(2)}-------\n"
-            providers, _ = get_param_info(explicit_params.get("provider"))
-            docstring += cls.get_OBBject_description(
-                results_type, ",".join(providers) if providers else None
-            )
+            _providers, _ = get_param_info(explicit_params.get("provider"))
+            if _providers:
+                docstring += cls.get_OBBject_description(results_type, _providers)
 
             # Schema
             underline = "-" * len(model_name)

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1,11 +1,11 @@
 """Package Builder Class."""
 
-# pylint: disable=too-many-lines,too-many-locals,too-many-nested-blocks,too-many-statements,too-many-branches
+# pylint: disable=too-many-lines
 import builtins
 import inspect
 import re
 import shutil
-import sys
+from dataclasses import Field as DCField
 from functools import partial
 from inspect import Parameter, _empty, isclass, signature
 from json import dumps, load
@@ -300,18 +300,20 @@ class ImportDefinition:
     def filter_hint_type_list(hint_type_list: List[Type]) -> List[Type]:
         """Filter the hint type list."""
         new_hint_type_list = []
+        primitive_types = {int, float, str, bool, list, dict, tuple, set}
+
         for hint_type in hint_type_list:
-            if hint_type != _empty and (
-                (
-                    hasattr(hint_type, "__module__")
-                    and hint_type.__module__ != "builtins"
-                )
-                or (isinstance(hint_type, str))
-            ):
+            # Skip primitive types and empty types
+            if hint_type == _empty or hint_type in primitive_types:
+                continue
+
+            # Only include types that have a module and are not builtins
+            if (
+                hasattr(hint_type, "__module__") and hint_type.__module__ != "builtins"
+            ) or (isinstance(hint_type, str)):
                 new_hint_type_list.append(hint_type)
 
         new_hint_type_list = list(set(new_hint_type_list))
-
         return new_hint_type_list
 
     @classmethod
@@ -332,14 +334,6 @@ class ImportDefinition:
 
         for parameter in parameter_map.values():
             hint_type_list.append(parameter.annotation)
-
-            # Extract dependencies from Annotated metadata
-            if isinstance(parameter.annotation, _AnnotatedAlias):
-                for meta in parameter.annotation.__metadata__:
-                    # Check if this is a Depends object
-                    if hasattr(meta, "dependency"):
-                        # Add the dependency function to hint_type_list
-                        hint_type_list.append(meta.dependency)
 
         if return_type:
             hint_type = (
@@ -397,7 +391,7 @@ class ImportDefinition:
         code += "\nfrom pydantic import BaseModel"
         code += "\nfrom inspect import Parameter"
         code += "\nimport typing"
-        code += "\nfrom typing import TYPE_CHECKING, ForwardRef, Union, Optional, Literal, Any"
+        code += "\nfrom typing import TYPE_CHECKING, ForwardRef, List, Dict, Union, Optional, Literal, Any"
         code += "\nfrom annotated_types import Ge, Le, Gt, Lt"
         code += "\nfrom warnings import warn, simplefilter"
         code += "\nfrom typing_extensions import Annotated, deprecated"
@@ -405,8 +399,6 @@ class ImportDefinition:
         code += "\nfrom openbb_core.app.static.utils.filters import filter_inputs\n"
         code += "\nfrom openbb_core.app.deprecation import OpenBBDeprecationWarning\n"
         code += "\nfrom openbb_core.app.model.field import OpenBBField"
-        code += "\nfrom fastapi import Depends"
-
         module_list = [
             hint_type.__module__ if hasattr(hint_type, "__module__") else hint_type
             for hint_type in hint_type_list
@@ -418,72 +410,7 @@ class ImportDefinition:
         for module in module_list:
             code += f"import {module}\n"
 
-        # Group types by module and capture the return types for the imports.
-        module_types: dict = {}
-        for hint_type in hint_type_list:
-            if hasattr(hint_type, "__module__") and hint_type.__module__ != "builtins":
-                module = hint_type.__module__
-
-                # Extract only the base type name without generic parameters
-                if hasattr(hint_type, "__origin__"):
-                    # This is a generic type like List[...] or Dict[...]
-                    type_name = (
-                        hint_type.__origin__.__name__
-                        if hasattr(hint_type.__origin__, "__name__")
-                        else str(hint_type.__origin__)
-                    )
-                else:
-                    # Extract the base name before any square brackets
-                    raw_type_name = getattr(
-                        hint_type,
-                        "__name__",
-                        str(hint_type).rsplit(".", maxsplit=1)[-1],
-                    )
-                    type_name = (
-                        raw_type_name.split("[")[0]
-                        if "[" in raw_type_name
-                        else raw_type_name
-                    )
-
-                # Skip built-in types when adding to typing module
-                if (
-                    module == "typing" and type_name in dir(__builtins__)
-                ) or type_name in ["Dict", "List"]:
-                    continue
-
-                if module not in module_types:
-                    module_types[module] = set()
-                module_types[module].add(type_name)
-
-        # Generate from-import statements for modules with specific types
-        for module, types in sorted(module_types.items()):
-            if len(types) == 1:
-                type_name = next(iter(types))
-                code += f"\nfrom {module} import {type_name}"
-            else:
-                import_types = [
-                    d
-                    for d in sorted(types)
-                    if d
-                    not in [
-                        "Dict",
-                        "List",
-                        "int",
-                        "float",
-                        "str",
-                        "dict",
-                        "list",
-                        "set",
-                    ]
-                ]
-                if import_types:
-                    code += f"\nfrom {module} import ("
-                    for type_name in import_types:
-                        code += f"\n    {type_name},"
-                    code += "\n)"
-                    code += "\n"
-
-        return code + "\n"
+        return code
 
 
 class ClassDefinition:
@@ -599,22 +526,15 @@ class MethodDefinition:
     @staticmethod
     def get_default(field: FieldInfo):
         """Get the default value of the field."""
-        # First check if field has a default attribute at all
-        if not hasattr(field, "default"):
+        field_default = getattr(field, "default", None)
+        if field_default is None or field_default is PydanticUndefined:
             return Parameter.empty
 
-        # Check for Ellipsis directly in field.default
-        if field.default is Ellipsis:
-            return None
+        default_default = getattr(field_default, "default", None)
+        if default_default is PydanticUndefined or default_default is Ellipsis:
+            return Parameter.empty
 
-        if hasattr(field, "default") and hasattr(field.default, "default"):
-            default_val = field.default.default
-            if default_val is PydanticUndefined:
-                return Parameter.empty
-            if default_val is Ellipsis:
-                return None
-            return default_val
-        return field.default
+        return default_default
 
     @staticmethod
     def get_extra(field: FieldInfo) -> dict:
@@ -652,27 +572,14 @@ class MethodDefinition:
 
     @staticmethod
     def reorder_params(
-        params: Dict[str, Parameter],
-        var_kw: Optional[List[str]] = None,
-        for_docstring: bool = False,
+        params: Dict[str, Parameter], var_kw: Optional[List[str]] = None
     ) -> "OrderedDict[str, Parameter]":
-        """Reorder the params based on context.
-
-        For function signatures: provider is placed last (before VAR_KEYWORD)
-        For docstrings: provider is placed first
-        """
+        """Reorder the params and make sure VAR_KEYWORD come after 'provider."""
         formatted_keys = list(params.keys())
-
-        if for_docstring and "provider" in formatted_keys:
-            # For docstrings: Place "provider" first
-            formatted_keys.remove("provider")
-            formatted_keys.insert(0, "provider")
-        else:
-            # For function signatures: Place "provider" and VAR_KEYWORD at the end
-            for k in ["provider"] + (var_kw or []):
-                if k in formatted_keys:
-                    formatted_keys.remove(k)
-                    formatted_keys.append(k)
+        for k in ["provider"] + (var_kw or []):
+            if k in formatted_keys:
+                formatted_keys.remove(k)
+                formatted_keys.append(k)
 
         od: OrderedDict[str, Parameter] = OrderedDict()
         for k in formatted_keys:
@@ -708,13 +615,8 @@ class MethodDefinition:
                 formatted[name] = Parameter(name="kwargs", kind=Parameter.VAR_KEYWORD)
                 var_kw.append(name)
             elif name == "provider_choices":
-                if param.annotation != Parameter.empty and hasattr(
-                    param.annotation, "__args__"
-                ):
-                    fields = param.annotation.__args__[0].__dataclass_fields__
-                    field = fields["provider"]
-                else:
-                    continue
+                fields = param.annotation.__args__[0].__dataclass_fields__
+                field = fields["provider"]
                 type_ = getattr(field, "type")
                 default_priority = getattr(type_, "__args__")
                 formatted["provider"] = Parameter(
@@ -732,7 +634,6 @@ class MethodDefinition:
                     ],
                     default=None,
                 )
-
             elif MethodDefinition.is_annotated_dc(param.annotation):
                 fields = param.annotation.__args__[0].__dataclass_fields__
                 for field_name, field in fields.items():
@@ -750,41 +651,6 @@ class MethodDefinition:
                         annotation=updated_type,
                         default=default,
                     )
-
-            if isinstance(param.annotation, _AnnotatedAlias):
-                # Specifically look for Depends dependency rather than any annotation
-                has_depends = any(
-                    hasattr(meta, "dependency")
-                    for meta in param.annotation.__metadata__
-                )
-                if has_depends:
-                    continue
-
-                # If not a dependency, process it as a normal parameter
-                new_type = MethodDefinition.get_expanded_type(name)
-                updated_type = (
-                    param.annotation
-                    if new_type is ...
-                    else Union[param.annotation, new_type]
-                )
-
-                metadata = getattr(param.annotation, "__metadata__", [])
-                description = (
-                    getattr(metadata[0], "description", "") if metadata else ""
-                )
-
-                formatted[name] = Parameter(
-                    name=name,
-                    kind=param.kind,
-                    annotation=Annotated[
-                        updated_type,
-                        OpenBBField(
-                            description=description,
-                        ),
-                    ],
-                    default=MethodDefinition.get_default(param),
-                )
-
             else:
                 new_type = MethodDefinition.get_expanded_type(name)
                 if hasattr(new_type, "__constraints__"):
@@ -797,158 +663,54 @@ class MethodDefinition:
                         else Union[param.annotation, new_type]
                     )
 
-                metadata = getattr(param.annotation, "__metadata__", [])
-                description = (
-                    getattr(metadata[0], "description", "") if metadata else ""
-                )
-
                 formatted[name] = Parameter(
                     name=name,
                     kind=param.kind,
-                    annotation=Annotated[
-                        updated_type,
-                        OpenBBField(
-                            description=description,
-                        ),
-                    ],
-                    default=MethodDefinition.get_default(param),
+                    annotation=updated_type,
+                    default=param.default,
                 )
                 if param.kind == Parameter.VAR_KEYWORD:
                     var_kw.append(name)
 
-        required_params = OrderedDict()
-        optional_params = OrderedDict()
-
-        for name, param in formatted.items():
-            if param.default == Parameter.empty:
-                required_params[name] = param
-            else:
-                optional_params[name] = param
-
-        # Combine them in the correct order
-        ordered_params = OrderedDict(
-            list(required_params.items()) + list(optional_params.items())
-        )
-
-        return MethodDefinition.reorder_params(params=ordered_params, var_kw=var_kw)
+        return MethodDefinition.reorder_params(params=formatted, var_kw=var_kw)
 
     @staticmethod
     def add_field_custom_annotations(
         od: OrderedDict[str, Parameter], model_name: Optional[str] = None
     ):
         """Add the field custom description and choices to the param signature as annotations."""
-        if not model_name:
-            return
-
-        provider_interface = ProviderInterface()
-
-        # Get fields from standard model
-        try:
-            available_fields = provider_interface.params[model_name][
-                "standard"
-            ].__dataclass_fields__
-            extra_fields = provider_interface.params[model_name][
-                "extra"
-            ].__dataclass_fields__
-        except (KeyError, AttributeError):
-            return
-
-        # Combined fields
-        all_fields: dict = {}
-        all_fields.update(available_fields)
-        all_fields.update(extra_fields)
-
-        for param, value in od.items():
-            if param not in all_fields:
-                continue
-
-            field_default = all_fields[param].default
-            extra = MethodDefinition.get_extra(all_fields[param])
-            choices = getattr(field_default, "json_schema_extra", {}).get("choices", [])
-            description = getattr(field_default, "description", "")
-
-            # Handle provider-specific choices and add them to the description
-            provider_specific: dict = {}
-            for provider, provider_info in extra.items():
-                if isinstance(provider_info, dict) and "choices" in provider_info:
-                    provider_specific[provider] = provider_info["choices"]
-
-            # Add provider-specific choices to description
-            if provider_specific:
-                # Add each provider's choices on a new line
-                for provider, provider_choices in provider_specific.items():
-                    if provider_choices:
-                        choices_str = ", ".join(f"'{c}'" for c in provider_choices)
-                        description += f"\nChoices for {provider}: {choices_str}"
-
-            # Handle multiple_items_allowed
-            multiple_items_providers: list = []
-            for provider, provider_info in extra.items():
-                if (
-                    isinstance(provider_info, dict)
-                    and provider_info.get("multiple_items_allowed")
-                    or (
-                        isinstance(provider_info, list)
-                        and "multiple_items_allowed" in provider_info
-                    )
-                ):
-                    multiple_items_providers.append(provider)
-
-            if (
-                multiple_items_providers
-                and "Multiple comma separated items allowed for provider(s)"
-                not in description
-            ):
-                description += f"\nMultiple items supported by: {', '.join(multiple_items_providers)}"
-
-            # Process the field type - if it's a Union of many Literals, simplify to base type
-            field_type = all_fields[param].type
-            simplified_type = field_type
-
-            # If there are provider-specific choices, try to simplify the type
-            if (
-                provider_specific
-                and hasattr(field_type, "__origin__")
-                and field_type.__origin__ is Union
-            ):
-                # Check if all union members are Literals
-                all_literals = True
-                for arg in field_type.__args__:
-                    if not (hasattr(arg, "__origin__") and arg.__origin__ is Literal):
-                        all_literals = False
-                        break
-
-                if all_literals:
-                    # Find the base type of the literals (usually str or int)
-                    literal_types = set()
-                    for arg in field_type.__args__:
-                        for lit_val in arg.__args__:
-                            literal_types.add(type(lit_val))
-
-                    # If all literals are of the same type, use that type
-                    if len(literal_types) == 1:
-                        simplified_type = next(iter(literal_types))
-
-            # Create field with enhanced description and possibly simplified type
-            field_kwargs = {
-                "description": description,
-            }
-
-            if choices:
-                field_kwargs["choices"] = choices
-
-            new_value = value.replace(
-                annotation=Annotated[
-                    (
-                        simplified_type
-                        if simplified_type != field_type
-                        else value.annotation
-                    ),
-                    OpenBBField(**field_kwargs),
-                ],
+        if model_name:
+            available_fields: Dict[str, DCField] = (
+                ProviderInterface().params[model_name]["standard"].__dataclass_fields__
             )
 
-            od[param] = new_value
+            for param, value in od.items():
+                if param not in available_fields:
+                    continue
+
+                field_default = available_fields[param].default
+                choices = getattr(field_default, "json_schema_extra", {}).get(
+                    "choices", []
+                )
+                description = getattr(field_default, "description", "")
+
+                PartialParameter = partial(
+                    OpenBBField,
+                    description=description,
+                )
+
+                new_value = value.replace(
+                    annotation=Annotated[
+                        value.annotation,
+                        (
+                            PartialParameter(choices=choices)
+                            if choices
+                            else PartialParameter()
+                        ),
+                    ],
+                )
+
+                od[param] = new_value
 
     @staticmethod
     def build_func_params(formatted_params: OrderedDict[str, Parameter]) -> str:
@@ -967,7 +729,6 @@ class MethodDefinition:
         func_params = func_params.replace("ForwardRef('DataFrame')", "DataFrame")
         func_params = func_params.replace("ForwardRef('Series')", "Series")
         func_params = func_params.replace("ForwardRef('ndarray')", "ndarray")
-        func_params = func_params.replace("Dict", "dict").replace("List", "list")
         return func_params
 
     @staticmethod
@@ -1056,37 +817,12 @@ class MethodDefinition:
         return code
 
     @staticmethod
-    def build_command_method_body(
-        path: str,
-        func: Callable,
-        formatted_params: Optional[OrderedDict[str, Parameter]] = None,
-    ):
+    def build_command_method_body(path: str, func: Callable):
         """Build the command method implementation."""
-        if formatted_params is None:
-            formatted_params = OrderedDict()
-
         sig = signature(func)
         parameter_map = dict(sig.parameters)
         parameter_map.pop("cc", None)
-
-        # Extract dependencies without disrupting other code paths
-        dependency_calls: list = []
-        dependency_names = set()
-
-        # Process dependencies
-        for name, param in parameter_map.items():
-            if isinstance(param.annotation, _AnnotatedAlias):
-                for meta in param.annotation.__metadata__:
-                    if hasattr(meta, "dependency") and meta.dependency is not None:
-                        dependency_func = meta.dependency
-                        func_name = dependency_func.__name__
-                        dependency_calls.append(f"        {name} = {func_name}()")
-                        dependency_names.add(name)
-
         code = ""
-
-        if dependency_calls:
-            code += "\n".join(dependency_calls) + "\n\n"
 
         if CHARTING_INSTALLED and path.replace("/", "_")[1:] in Charting.functions():
             parameter_map["chart"] = Parameter(
@@ -1106,21 +842,9 @@ class MethodDefinition:
         code += "        return self._run(\n"
         code += f"""            "{path}",\n"""
         code += "            **filter_inputs(\n"
-
-        # Check if we already have a kwargs parameter (VAR_KEYWORD) in formatted_params
-        has_kwargs = any(
-            param.kind == Parameter.VAR_KEYWORD for param in formatted_params.values()
-        )
-        has_extra_params = False
-
         for name, param in parameter_map.items():
             if name == "extra_params":
-                has_extra_params = True
-                fields = (
-                    param.annotation.__args__[0].__dataclass_fields__
-                    if hasattr(param.annotation, "__args__")
-                    else param.annotation
-                )
+                fields = param.annotation.__args__[0].__dataclass_fields__
                 values = {k: k for k in fields}
                 for k in values:
                     if extra := MethodDefinition.get_extra(fields[k]):
@@ -1154,10 +878,6 @@ class MethodDefinition:
 
         if MethodDefinition.is_data_processing_function(path):
             code += "                data_processing=True,\n"
-
-        # Add kwargs parameter
-        if has_kwargs and not has_extra_params:
-            code += "                **kwargs,\n"
 
         code += "            )\n"
         code += "        )\n"
@@ -1202,96 +922,7 @@ class MethodDefinition:
         sig = signature(func)
         parameter_map = dict(sig.parameters)
 
-        # Get the function source code and extract filter_inputs parameters
-        additional_params = {}
-        if hasattr(func, "__code__"):
-            try:
-                func_source = inspect.getsource(func)
-
-                # First, find the filter_inputs block to extract parameter names
-                filter_inputs_match = re.search(
-                    r"filter_inputs\(\s*(.*?)\s*\)", func_source, re.DOTALL
-                )
-                if filter_inputs_match:
-                    filter_inputs_text = filter_inputs_match.group(1)
-                    filter_params = re.findall(r"(\w+)=(\w+)", filter_inputs_text)
-
-                    # Then look for parameter definitions in function body
-                    # Find parameters defined with types in comments or actual code
-                    param_defs = re.findall(
-                        r"(\w+)\s*:\s*(\w+)(?:\s*=\s*([^,\n]+))?", func_source
-                    )
-                    param_dict = {
-                        name: (typ, default) for name, typ, default in param_defs
-                    }
-
-                    # Add missing parameters preserving types when available
-                    for param_name, param_value in filter_params:
-                        if (
-                            param_name != param_value
-                            and param_value not in parameter_map
-                            and param_value not in ["True", "False", "None"]
-                        ):
-
-                            # Use type from param_dict if available, otherwise Any
-                            if param_value in param_dict:
-                                param_type = param_dict[param_value][0]
-                                try:
-                                    # Try to evaluate the type
-                                    annotation = (
-                                        eval(  # noqa: S307  # pylint: disable=eval-used
-                                            param_type
-                                        )
-                                    )
-                                except (NameError, SyntaxError):
-                                    annotation = Any
-
-                                # Get default if available
-                                default_str = param_dict[param_value][1]
-                                try:
-                                    default = (
-                                        eval(  # noqa: S307  # pylint: disable=eval-used
-                                            default_str
-                                        )
-                                        if default_str
-                                        else None
-                                    )
-                                except (NameError, SyntaxError):
-                                    default = None
-                            else:
-                                annotation = Any
-                                default = None
-
-                            # Add parameter with preserved type/default
-                            additional_params[param_value] = Parameter(
-                                name=param_value,
-                                kind=Parameter.POSITIONAL_OR_KEYWORD,
-                                annotation=annotation,
-                                default=default,
-                            )
-            except (OSError, TypeError):
-                pass
-
-        # Add missing parameters to parameter_map
-        for name, param in additional_params.items():
-            if name not in parameter_map:
-                parameter_map[name] = param
-
         formatted_params = cls.format_params(path=path, parameter_map=parameter_map)
-
-        has_var_kwargs = any(
-            param.kind == Parameter.VAR_KEYWORD for param in formatted_params.values()
-        )
-
-        # If not, add **kwargs to formatted_params
-        if not has_var_kwargs:
-            formatted_params["kwargs"] = Parameter(
-                name="kwargs",
-                kind=Parameter.VAR_KEYWORD,
-                annotation=Any,
-                default=Parameter.empty,
-            )
-
         code = cls.build_command_method_signature(
             func_name=func_name,
             formatted_params=formatted_params,
@@ -1307,9 +938,7 @@ class MethodDefinition:
             examples=examples,
         )
 
-        code += cls.build_command_method_body(
-            path=path, func=func, formatted_params=formatted_params
-        )
+        code += cls.build_command_method_body(path=path, func=func)
 
         return code
 
@@ -1455,47 +1084,6 @@ class DocstringGenerator:
         def format_type(type_: str, char_limit: Optional[int] = None) -> str:
             """Format type in docstrings."""
             type_str = str(type_)
-
-            # Check if this is a complex union of literals (provider-specific choices)
-            if (
-                "Union[" in type_str
-                and "Literal[" in type_str
-                and type_str.count("Literal[") > 1
-            ):
-                # For complex Union with multiple Literals, simplify to the base type
-                base_types = set()
-
-                # Extract the base types from literals first
-                literal_pattern = r"Literal\['([^']+)'(?:,\s*'[^']+')*\]"
-                for match in re.finditer(literal_pattern, type_str):
-                    if match.group(1):
-                        try:
-                            val = match.group(1)
-                            if val.isdigit():
-                                base_types.add("int")
-                            elif val.isdecimal():
-                                base_types.add("float")
-                            else:
-                                base_types.add("str")
-                        except (IndexError, AttributeError):
-                            pass
-
-                # Also check for explicit types in the Union
-                if "str" in type_str.split("[", maxsplit=1)[0].split(", "):
-                    base_types.add("str")
-                if "int" in type_str.split("[", maxsplit=1)[0].split(", "):
-                    base_types.add("int")
-                if "float" in type_str.split("[", maxsplit=1)[0].split(", "):
-                    base_types.add("float")
-
-                # Use the base types instead of the complex Union[Literal[...]]
-                if base_types:
-                    if len(base_types) == 1:
-                        type_str = next(iter(base_types))
-                    else:
-                        type_str = f"Union[{', '.join(sorted(base_types))}]"
-
-            # Apply the standard formatting
             type_str = (
                 type_str.replace("<class '", "")
                 .replace("'>", "")
@@ -1505,100 +1093,16 @@ class DocstringGenerator:
                 .replace("datetime.date", "date")
                 .replace("datetime.datetime", "datetime")
             )
-
             if char_limit:
                 type_str = type_str[:char_limit] + (
                     "..." if len(str(type_str)) > char_limit else ""
                 )
             return type_str
 
-        def format_schema_description(description: str) -> str:
+        def format_description(description: str) -> str:
             """Format description in docstrings."""
             description = description.replace("\n", f"\n{create_indent(2)}")
             return description
-
-        def format_description(description: str) -> str:
-            """Format description in docstrings with proper indentation for provider choices."""
-            # Handle semicolon-separated provider descriptions
-            if ";" in description and "(provider:" in description:
-                parts = description.split(";")
-                formatted_parts = []
-
-                # Process the first part (main description)
-                first_part = parts[0].strip()
-
-                # Extract the first sentence from the first part
-                first_sentence = ""
-                remainder = ""
-                if "." in first_part:
-                    first_sentence, remainder = first_part.split(".", 1)
-                    first_sentence = first_sentence.strip()
-                    remainder = remainder.strip()
-
-                    # Add the first sentence to formatted_parts
-                    formatted_parts.append(first_sentence)
-
-                    # Add the remainder of the first part with indentation
-                    if remainder:
-                        formatted_parts.append(f"{create_indent(3)}{remainder}")
-                else:
-                    # If no period in the first part, just add it as is
-                    formatted_parts.append(first_part)
-
-                # Process subsequent parts (provider-specific descriptions)
-                for part in parts[1:]:
-                    part = part.strip()  # noqa: PLW2901
-
-                    # Check if this part starts with the same first sentence
-                    if first_sentence and part.startswith(first_sentence.rstrip(".")):
-                        # Skip the repeated sentence and add only what follows
-                        part_remainder = part[len(first_sentence.rstrip(".")) :].strip()
-                        if part_remainder.startswith("."):
-                            part_remainder = part_remainder[1:].strip()
-                        formatted_parts.append(f"{create_indent(3)}{part_remainder}")
-                    else:
-                        # No repetition, add the entire part with indentation
-                        formatted_parts.append(f"{create_indent(3)}{part.strip()}")
-
-                # Join all parts with semicolons
-                description = ";\n".join(formatted_parts)
-
-            # Handle provider-specific choices
-            if "\nChoices for " in description:
-                # Split into main description and provider choices part
-                parts = description.split("\nChoices for ")
-                main_desc = parts[0].rstrip()
-
-                if len(parts) > 1:
-                    formatted_lines = [main_desc]
-
-                    # Add each provider choice line with proper indentation
-                    for choice_line in parts[1:]:
-                        # Check if the line contains a newline character (due to word wrapping)
-                        if "\n" in choice_line:
-                            # Split the choice line at newlines
-                            choice_parts = choice_line.split("\n")
-                            # Add first part with "Choices for" prefix
-                            formatted_lines.append(
-                                f"{create_indent(3)}Choices for {choice_parts[0]}"
-                            )
-
-                            # Add remaining parts with proper indentation
-                            for part in choice_parts[1:]:
-                                if part.strip():  # Skip empty lines
-                                    formatted_lines.append(
-                                        f"{create_indent(4)}{part.strip()}"
-                                    )
-                        else:
-                            # No line breaks in this choice
-                            formatted_lines.append(
-                                f"{create_indent(3)}Choices for {choice_line}"
-                            )
-
-                    return "\n".join(formatted_lines)
-
-            # Standard behavior for other descriptions - add proper indentation to each line
-            return description.replace("\n", f"\n{create_indent(3)}")
 
         def get_param_info(parameter: Optional[Parameter]) -> Tuple[str, str]:
             """Get the parameter info."""
@@ -1617,25 +1121,13 @@ class DocstringGenerator:
             description = getattr(metadata[0], "description", "") if metadata else ""
             return type_, description  # type: ignore
 
-        provider_param: Union[Parameter, dict] = {}
-        chart_param: Union[Parameter, dict] = {}
-
         # Description summary
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")
             docstring += "\n\n"
-
-            provider_param = explicit_params.pop("provider", {})  # type: ignore
-            chart_param = explicit_params.pop("chart", {})  # type: ignore
         if "parameters" in sections:
             docstring += f"{create_indent(2)}Parameters\n"
             docstring += f"{create_indent(2)}----------\n"
-
-            if provider_param:
-                _, description = get_param_info(provider_param)  # type: ignore
-                provider_param._annotation = str  # type: ignore  # pylint: disable=protected-access
-                docstring += f"{create_indent(2)}provider : str\n"
-                docstring += f"{create_indent(3)}{format_description(description)}\n"
 
             # Explicit parameters
             for param_name, param in explicit_params.items():
@@ -1652,96 +1144,13 @@ class DocstringGenerator:
                     if inspect.isclass(p_type)
                     else p_type
                 )
-                type_ = format_type(type_)
+
                 if "NoneType" in str(type_):
                     type_ = f"Optional[{type_}]".replace(", NoneType", "")
 
                 default = getattr(param, "default", "")
                 description = getattr(default, "description", "")
-
-                # Extract provider-specific choices directly from the provider interface
-                if hasattr(p_type, "__origin__") and p_type.__origin__ is Union:
-                    provider_choices = {}
-
-                    # Get the list of providers for this model directly from provider_interface.model_providers
-                    try:
-                        providers = list(
-                            cls.provider_interface.model_providers.get(model_name)
-                            .__dataclass_fields__.get("provider")
-                            .type.__args__
-                        )
-
-                        # For each provider, extract their specific choices for this parameter from the map
-                        for provider in providers:
-                            if provider == "openbb":
-                                continue
-                            try:
-                                # Directly get provider field info from the map structure
-                                provider_field_info = (
-                                    cls.provider_interface.map.get(model_name, {})
-                                    .get(provider, {})
-                                    .get("QueryParams", {})
-                                    .get("fields", {})
-                                    .get(param_name)
-                                )
-
-                                # If the field exists and has a Literal annotation
-                                if (
-                                    provider_field_info
-                                    and hasattr(provider_field_info, "annotation")
-                                    and hasattr(
-                                        provider_field_info.annotation, "__origin__"
-                                    )
-                                    and provider_field_info.annotation.__origin__
-                                    is Literal
-                                ):
-                                    # Extract literal values as provider choices
-                                    provider_choices[provider] = list(
-                                        provider_field_info.annotation.__args__
-                                    )
-                            except (KeyError, AttributeError):
-                                continue
-                    except (AttributeError, KeyError):
-                        pass
-
-                    # Add provider-specific choices to description
-                    for provider, choices in provider_choices.items():
-                        if choices:
-                            # Format choices with word wrapping for readability
-                            formatted_choices = []
-                            line_length = 0
-                            line_limit = 100  # Max line length
-
-                            for i, choice in enumerate(choices):
-                                choice_str = f"'{choice}'"
-
-                                # If adding this choice would exceed line limit, start a new line
-                                if (
-                                    line_length > 0
-                                    and line_length + len(choice_str) + 2 > line_limit
-                                ):
-                                    # End the current line
-                                    formatted_choices.append("\n")
-                                    line_length = 0
-
-                                # Add comma and space if not the first choice in the line
-                                if i > 0 and line_length > 0:
-                                    formatted_choices.append(", ")
-                                    line_length += 2
-
-                                formatted_choices.append(choice_str)
-                                line_length += len(choice_str)
-
-                            choices_str = "".join(formatted_choices)
-
-                            description += f"\nChoices for {provider}: {choices_str}"
-
                 docstring += f"{create_indent(2)}{param_name} : {type_}\n"
-                docstring += f"{create_indent(3)}{format_description(description)}\n"
-
-            if chart_param:
-                _, description = get_param_info(chart_param)  # type: ignore
-                docstring += f"{create_indent(2)}chart : bool\n"
                 docstring += f"{create_indent(3)}{format_description(description)}\n"
 
         if "returns" in sections:
@@ -1749,9 +1158,8 @@ class DocstringGenerator:
             docstring += "\n"
             docstring += f"{create_indent(2)}Returns\n"
             docstring += f"{create_indent(2)}-------\n"
-            _providers, _ = get_param_info(explicit_params.get("provider"))
-            if _providers:
-                docstring += cls.get_OBBject_description(results_type, _providers)
+            providers, _ = get_param_info(explicit_params.get("provider"))
+            docstring += cls.get_OBBject_description(results_type, providers)
 
             # Schema
             underline = "-" * len(model_name)
@@ -1762,7 +1170,7 @@ class DocstringGenerator:
                 field_type = cls.get_field_type(field.annotation, field.is_required())
                 description = getattr(field, "description", "")
                 docstring += f"{create_indent(2)}{field.alias or name} : {field_type}\n"
-                docstring += f"{create_indent(3)}{format_schema_description(description.strip())}\n"
+                docstring += f"{create_indent(3)}{format_description(description)}\n"
         return docstring
 
     @classmethod
@@ -1890,8 +1298,7 @@ class DocstringGenerator:
         [List, Dict, Tuple], M -> "Union[List[M], Dict[str, M], Tuple[M]]"
         """
         if s := [
-            f"{i}[str, {model}]" if i.lower() == "dict" else f"{i}[{model}]"
-            for i in items
+            f"Dict[str, {model}]" if i == "Dict" else f"{i}[{model}]" for i in items
         ]:
             return f"Union[{', '.join(s)}]" if len(s) > 1 else s[0]
         return model
@@ -2097,23 +1504,9 @@ class ReferenceGenerator:
             # Determine the field type, expanding it if necessary and if params_type is "Parameters"
             field_type = field_info.annotation
             is_required = field_info.is_required()
-            field_type_str = DocstringGenerator.get_field_type(
+            field_type = DocstringGenerator.get_field_type(
                 field_type, is_required, "website"
             )
-
-            # Handle case where field_type_str contains ", optional" suffix
-            if ", optional" in field_type_str:
-                field_type_str = field_type_str.replace(", optional", "")
-                is_required = False
-
-            # Extract metadata from Annotated types
-            field_metadata = {}
-            if hasattr(field_type, "__metadata__"):
-                for meta in field_type.__metadata__:
-                    if hasattr(meta, "description"):
-                        field_metadata["description"] = meta.description
-                    if hasattr(meta, "choices"):
-                        field_metadata["choices"] = meta.choices
 
             cleaned_description = (
                 str(field_info.description)
@@ -2143,19 +1536,19 @@ class ReferenceGenerator:
                     )
                     # Manually setting to List[<field_type>] for multiple items
                     # Should be removed if TYPE_EXPANSION is updated to include this
-                    field_type_str = f"Union[{field_type_str}, List[{field_type_str}]]"
+                    field_type = f"Union[{field_type}, List[{field_type}]]"
             elif field in expanded_types:
                 expanded_type = DocstringGenerator.get_field_type(
                     expanded_types[field], is_required, "website"
                 )
-                field_type_str = f"Union[{field_type_str}, {expanded_type}]"
+                field_type = f"Union[{field_type}, {expanded_type}]"
 
             default_value = "" if field_info.default is PydanticUndefined else field_info.default  # fmt: skip
 
             provider_field_params.append(
                 {
                     "name": field,
-                    "type": field_type_str,
+                    "type": field_type,
                     "description": cleaned_description,
                     "default": default_value,
                     "optional": not is_required,
@@ -2188,7 +1581,7 @@ class ReferenceGenerator:
         obbject_list = [
             {
                 "name": "results",
-                "type": f"list[{model}]",
+                "type": f"List[{model}]",
                 "description": "Serializable results.",
             },
             {
@@ -2198,7 +1591,7 @@ class ReferenceGenerator:
             },
             {
                 "name": "warnings",
-                "type": "Optional[list[Warning_]]",
+                "type": "Optional[List[Warning_]]",
                 "description": "List of warnings.",
             },
             {
@@ -2208,7 +1601,7 @@ class ReferenceGenerator:
             },
             {
                 "name": "extra",
-                "type": "dict[str, Any]",
+                "type": "Dict[str, Any]",
                 "description": "Extra info.",
             },
         ]
@@ -2229,19 +1622,10 @@ class ReferenceGenerator:
         Returns
         -------
         List[Dict[str, str]]
-            List of dictionaries containing the name, type, description, default
+            List of dictionaries containing the name,type, description, default
             and optionality of each parameter.
         """
-        parameters_list: list = []
-
-        # Extract only the Parameters section (between "Parameters" and "Returns")
-        params_section = ""
-        if "Parameters" in docstring and "Returns" in docstring:
-            params_section = docstring.split("Parameters")[1].split("Returns")[0]
-        elif "Parameters" in docstring:
-            params_section = docstring.split("Parameters")[1]
-        else:
-            return parameters_list  # No parameters section found
+        parameters_list = []
 
         # Define a regex pattern to match parameter blocks
         # This pattern looks for a parameter name followed by " : ", then captures the type and description
@@ -2249,8 +1633,8 @@ class ReferenceGenerator:
             r"\n\s*(?P<name>\w+)\s*:\s*(?P<type>[^\n]+?)(?:\s*=\s*(?P<default>[^\n]+))?\n\s*(?P<description>[^\n]+)"
         )
 
-        # Find all matches in the parameters section only
-        matches = pattern.finditer(params_section)
+        # Find all matches in the docstring
+        matches = pattern.finditer(docstring)
 
         if matches:
             # Iterate over the matches to extract details
@@ -2258,32 +1642,19 @@ class ReferenceGenerator:
                 # Extract named groups as a dictionary
                 param_info = match.groupdict()
 
-                # Clean up and process the type string
-                param_type = param_info["type"].strip()
-
-                # Check for ", optional" in type and handle appropriately
-                is_optional = "Optional" in param_type or ", optional" in param_type
-                if ", optional" in param_type:
-                    param_type = param_type.replace(", optional", "")
+                # Determine if the parameter is optional
+                is_optional = "Optional" in param_info["type"]
 
                 # If no default value is captured, set it to an empty string
                 default_value = (
                     param_info["default"] if param_info["default"] is not None else ""
                 )
-                param_type = (
-                    str(param_type)
-                    .replace("openbb_core.provider.abstract.data.Data", "Data")
-                    .replace("List", "list")
-                    .replace("Dict", "dict")
-                    .replace("NoneType", "None")
-                )
+
                 # Create a new dictionary with fields in the desired order
                 param_dict = {
                     "name": param_info["name"],
-                    "type": ReferenceGenerator._clean_string_values(param_type),
-                    "description": ReferenceGenerator._clean_string_values(
-                        param_info["description"]
-                    ),
+                    "type": param_info["type"],
+                    "description": param_info["description"],
                     "default": default_value,
                     "optional": is_optional,
                 }
@@ -2294,174 +1665,7 @@ class ReferenceGenerator:
         return parameters_list
 
     @staticmethod
-    def _clean_string_values(value: Any) -> Any:
-        """Convert double quotes in string values to single quotes and fix type references.
-
-        Parameters
-        ----------
-        value : Any
-            The value to clean
-
-        Returns
-        -------
-        Any
-            The cleaned value
-        """
-        if isinstance(value, str):
-            # Fix fully qualified Data type references
-            value = re.sub(
-                r"List\[openbb_core\.provider\.abstract\.data\.Data\]",
-                "list[Data]",
-                value,
-            )
-            value = re.sub(
-                r"openbb_core\.provider\.abstract\.data\.Data", "Data", value
-            )
-
-            # Handle Literal types specifically
-            if (
-                "Literal[" in value
-                and "]" in value
-                and "'" not in value
-                and '"' not in value
-            ):
-                # Extract the content between Literal[ and ]
-                start_idx = value.find("Literal[") + len("Literal[")
-                end_idx = value.rfind("]")
-                if start_idx < end_idx:
-                    content = value[start_idx:end_idx]
-                    # Add single quotes around each value
-                    values = [f"'{v.strip()}'" for v in content.split(",")]
-                    # Reconstruct the Literal type
-                    return f"Literal[{', '.join(values)}]"
-
-            # Replace capitalized Dict with lowercase dict
-            value = re.sub(r"\bDict\b", "dict", value)
-
-            # Replace capitalized List with lowercase list
-            value = re.sub(r"\bList\b", "list", value)
-
-            # Replace double quotes with single quotes for other strings
-            return value.replace('"', "'")
-        if isinstance(value, dict):
-            return {
-                k: ReferenceGenerator._clean_string_values(v) for k, v in value.items()
-            }
-        if isinstance(value, list):
-            return [ReferenceGenerator._clean_string_values(item) for item in value]
-
-        return value
-
-    @staticmethod
-    def _get_function_signature_info(func: Callable) -> List[Dict[str, Any]]:
-        """Extract parameter information directly from function signature."""
-        params_info = []
-        sig = signature(func)
-
-        for name, param in sig.parameters.items():
-            # Skip 'self' and context parameters
-            if name in ["self", "cc"]:
-                continue
-
-            # Skip parameters with dependency injections through annotations
-            if isinstance(param.annotation, _AnnotatedAlias) and any(
-                hasattr(meta, "dependency") for meta in param.annotation.__metadata__
-            ):
-                continue
-
-            # Skip parameters with Depends in default values
-            if param.default is not Parameter.empty:
-                default_str = str(param.default)
-                if "Depends" in default_str:
-                    continue
-
-            param_type = param.annotation
-            is_optional = False
-            description = ""
-            choices = None
-            default = param.default if param.default is not Parameter.empty else None
-            json_extra = None
-
-            # Check if type is optional
-            if (
-                hasattr(param_type, "__origin__")
-                and param_type.__origin__ is Union
-                and (type(None) in param_type.__args__ or None in param_type.__args__)
-            ):
-                # Check if None or NoneType is in the union
-                is_optional = True
-                # Extract the actual type (excluding None)
-                non_none_args = [
-                    arg
-                    for arg in param_type.__args__
-                    if arg is not type(None) and arg is not None
-                ]
-                if len(non_none_args) == 1:
-                    param_type = non_none_args[0]
-
-            # Process Annotated types to extract metadata
-            if isinstance(param_type, _AnnotatedAlias):
-                base_type = param_type.__args__[0]
-                for meta in param_type.__metadata__:
-                    if hasattr(meta, "description"):
-                        description = meta.description
-                    if hasattr(meta, "choices"):
-                        choices = meta.choices
-                    if hasattr(meta, "default"):
-                        default = meta.default
-                    if hasattr(meta, "json_schema_extra"):
-                        json_extra = meta.json_schema_extra
-                # Set the actual type to the base type
-                param_type = base_type
-
-            # Handle Query objects passed as parameters or default values.
-            if str(default.__class__).endswith("Query'>") or "Query" in str(
-                default.__class__
-            ):
-                param_type = (
-                    param_type.annotation
-                    if hasattr(param_type, "annotation")
-                    else str(param_type)
-                )
-                description = default.description  # type: ignore
-                json_extra = default.json_schema_extra  # type: ignore
-                default = (
-                    default.default  # type: ignore
-                    if default.default  # type: ignore
-                    not in [Parameter.empty, PydanticUndefined, Ellipsis]
-                    else None
-                )
-
-            # Convert type to string representation
-            type_str = str(param_type)
-            # Clean up type string
-            type_str = (
-                type_str.replace("<class '", "")
-                .replace("'>", "")
-                .replace("typing.", "")
-                .replace("NoneType", "None")
-            )
-
-            # Default value makes the parameter optional
-            if default is not None:
-                is_optional = True
-
-            params_info.append(
-                {
-                    "name": name,
-                    "type": ReferenceGenerator._clean_string_values(description),
-                    "description": ReferenceGenerator._clean_string_values(description),
-                    "default": ReferenceGenerator._clean_string_values(default),
-                    "optional": is_optional,
-                    "choices": choices,
-                    "json_schema_extra": json_extra if json_extra else None,
-                }
-            )
-
-        return params_info
-
-    @staticmethod
-    def _get_post_method_returns_info(docstring: str) -> dict:
+    def _get_post_method_returns_info(docstring: str) -> List[Dict[str, str]]:
         """Get the returns information for the POST method endpoints.
 
         Parameters
@@ -2475,7 +1679,7 @@ class ReferenceGenerator:
             Single element list having a dictionary containing the name, type,
             description of the return value
         """
-        returns_dict: dict = {}
+        returns_list = []
 
         # Define a regex pattern to match the Returns section
         # This pattern captures the model name inside "OBBject[]" and its description
@@ -2495,18 +1699,18 @@ class ReferenceGenerator:
                 else return_type
             )
 
-            returns_dict = {
-                "name": "results",
-                "type": return_type,
-                "description": description,
-            }
+            returns_list = [
+                {
+                    "name": "results",
+                    "type": return_type,
+                    "description": description,
+                }
+            ]
 
-        return returns_dict
+        return returns_list
 
     @classmethod
-    def get_paths(  # noqa: PLR0912
-        cls, route_map: Dict[str, BaseRoute]
-    ) -> Dict[str, Dict[str, Any]]:
+    def get_paths(cls, route_map: Dict[str, BaseRoute]) -> Dict[str, Dict[str, Any]]:
         """Get path reference data.
 
         The reference data is a dictionary containing the description, parameters,
@@ -2542,17 +1746,14 @@ class ReferenceGenerator:
                 "message": MethodDefinition.get_deprecation_message(path),
             }
             # Add endpoint examples
-            examples = openapi_extra.pop("examples", [])
+            examples = openapi_extra.get("examples", [])
             reference[path]["examples"] = cls._get_endpoint_examples(
                 path,
                 route_func,
                 examples,  # type: ignore
             )
-            validate_output = not openapi_extra.pop("no_validate", None)
+            validate_output = not cls.route_map[path].openapi_extra.get("no_validate")
             model_map = cls.pi.map.get(standard_model, {})
-            reference[path]["openapi_extra"] = {
-                k: v for k, v in openapi_extra.items() if v
-            }
 
             # Add data for the endpoints having a standard model
             if route_method == {"GET"} and model_map:
@@ -2614,6 +1815,7 @@ class ReferenceGenerator:
                                 ] = None
 
                 # Add endpoint returns data
+                # Currently only OBBject object is returned
                 if validate_output is False:
                     reference[path]["returns"]["Any"] = {
                         "description": "Unvalidated results object.",
@@ -2624,10 +1826,11 @@ class ReferenceGenerator:
                         cls._get_obbject_returns_fields(standard_model, providers)
                     )
             # Add data for the endpoints without a standard model (data processing endpoints)
-            else:
-                # Get function signature information
-                sig_params = cls._get_function_signature_info(route_func)
-
+            elif (
+                route_method == {"POST"}
+                or "PUT" in str(route_method)
+                or "PATCH" in str(route_method)
+            ) or (route_method == {"GET"} and not model_map):
                 # Non-model method's router `description` attribute is unreliable as it may or
                 # may not contain the "Parameters" and "Returns" sections. Hence, the
                 # endpoint function docstring is used instead.
@@ -2639,28 +1842,10 @@ class ReferenceGenerator:
                 description = docstring.split("Parameters")[0].strip()
                 # Remove extra spaces in between the string
                 reference[path]["description"] = re.sub(" +", " ", description)
-
-                # Combine signature parameters with docstring parameters
-                docstring_params = cls._get_post_method_parameters_info(docstring)
-
-                # Create a merged parameter list with signature info taking precedence
-                merged_params: dict = {}
-                for param in docstring_params:
-                    merged_params[param["name"]] = param
-
-                for param in sig_params:
-                    name = param["name"]
-                    if name in merged_params:
-                        # Update existing param with signature info
-                        for key, value in param.items():
-                            if value and not (key == "description" and not value):
-                                merged_params[name][key] = value
-                    else:
-                        merged_params[name] = param
-
-                # Add endpoint parameters fields from the merged info
-                reference[path]["parameters"]["standard"] = list(merged_params.values())
-
+                # Add endpoint parameters fields for non-model methods
+                reference[path]["parameters"]["standard"] = (
+                    cls._get_post_method_parameters_info(docstring)
+                )
                 # Add endpoint returns data
                 # If the endpoint is not validated, the return type is set to Any
                 if validate_output is False:
@@ -2668,375 +1853,32 @@ class ReferenceGenerator:
                         "description": "Unvalidated results object.",
                     }
                 else:
-                    model_fields: list = []
-                    # First try to get from function signature
-                    returns_info = cls._extract_return_type(route_func)
-
-                    if not returns_info:
-                        # Then try to get return info from docstring
-                        returns_info = cls._get_post_method_returns_info(docstring)
-
-                    return_annotation = inspect.signature(route_func).return_annotation
-
-                    is_generic_obbject = (
-                        isinstance(returns_info, dict)
-                        and "OBBject" in returns_info
-                        and any(
-                            item.get("name") == "results" and "Data" in item.get("type")
-                            for item in returns_info.get("OBBject", [])
-                        )
-                    )
-
-                    # Set returns field directly
-                    reference[path]["returns"] = returns_info
-                    reference[path]["model"] = None
-                    reference[path]["data"] = {}
-
-                    if isinstance(returns_info, str) and "[" in returns_info:
-                        # Extract inner type from container type (e.g., "list[ModelName]")
-                        match = re.search(r"\[(.*?)\]", returns_info)
-                        if match:
-                            inner_type_name = match.group(1)
-                            # Try to find the actual model class
-                            for module in sys.modules.values():
-                                if hasattr(module, inner_type_name):
-                                    model_class = getattr(module, inner_type_name)
-                                    if hasattr(model_class, "model_fields"):
-                                        # Found the model class, extract its fields
-                                        model_fields = []
-                                        for (
-                                            field_name,
-                                            field,
-                                        ) in model_class.model_fields.items():
-                                            if field_name.startswith("_"):
-                                                continue
-
-                                            field_type = (
-                                                DocstringGenerator.get_field_type(
-                                                    field.annotation,
-                                                    not field.is_required(),
-                                                    "website",
-                                                )
-                                            )
-
-                                            model_fields.append(
-                                                {
-                                                    "name": field_name,
-                                                    "type": ReferenceGenerator._clean_string_values(
-                                                        field_type
-                                                    ),
-                                                    "description": (
-                                                        ReferenceGenerator._clean_string_values(
-                                                            field.description
-                                                        )
-                                                        if field.description
-                                                        else ""
-                                                    ),
-                                                    "default": (
-                                                        field.default
-                                                        if field.default
-                                                        and field.default
-                                                        != PydanticUndefined
-                                                        else ""
-                                                    ),
-                                                    "optional": not field.is_required(),
-                                                }
-                                            )
-
-                                        if model_fields:
-                                            list_match = re.search(
-                                                r"list\[(.*?)\]", returns_info
-                                            )
-                                            model_name = (
-                                                list_match.group(1)
-                                                if list_match
-                                                else returns_info
-                                            )
-
-                                            reference[path]["data"][
-                                                model_name
-                                            ] = model_fields
-                                        break
-                    # For Pydantic models, extract the fields
-                    elif (
-                        hasattr(return_annotation, "model_fields")
-                        and not is_generic_obbject
-                    ):
-                        for field_name, field in return_annotation.model_fields.items():
-                            # Skip private fields
-                            if field_name.startswith("_"):
-                                continue
-
-                            field_type = DocstringGenerator.get_field_type(
-                                field.annotation, not field.is_required(), "website"
-                            )
-
-                            model_fields.append(
-                                {
-                                    "name": field_name,
-                                    "type": field_type,
-                                    "description": (
-                                        field.description.replace('"', "'")
-                                        if field.description
-                                        else ""
-                                    ),
-                                    "default": (
-                                        field.default
-                                        if field.default
-                                        and field.default != PydanticUndefined
-                                        else ""
-                                    ),
-                                    "optional": field.is_required(),
-                                }
-                            )
-                    # For results field in OBBject returns, check for actual model type
-
-                    if isinstance(returns_info, dict) and "OBBject" in returns_info:
-                        # For OBBject returns, extract model name from results field type
-                        model_name = None
-                        for item in returns_info["OBBject"]:
-                            if item["name"] == "results":
-                                result_type = item["type"]
-                                # Extract model name from result type (e.g., "list[ModelName]" -> "ModelName")
-                                list_match = re.search(r"list\[(.*?)\]", result_type)
-                                model_name = (
-                                    list_match.group(1) if list_match else result_type
-                                )
-
-                                # Don't add data fields for generic types like "Data" or if already in parameters
-                                if model_name and model_name != "Data":
-                                    # Try to find the actual model class
-                                    for (
-                                        module_name,  # pylint: disable=unused-variable
-                                        module,
-                                    ) in sys.modules.items():  # noqa: W0612
-                                        if hasattr(module, model_name):
-                                            model_class = getattr(module, model_name)
-                                            if hasattr(model_class, "model_fields"):
-                                                # Found the model class, extract its fields
-                                                model_fields = []
-                                                for (
-                                                    field_name,
-                                                    field,
-                                                ) in model_class.model_fields.items():
-                                                    if field_name.startswith("_"):
-                                                        continue
-
-                                                    field_type = DocstringGenerator.get_field_type(
-                                                        field.annotation,
-                                                        not field.is_required(),
-                                                        "website",
-                                                    )
-
-                                                    model_fields.append(
-                                                        {
-                                                            "name": field_name,
-                                                            "type": field_type,
-                                                            "description": field.description
-                                                            or "",
-                                                            "default": (
-                                                                field.default
-                                                                if field.default
-                                                                != PydanticUndefined
-                                                                else ""
-                                                            ),
-                                                            "optional": not field.is_required(),
-                                                        }
-                                                    )
-
-                                                if model_fields:
-                                                    reference[path]["data"][
-                                                        model_name
-                                                    ] = model_fields
-                                                break
-                                break
-                    elif isinstance(returns_info, str):
-                        # For string return types like "list[YFinanceUdfSearchResult]"
-                        list_match = re.search(r"list\[(.*?)\]", returns_info)
-                        model_name = list_match.group(1) if list_match else returns_info
-
-                        # Skip basic types
-                        if model_name not in (
-                            "str",
-                            "int",
-                            "float",
-                            "bool",
-                            "Any",
-                            "dict",
-                        ):
-                            # Try to find the model class
-                            for module_name, module in sys.modules.items():
-                                if hasattr(module, model_name):
-                                    model_class = getattr(module, model_name)
-                                    if hasattr(model_class, "model_fields"):
-                                        # Found the model class, extract its fields
-                                        model_fields = []
-                                        for (
-                                            field_name,
-                                            field,
-                                        ) in model_class.model_fields.items():
-                                            if field_name.startswith("_"):
-                                                continue
-
-                                            field_type = (
-                                                DocstringGenerator.get_field_type(
-                                                    field.annotation,
-                                                    not field.is_required(),
-                                                    "website",
-                                                )
-                                            )
-
-                                            model_fields.append(
-                                                {
-                                                    "name": field_name,
-                                                    "type": field_type,
-                                                    "description": field.description
-                                                    or "",
-                                                    "default": (
-                                                        field.default
-                                                        if field.default
-                                                        != PydanticUndefined
-                                                        else ""
-                                                    ),
-                                                    "optional": not field.is_required(),
-                                                }
-                                            )
-
-                                        if model_fields:
-                                            reference[path]["data"][
-                                                model_name
-                                            ] = model_fields
-                                        break
+                    returns_info = cls._get_post_method_returns_info(docstring)
+                    if returns_info and "OBBject" in returns_info[0]["type"]:
+                        reference[path]["returns"]["OBBject"] = returns_info
                     else:
-                        # For direct returns that aren't OBBject
-                        model_name = (
-                            return_annotation.__name__
-                            if hasattr(return_annotation, "__name__")
-                            else "Model"
-                        )
-                        reference[path]["data"] = (
-                            {model_name: model_fields} if model_fields else {}
-                        )
+                        r_info = returns_info[0] if returns_info else {}
+                        r_type = r_info.pop("type", "Any")
+                        r_info["name"] = None  # type: ignore
+                        if len(returns_info) == 2:
+                            r_info = returns_info[1]
+                        elif len(returns_info) == 1:
+                            r_info["type"] = "Any"
+                        if r_type:
+                            if "[" in r_type:
+                                c_types = r_type.split("[")[1].split("]")[0]
+                                r_type = r_type.split("[")[0]
+                                r_info["type"] = (
+                                    "[" + c_types + "]" if c_types else "Any"
+                                )
+                            reference[path]["returns"][r_type] = r_info
+                        else:
+                            reference[path]["returns"] = returns_info
 
         return reference
 
-    @staticmethod
-    def _extract_return_type(func: Callable) -> Union[str, dict]:
-        """Extract return type information from function."""
-        return_annotation = inspect.signature(func).return_annotation
-
-        # If no return annotation, or return annotation is inspect.Signature.empty
-        if return_annotation is inspect.Signature.empty:
-            return {"type": "Any"}
-
-        # Check if the return type is an OBBject
-        type_str = str(return_annotation)
-
-        if "OBBject" in type_str or (
-            hasattr(return_annotation, "__name__")
-            and "OBBject" in return_annotation.__name__
-        ):
-            # Extract the model name from docstring or type annotation
-            result_type = "list[Data]"  # Default fallback
-
-            # Try to extract from type annotation first (more reliable)
-            if hasattr(return_annotation, "__origin__") and hasattr(
-                return_annotation, "__args__"
-            ):
-                # For OBBject[SomeType]
-                inner_type = return_annotation.__args__[0]
-                if hasattr(inner_type, "__name__"):
-                    result_type = inner_type.__name__
-                elif hasattr(inner_type, "_name") and inner_type._name:
-                    result_type = inner_type._name
-
-            # If not found, try to extract from docstring
-            if result_type == "list[Data]":
-                docstring = inspect.getdoc(func) or ""
-                if "Returns" in docstring:
-                    returns_section = docstring.split("Returns")[1].split("\n\n")[0]
-                    # Look for model name in docstring
-                    patterns = [
-                        r"OBBject\[(.*?)\]",  # OBBject[Model]
-                        r"results : ([\w\d_]+)",  # results : Model
-                        r"Returns\s+-------\s+(\w+)",  # Direct return type
-                    ]
-
-                    for pattern in patterns:
-                        model_match = re.search(pattern, returns_section)
-                        if model_match:
-                            result_type = model_match.group(1)
-                            break
-
-            # Ensure result_type doesn't already have a container type
-            if "[" in result_type and "]" not in result_type:
-                result_type += "]"  # Add missing closing bracket
-
-            result_type = ReferenceGenerator._clean_string_values(result_type)
-            # Return the standard OBBject structure with correct result type
-            return {
-                "OBBject": [
-                    {
-                        "name": "results",
-                        "type": (
-                            result_type
-                            if "[" in result_type
-                            else f"list[{result_type}]"
-                        ),
-                        "description": "Serializable results.",
-                    },
-                    {"name": "provider", "type": None, "description": "Provider name."},
-                    {
-                        "name": "warnings",
-                        "type": "Optional[list[Warning_]]",
-                        "description": "List of warnings.",
-                    },
-                    {
-                        "name": "chart",
-                        "type": "Optional[Chart]",
-                        "description": "Chart object.",
-                    },
-                    {
-                        "name": "extra",
-                        "type": "dict[str, Any]",
-                        "description": "Extra info.",
-                    },
-                ]
-            }
-
-        # Clean up return type string
-        type_str = (
-            type_str.replace("<class '", "")
-            .replace("'>", "")
-            .replace("typing.", "")
-            .replace("NoneType", "None")
-        )
-
-        # Basic types handling
-        basic_types = ["int", "str", "dict", "bool", "float", "None", "Any"]
-        if type_str.lower() in [t.lower() for t in basic_types]:
-            return type_str.lower()
-
-        # Check for container types with square brackets
-        container_match = re.search(r"(\w+)\[(.*?)\]", type_str)
-        if container_match:
-            container_type = container_match.group(1)
-            inner_type = container_match.group(2)
-
-            inner_type_name = (
-                inner_type.split(".")[-1] if "." in inner_type else inner_type
-            )
-
-            return f"{container_type}[{inner_type_name}]"
-
-        model_name = (
-            type_str.rsplit(".", maxsplit=1)[-1] if "." in type_str else type_str
-        )
-
-        return model_name
-
     @classmethod
-    def get_routers(cls, route_map: Dict[str, BaseRoute]) -> dict:
+    def get_routers(cls, route_map: Dict[str, BaseRoute]) -> Dict[str, Dict[str, Any]]:
         """Get router reference data.
 
         Parameters
@@ -3050,7 +1892,7 @@ class ReferenceGenerator:
             Dictionary containing the description for each router.
         """
         main_router = RouterLoader.from_extensions()
-        routers: dict = {}
+        routers = {}
         for path in route_map:
             path_parts = path.split("/")
             # We start at 2: ["/", "some_router"] "/some_router"

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -308,9 +308,9 @@ class ImportDefinition:
                 continue
 
             # Only include types that have a module and are not builtins
-            if ((hasattr(hint_type, "__module__") and
-                hint_type.__module__ != "builtins") or
-                (isinstance(hint_type, str))):
+            if (
+                hasattr(hint_type, "__module__") and hint_type.__module__ != "builtins"
+            ) or (isinstance(hint_type, str)):
                 new_hint_type_list.append(hint_type)
 
         new_hint_type_list = list(set(new_hint_type_list))
@@ -454,7 +454,16 @@ class ImportDefinition:
                 # Skip built-in types when adding to typing module
                 if (
                     module == "typing" and type_name in dir(__builtins__)
-                ) or type_name in ["Dict", "List", "int", int, "float", float]:
+                ) or type_name in [
+                    "Dict",
+                    "List",
+                    "int",
+                    int,
+                    "float",
+                    float,
+                    str,
+                    "str",
+                ]:
                     continue
 
                 if module not in module_types:

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1,6 +1,6 @@
 """Package Builder Class."""
 
-# pylint: disable=too-many-lines,too-many-locals,too-many-nested-blocks,too-many-statements,too-many-branches
+# pylint: disable=too-many-lines,too-many-locals,too-many-nested-blocks,too-many-statements,too-many-branches,too-many-positional-arguments
 import builtins
 import inspect
 import re
@@ -1481,7 +1481,7 @@ class DocstringGenerator:
         return ""
 
     @classmethod
-    def generate_model_docstring(  # noqa: PLR0912
+    def generate_model_docstring(  # noqa: PLR0912, PLR0917
         cls,
         model_name: str,
         summary: str,
@@ -1956,7 +1956,11 @@ class DocstringGenerator:
                 sig = inspect.signature(func)
                 return_annotation = sig.return_annotation
 
-                if return_annotation and return_annotation != inspect._empty:
+                if (
+                    return_annotation
+                    and return_annotation
+                    != inspect._empty  # pylint: disable=protected-access
+                ):
                     # Extract the type name properly
                     if hasattr(return_annotation, "__name__"):
                         type_name = return_annotation.__name__

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1525,6 +1525,7 @@ class DocstringGenerator:
         sections: List[str],
     ) -> str:
         """Create the docstring for model."""
+        docstring: str = ""
 
         def format_type(type_: str, char_limit: Optional[int] = None) -> str:
             """Format type in docstrings."""
@@ -1722,10 +1723,12 @@ class DocstringGenerator:
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")
             docstring += "\n\n"
+        else:
+            docstring += "\n\n"
 
+        if "parameters" in sections:
             provider_param = explicit_params.pop("provider", {})  # type: ignore
             chart_param = explicit_params.pop("chart", {})  # type: ignore
-        if "parameters" in sections:
             docstring += f"{create_indent(2)}Parameters\n"
             docstring += f"{create_indent(2)}----------\n"
 

--- a/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
+++ b/openbb_platform/extensions/econometrics/openbb_econometrics/econometrics_router.py
@@ -1,7 +1,7 @@
 """Econometrics Router."""
 
 from itertools import combinations
-from typing import Dict, List, Literal, Optional
+from typing import Literal, Optional
 
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
@@ -26,8 +26,8 @@ router = Router(prefix="", description="Econometrics analysis tools.")
     ],
 )
 def correlation_matrix(
-    data: List[Data], method: Literal["pearson", "kendall", "spearman"] = "pearson"
-) -> OBBject[List[Data]]:
+    data: list[Data], method: Literal["pearson", "kendall", "spearman"] = "pearson"
+) -> OBBject[list[Data]]:
     """Get the correlation matrix of an input dataset.
 
     The correlation matrix provides a view of how different variables in your dataset relate to one another.
@@ -37,7 +37,7 @@ def correlation_matrix(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Input dataset.
     method : Literal["pearson", "kendall", "spearman"]
         Method to use for correlation calculation. Default is "pearson".
@@ -47,7 +47,7 @@ def correlation_matrix(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         Correlation matrix.
     """
     # pylint: disable=import-outside-toplevel
@@ -96,10 +96,10 @@ def correlation_matrix(
     ],
 )
 def ols_regression(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Perform Ordinary Least Squares (OLS) regression.
 
     OLS regression is a fundamental statistical method to explore and model the relationship between a
@@ -109,16 +109,16 @@ def ols_regression(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the results being model and results objects.
     """
     # pylint: disable=import-outside-toplevel
@@ -156,9 +156,9 @@ def ols_regression(
     ],
 )
 def ols_regression_summary(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
+    x_columns: list[str],
 ) -> OBBject[Data]:
     """Perform Ordinary Least Squares (OLS) regression.
 
@@ -166,12 +166,12 @@ def ols_regression_summary(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
@@ -250,9 +250,9 @@ def ols_regression_summary(
     ],
 )
 def autocorrelation(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
+    x_columns: list[str],
 ) -> OBBject[Data]:
     """Perform Durbin-Watson test for autocorrelation.
 
@@ -266,16 +266,16 @@ def autocorrelation(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the results being the score from the test.
     """
     # pylint: disable=import-outside-toplevel
@@ -313,9 +313,9 @@ def autocorrelation(
     ],
 )
 def residual_autocorrelation(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
+    x_columns: list[str],
     lags: PositiveInt = 1,
 ) -> OBBject[Data]:
     """Perform Breusch-Godfrey Lagrange Multiplier tests for residual autocorrelation.
@@ -330,12 +330,12 @@ def residual_autocorrelation(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
     lags: PositiveInt
         Number of lags to use in the test.
 
@@ -386,8 +386,8 @@ def residual_autocorrelation(
     ],
 )
 def cointegration(
-    data: List[Data],
-    columns: List[str],
+    data: list[Data],
+    columns: list[str],
 ) -> OBBject[Data]:
     """Show co-integration between two timeseries using the two step Engle-Granger test.
 
@@ -402,9 +402,9 @@ def cointegration(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
-    columns: List[str]
+    columns: list[str]
         Data columns to check cointegration
     maxlag: PositiveInt
         Number of lags to use in the test.
@@ -465,7 +465,7 @@ def cointegration(
     ],
 )
 def causality(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
     x_column: str,
     lag: PositiveInt = 3,
@@ -482,7 +482,7 @@ def causality(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
@@ -539,7 +539,7 @@ def causality(
     ],
 )
 def unit_root(
-    data: List[Data],
+    data: list[Data],
     column: str,
     regression: Literal["c", "ct", "ctt"] = "c",
 ) -> OBBject[Data]:
@@ -556,7 +556,7 @@ def unit_root(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     column: str
         Data columns to check unit root
@@ -598,10 +598,10 @@ def unit_root(
     ],
 )
 def panel_random_effects(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Perform One-way Random Effects model for panel data.
 
     One-way Random Effects model to panel data is offering a nuanced approach to analyzing data that spans across both
@@ -611,16 +611,16 @@ def panel_random_effects(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -654,10 +654,10 @@ def panel_random_effects(
     ],
 )
 def panel_between(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Perform a Between estimator regression on panel data.
 
     The Between estimator for regression analysis on panel data is focusing on the differences between entities
@@ -667,16 +667,16 @@ def panel_between(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -708,10 +708,10 @@ def panel_between(
     ],
 )
 def panel_pooled(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Perform a Pooled coefficient estimator regression on panel data.
 
     The Pooled coefficient estimator for regression analysis on panel data is treating the data as a large
@@ -722,16 +722,16 @@ def panel_pooled(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -763,10 +763,10 @@ def panel_pooled(
     ],
 )
 def panel_fixed(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """One- and two-way fixed effects estimator for panel data.
 
     The Fixed Effects estimator to panel data is enabling a focused analysis on the unique characteristics of entities
@@ -776,16 +776,16 @@ def panel_fixed(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -817,10 +817,10 @@ def panel_fixed(
     ],
 )
 def panel_first_difference(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Perform a first-difference estimate for panel data.
 
     The First-Difference estimator for panel data analysis is focusing on the changes between consecutive observations
@@ -830,16 +830,16 @@ def panel_first_difference(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -870,10 +870,10 @@ def panel_first_difference(
     ],
 )
 def panel_fmac(
-    data: List[Data],
+    data: list[Data],
     y_column: str,
-    x_columns: List[str],
-) -> OBBject[Dict]:
+    x_columns: list[str],
+) -> OBBject[dict]:
     """Fama-MacBeth estimator for panel data.
 
     The Fama-MacBeth estimator, a two-step procedure renowned for its application in finance to estimate the risk
@@ -884,16 +884,16 @@ def panel_fmac(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         Input dataset.
     y_column: str
         Target column.
-    x_columns: List[str]
-        List of columns to use as exogenous variables.
+    x_columns: list[str]
+        list of columns to use as exogenous variables.
 
     Returns
     -------
-    OBBject[Dict]
+    OBBject[dict]
         OBBject with the fit model returned
     """
     # pylint: disable=import-outside-toplevel
@@ -926,8 +926,8 @@ def panel_fmac(
     ],
 )
 def variance_inflation_factor(
-    data: List[Data], columns: Optional[list] = None
-) -> OBBject[List[Data]]:
+    data: list[Data], columns: Optional[list] = None
+) -> OBBject[list[Data]]:
     """Calculate VIF (variance inflation factor), which tests for collinearity.
 
     It quantifies the severity of multicollinearity in an ordinary least squares regression analysis. The square
@@ -948,14 +948,14 @@ def variance_inflation_factor(
 
     Parameters
     ----------
-    dataset: List[Data]
+    dataset: list[Data]
         Dataset to calculate VIF on
     columns: Optional[list]
         The columns to calculate to test for collinearity
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The resulting VIF values for the selected columns
     """
     # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -304,14 +304,15 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
         p["type"] = "text"
         p["label"] = "Provider"
         p["description"] = "Source of the data."
+        p["show"] = False
         p["available_providers"] = providers
         return p
 
     multiple_items_allowed_dict: dict = {}
     for _provider in providers:
-        if _provider in param["schema"] and param["schema"][_provider].get(
-            "multiple_items_allowed", False
-        ):
+        if param.get("schema", {}).get(_provider, {}).get(
+            "multiple_items_allowed"
+        ) and param["schema"][_provider].get("multiple_items_allowed"):
             multiple_items_allowed_dict[_provider] = True
 
     p["multiple_items_allowed"] = multiple_items_allowed_dict

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -307,35 +307,23 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
         p["available_providers"] = providers
         return p
 
-    if param_name in ["symbol", "series_id", "release_id"]:
-        p["type"] = "text"
-        p["label"] = param_name.title().replace("_", " ").replace("Id", "ID")
+    multiple_items_allowed_dict: dict = {}
+    for _provider in providers:
+        if _provider in param["schema"] and param["schema"][_provider].get(
+            "multiple_items_allowed", False
+        ):
+            multiple_items_allowed_dict[_provider] = True
+
+    p["multiple_items_allowed"] = multiple_items_allowed_dict
+
+    if "Multiple comma separated items allowed" in p["description"]:
         p["description"] = (
-            p["description"]
-            .split("Multiple comma separated items allowed for provider(s)")[0]
-            .strip()
+            p["description"].split("Multiple comma separated items allowed")[0].strip()
         )
-        multiple_items_allowed_dict: dict = {}
-        for _provider in providers:
-            if _provider in param["schema"] and param["schema"][_provider].get(
-                "multiple_items_allowed", False
-            ):
-                multiple_items_allowed_dict[_provider] = True
 
-        p["multiple_items_allowed"] = multiple_items_allowed_dict
-        if "Multiple comma separated items allowed" in p["description"]:
-            p["description"] = (
-                p["description"]
-                .split("Multiple comma separated items allowed")[0]
-                .strip()
-            )
-
-        if widget_config := param["schema"].get("x-widget_config", {}):
-            p["x-widget_config"] = widget_config
-
-        return p
-
-    if x_widget_config := param.get("x-widget_config", {}):
+    if x_widget_config := param.get(
+        "x-widget_config", param.get("schema", {}.get("x-widget_config", {}))
+    ):
         p["x-widget_config"] = x_widget_config
 
     p_schema = param.get("schema", {}) or param

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -322,7 +322,7 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
         )
 
     if x_widget_config := param.get(
-        "x-widget_config", param.get("schema", {}.get("x-widget_config", {}))
+        "x-widget_config", param.get("schema", {}).get("x-widget_config", {})
     ):
         p["x-widget_config"] = x_widget_config
 

--- a/openbb_platform/extensions/platform_api/tests/mock_openapi.json
+++ b/openbb_platform/extensions/platform_api/tests/mock_openapi.json
@@ -56,7 +56,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -75,7 +75,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -127,7 +127,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -235,7 +235,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -254,7 +254,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -276,7 +276,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -299,7 +299,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -327,7 +327,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -427,7 +427,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -446,7 +446,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -468,7 +468,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -491,7 +491,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -519,7 +519,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -619,7 +619,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -638,7 +638,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -714,7 +714,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -737,7 +737,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -765,7 +765,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -877,7 +877,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed for provider(s): fred.",
@@ -1131,7 +1131,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -1150,7 +1150,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -1313,7 +1313,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1332,7 +1332,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1439,7 +1439,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "The search word(s).",
@@ -1457,7 +1457,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1479,7 +1479,7 @@
                   "type": "integer"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1497,7 +1497,7 @@
                   "type": "integer"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1516,7 +1516,7 @@
                   "minimum": 0
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1540,7 +1540,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1558,7 +1558,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1576,7 +1576,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1597,7 +1597,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1618,7 +1618,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1742,7 +1742,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -1761,7 +1761,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -1779,7 +1779,7 @@
                   "type": "integer"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "The number of data entries to return.",
@@ -1814,7 +1814,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1837,7 +1837,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1866,7 +1866,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -1996,7 +1996,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "The element ID of a specific table in the release.",
@@ -2018,7 +2018,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "A specific date to get data for. Multiple comma separated items allowed for provider(s): fred.",
@@ -2154,7 +2154,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -2173,7 +2173,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -2191,7 +2191,7 @@
                   "type": "integer"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "The number of data entries to return.",
@@ -2232,7 +2232,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2267,7 +2267,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2301,7 +2301,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2324,7 +2324,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2353,7 +2353,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2465,7 +2465,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "The item or basket of items to query.",
@@ -2496,7 +2496,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Start date of the data, in YYYY-MM-DD format.",
@@ -2515,7 +2515,7 @@
                   "format": "date"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "End date of the data, in YYYY-MM-DD format.",
@@ -2579,7 +2579,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "fred",
@@ -2702,7 +2702,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "A specific date to get data for. Default is the latest report. Multiple comma separated items allowed for provider(s): fred.",
@@ -2847,7 +2847,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "sec",
@@ -2960,7 +2960,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Whether or not to use cache.",
@@ -3080,7 +3080,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Whether or not to use cache.",
@@ -3099,7 +3099,7 @@
                   "type": "string"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "title": "sec",
@@ -3232,7 +3232,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Whether or not to use cache. If True, cache will store for seven days.",
@@ -3426,7 +3426,7 @@
                   "type": "boolean"
                 },
                 {
-                  "type": "null"
+                  "type": null
                 }
               ],
               "description": "Whether or not to use cache.",
@@ -3593,7 +3593,7 @@
                 "type": "object"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Content",
@@ -3605,7 +3605,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Format",
@@ -3617,7 +3617,7 @@
 
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Fig",
@@ -3671,7 +3671,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Percent Of Gdp",
@@ -3685,7 +3685,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Total",
@@ -3697,7 +3697,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Total Services",
@@ -3709,7 +3709,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Total Secondary Income",
@@ -3721,7 +3721,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Total Goods",
@@ -3733,7 +3733,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Balance Total Primary Income",
@@ -3745,7 +3745,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Services Percent Of Goods And Services",
@@ -3759,7 +3759,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Services Percent Of Current Account",
@@ -3773,7 +3773,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Total Services",
@@ -3785,7 +3785,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Total Goods",
@@ -3797,7 +3797,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Total Primary Income",
@@ -3809,7 +3809,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Total Secondary Income",
@@ -3821,7 +3821,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Credits Total",
@@ -3833,7 +3833,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Services Percent Of Goods And Services",
@@ -3847,7 +3847,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Services Percent Of Current Account",
@@ -3861,7 +3861,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Total Services",
@@ -3873,7 +3873,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Total Goods",
@@ -3885,7 +3885,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Total Primary Income",
@@ -3897,7 +3897,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Total",
@@ -3909,7 +3909,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Debits Total Secondary Income",
@@ -3935,7 +3935,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Topic",
@@ -3947,7 +3947,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Diffusion Index",
@@ -3959,7 +3959,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Percent Reporting Increase",
@@ -3973,7 +3973,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Percent Reporting Decrease",
@@ -3987,7 +3987,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Percent Reporting No Change",
@@ -4043,7 +4043,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Children",
@@ -4108,7 +4108,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Children",
@@ -4174,7 +4174,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Value",
@@ -4206,7 +4206,7 @@
                 "format": "date"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Date",
@@ -4218,7 +4218,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Level",
@@ -4230,7 +4230,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Element Type",
@@ -4242,7 +4242,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Line",
@@ -4254,7 +4254,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Element Id",
@@ -4266,7 +4266,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Parent Id",
@@ -4278,7 +4278,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Children",
@@ -4290,7 +4290,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Symbol",
@@ -4302,7 +4302,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Name",
@@ -4314,7 +4314,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Value",
@@ -4335,7 +4335,7 @@
                 "format": "date"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Date",
@@ -4347,7 +4347,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Symbol",
@@ -4359,7 +4359,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Country",
@@ -4376,7 +4376,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Value",
@@ -4399,7 +4399,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Release Id",
@@ -4411,7 +4411,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Series Id",
@@ -4423,7 +4423,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Name",
@@ -4435,7 +4435,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Title",
@@ -4448,7 +4448,7 @@
                 "format": "date"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Observation Start",
@@ -4461,7 +4461,7 @@
                 "format": "date"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Observation End",
@@ -4473,7 +4473,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Frequency",
@@ -4485,7 +4485,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Frequency Short",
@@ -4497,7 +4497,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Units",
@@ -4509,7 +4509,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Units Short",
@@ -4521,7 +4521,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Seasonal Adjustment",
@@ -4533,7 +4533,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Seasonal Adjustment Short",
@@ -4546,7 +4546,7 @@
                 "format": "date-time"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Last Updated",
@@ -4558,7 +4558,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Notes",
@@ -4570,7 +4570,7 @@
                 "type": "boolean"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Press Release",
@@ -4582,7 +4582,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Url",
@@ -4594,7 +4594,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Popularity",
@@ -4606,7 +4606,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Group Popularity",
@@ -4618,7 +4618,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Region Type",
@@ -4633,7 +4633,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Series Group",
@@ -4659,7 +4659,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Symbol",
@@ -4676,7 +4676,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Title",
@@ -4724,7 +4724,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Activity Index",
@@ -4736,7 +4736,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "One Year Outlook",
@@ -4748,7 +4748,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Manufacturing Activity",
@@ -4760,7 +4760,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Non Manufacturing Activity",
@@ -4772,7 +4772,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Capital Expenditures Expectations",
@@ -4784,7 +4784,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Hiring Expectations",
@@ -4796,7 +4796,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Current Hiring",
@@ -4808,7 +4808,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Labor Costs",
@@ -4820,7 +4820,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Non Labor Costs",
@@ -4849,7 +4849,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Consumer Sentiment",
@@ -4861,7 +4861,7 @@
                 "type": "number"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Inflation Expectation",
@@ -4906,7 +4906,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -4918,7 +4918,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -4933,7 +4933,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -4945,7 +4945,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -4972,7 +4972,7 @@
                 "$ref": "#/components/schemas/SecCikMapData"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Serializable results."
@@ -4983,7 +4983,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -4998,7 +4998,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5010,7 +5010,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5040,7 +5040,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5052,7 +5052,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5067,7 +5067,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5079,7 +5079,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5109,7 +5109,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5121,7 +5121,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5136,7 +5136,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5148,7 +5148,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5178,7 +5178,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5190,7 +5190,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5205,7 +5205,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5217,7 +5217,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5247,7 +5247,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5259,7 +5259,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5274,7 +5274,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5286,7 +5286,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5316,7 +5316,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5328,7 +5328,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5343,7 +5343,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5355,7 +5355,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5385,7 +5385,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5397,7 +5397,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5412,7 +5412,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5424,7 +5424,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5454,7 +5454,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5466,7 +5466,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5481,7 +5481,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5493,7 +5493,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5523,7 +5523,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5535,7 +5535,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5550,7 +5550,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5562,7 +5562,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5592,7 +5592,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5604,7 +5604,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5619,7 +5619,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5631,7 +5631,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5661,7 +5661,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5673,7 +5673,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5688,7 +5688,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5700,7 +5700,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5730,7 +5730,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5742,7 +5742,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5757,7 +5757,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5769,7 +5769,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5796,7 +5796,7 @@
                 "$ref": "#/components/schemas/SecSchemaFilesData"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Serializable results."
@@ -5807,7 +5807,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5822,7 +5822,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5834,7 +5834,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5864,7 +5864,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5876,7 +5876,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5891,7 +5891,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5903,7 +5903,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -5933,7 +5933,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -5945,7 +5945,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -5960,7 +5960,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -5972,7 +5972,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -6002,7 +6002,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -6014,7 +6014,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -6029,7 +6029,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -6041,7 +6041,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -6068,7 +6068,7 @@
                 "$ref": "#/components/schemas/SecSymbolMapData"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Serializable results."
@@ -6079,7 +6079,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -6094,7 +6094,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -6106,7 +6106,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -6136,7 +6136,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Results",
@@ -6148,7 +6148,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Provider",
@@ -6163,7 +6163,7 @@
                 "type": "array"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Warnings",
@@ -6175,7 +6175,7 @@
                 "$ref": "#/components/schemas/Chart"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "description": "Chart object."
@@ -6220,7 +6220,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Cik",
@@ -6240,7 +6240,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Institution",
@@ -6255,7 +6255,7 @@
                 "type": "integer"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Cik Number",
@@ -6395,7 +6395,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "First Name"
@@ -6406,7 +6406,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Last Name"
@@ -6439,7 +6439,7 @@
                 "type": "string"
               },
               {
-                "type": "null"
+                "type": null
               }
             ],
             "title": "Diagnosis"

--- a/openbb_platform/extensions/platform_api/tests/mock_widgets.json
+++ b/openbb_platform/extensions/platform_api/tests/mock_widgets.json
@@ -3641,7 +3641,7 @@
         "params": [
             {
                 "label": "Some Param",
-                "description": "",
+                "description": "Some Param",
                 "optional": true,
                 "type": "text",
                 "value": "",
@@ -3656,8 +3656,8 @@
                 "endpoint": "form_submit",
                 "inputParams": [
                     {
-                        "label": "Record Opened Date",
-                        "description": "",
+                        "label": "Date",
+                        "description": "Date",
                         "optional": true,
                         "type": "date",
                         "value": null,
@@ -3665,7 +3665,7 @@
                     },
                     {
                         "label": "Record ID",
-                        "description": "",
+                        "description": "Record Id",
                         "optional": true,
                         "type": "number",
                         "value": null,
@@ -3673,7 +3673,7 @@
                     },
                     {
                         "label": "First Name",
-                        "description": "",
+                        "description": "First Name",
                         "optional": true,
                         "type": "text",
                         "value": null,
@@ -3681,7 +3681,7 @@
                     },
                     {
                         "label": "Last Name",
-                        "description": "",
+                        "description": "Last Name",
                         "optional": true,
                         "type": "text",
                         "value": null,
@@ -3689,7 +3689,7 @@
                     },
                     {
                         "label": "Symptoms",
-                        "description": "",
+                        "description": "Symptoms",
                         "optional": true,
                         "type": "text",
                         "value": null,
@@ -3712,7 +3712,7 @@
                     },
                     {
                         "label": "Diagnosis",
-                        "description": "",
+                        "description": "Diagnosis",
                         "optional": true,
                         "type": "text",
                         "value": null,
@@ -3720,7 +3720,7 @@
                     },
                     {
                         "label": "Add Record",
-                        "description": "",
+                        "description": "Add Record",
                         "optional": true,
                         "type": "button",
                         "value": true,

--- a/openbb_platform/extensions/platform_api/tests/test_openapi_utils.py
+++ b/openbb_platform/extensions/platform_api/tests/test_openapi_utils.py
@@ -98,6 +98,7 @@ def mock_openapi_json():
                         ]
                     },
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
                 {
@@ -110,6 +111,7 @@ def mock_openapi_json():
                     "multiple_items_allowed": {},
                     "options": {"fred": []},
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
                 {
@@ -122,6 +124,7 @@ def mock_openapi_json():
                     "multiple_items_allowed": {},
                     "options": {"fred": []},
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
             ],
@@ -216,6 +219,7 @@ def mock_openapi_json():
                         ]
                     },
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
                 {
@@ -234,6 +238,7 @@ def mock_openapi_json():
                         ]
                     },
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
                 {
@@ -257,6 +262,7 @@ def mock_openapi_json():
                         ]
                     },
                     "x-widget_config": {},
+                    "available_providers": ["fred"],
                     "show": True,
                 },
             ],
@@ -310,6 +316,7 @@ def mock_openapi_json():
                     "multiple_items_allowed": {},
                     "options": {"sec": []},
                     "x-widget_config": {},
+                    "available_providers": ["sec"],
                     "show": True,
                 },
             ],

--- a/openbb_platform/extensions/platform_api/tests/test_openapi_utils.py
+++ b/openbb_platform/extensions/platform_api/tests/test_openapi_utils.py
@@ -34,8 +34,8 @@ def mock_openapi_json():
                     "optional": True,
                     "type": "text",
                     "value": None,
+                    "show": False,
                     "available_providers": ["fred"],
-                    "show": True,
                 },
                 {
                     "parameter_name": "country",
@@ -138,8 +138,8 @@ def mock_openapi_json():
                     "optional": True,
                     "type": "text",
                     "value": None,
+                    "show": False,
                     "available_providers": ["fred"],
-                    "show": True,
                 },
                 {
                     "parameter_name": "symbol",
@@ -149,6 +149,8 @@ def mock_openapi_json():
                     "type": "text",
                     "value": None,
                     "multiple_items_allowed": {"fred": True},
+                    "options": {"fred": []},
+                    "x-widget_config": {},
                     "show": True,
                 },
                 {
@@ -271,8 +273,8 @@ def mock_openapi_json():
                     "optional": True,
                     "type": "text",
                     "value": None,
+                    "show": False,
                     "available_providers": ["sec"],
-                    "show": True,
                 },
                 {
                     "parameter_name": "query",

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
@@ -1,5 +1,7 @@
 """OpenBB Performance Extension router."""
 
+# pylint: disable=too-many-positional-arguments
+
 from typing import TYPE_CHECKING
 
 from openbb_core.app.model.example import APIEx, PythonEx

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/performance/performance_router.py
@@ -1,6 +1,6 @@
 """OpenBB Performance Extension router."""
 
-from typing import TYPE_CHECKING, List
+from typing import TYPE_CHECKING
 
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
@@ -40,11 +40,11 @@ router = Router(prefix="/performance")
     ],
 )
 def omega_ratio(
-    data: List[Data],
+    data: list[Data],
     target: str,
     threshold_start: float = 0.0,
     threshold_end: float = 1.5,
-) -> OBBject[List[OmegaModel]]:
+) -> OBBject[list[OmegaModel]]:
     """Calculate the Omega Ratio.
 
     The Omega Ratio is a sophisticated metric that goes beyond traditional performance measures by considering the
@@ -53,7 +53,7 @@ def omega_ratio(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -64,7 +64,7 @@ def omega_ratio(
 
     Returns
     -------
-    OBBject[List[OmegaModel]]
+    OBBject[list[OmegaModel]]
         Omega ratios.
     """
     # pylint: disable=import-outside-toplevel
@@ -121,12 +121,12 @@ def omega_ratio(
     ],
 )
 def sharpe_ratio(
-    data: List[Data],
+    data: list[Data],
     target: str,
     rfr: float = 0.0,
     window: PositiveInt = 252,
     index: str = "date",
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Get Rolling Sharpe Ratio.
 
     This function calculates the Sharpe Ratio, a metric used to assess the return of an investment compared to its risk.
@@ -138,7 +138,7 @@ def sharpe_ratio(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -150,7 +150,7 @@ def sharpe_ratio(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         Sharpe ratio.
     """
     # pylint: disable=import-outside-toplevel
@@ -200,13 +200,13 @@ def sharpe_ratio(
     ],
 )
 def sortino_ratio(
-    data: List[Data],
+    data: list[Data],
     target: str,
     target_return: float = 0.0,
     window: PositiveInt = 252,
     adjusted: bool = False,
     index: str = "date",
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Get rolling Sortino Ratio.
 
     The Sortino Ratio enhances the evaluation of investment returns by distinguishing harmful volatility
@@ -223,7 +223,7 @@ def sortino_ratio(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -237,7 +237,7 @@ def sortino_ratio(
         Index column for input data
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         Sortino ratio.
     """
     # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/quantitative_router.py
@@ -1,6 +1,6 @@
 """Quantitative Analysis Router."""
 
-from typing import List, Literal
+from typing import Literal
 
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
@@ -41,7 +41,7 @@ router.include_router(performance_router)
         APIEx(parameters={"target": "close", "data": APIEx.mock_data("timeseries", 8)}),
     ],
 )
-def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
+def normality(data: list[Data], target: str) -> OBBject[NormalityModel]:
     """Get Normality Statistics.
 
     - **Kurtosis**: whether the kurtosis of a sample differs from the normal distribution.
@@ -52,7 +52,7 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -104,7 +104,7 @@ def normality(data: List[Data], target: str) -> OBBject[NormalityModel]:
         ),
     ],
 )
-def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
+def capm(data: list[Data], target: str) -> OBBject[CAPMModel]:
     """Get Capital Asset Pricing Model (CAPM).
 
     CAPM offers a streamlined way to assess the expected return on an investment while accounting for its risk relative
@@ -113,7 +113,7 @@ def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -175,7 +175,7 @@ def capm(data: List[Data], target: str) -> OBBject[CAPMModel]:
     ],
 )
 def unitroot_test(
-    data: List[Data],
+    data: list[Data],
     target: str,
     fuller_reg: Literal["c", "ct", "ctt", "nc", "c"] = "c",
     kpss_reg: Literal["c", "ct"] = "c",
@@ -192,7 +192,7 @@ def unitroot_test(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -249,7 +249,7 @@ def unitroot_test(
         APIEx(parameters={"target": "close", "data": APIEx.mock_data("timeseries", 5)}),
     ],
 )
-def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
+def summary(data: list[Data], target: str) -> OBBject[SummaryModel]:
     """Get Summary Statistics.
 
     The summary that offers a snapshot of its central tendencies, variability, and distribution.
@@ -261,7 +261,7 @@ def summary(data: List[Data], target: str) -> OBBject[SummaryModel]:
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/rolling/rolling_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/rolling/rolling_router.py
@@ -1,7 +1,5 @@
 """Rolling submenu of quantitative models for rolling statistics."""
 
-from typing import List
-
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.router import Router
@@ -35,8 +33,8 @@ router = Router(prefix="/rolling")
     ],
 )
 def skew(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
-) -> OBBject[List[Data]]:
+    data: list[Data], target: str, window: PositiveInt = 21, index: str = "date"
+) -> OBBject[list[Data]]:
     """Get Rolling Skew.
 
     Skew is a statistical measure that reveals the degree of asymmetry of a distribution around its mean.
@@ -47,7 +45,7 @@ def skew(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
@@ -58,7 +56,7 @@ def skew(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         Rolling skew.
 
     """
@@ -107,8 +105,8 @@ def skew(
     ],
 )
 def variance(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
-) -> OBBject[List[Data]]:
+    data: list[Data], target: str, window: PositiveInt = 21, index: str = "date"
+) -> OBBject[list[Data]]:
     """
     Calculate the rolling variance of a target column within a given window size.
 
@@ -117,7 +115,7 @@ def variance(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate variance.
@@ -128,7 +126,7 @@ def variance(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling variance values.
     """
     # pylint: disable=import-outside-toplevel
@@ -174,8 +172,8 @@ def variance(
     ],
 )
 def stdev(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
-) -> OBBject[List[Data]]:
+    data: list[Data], target: str, window: PositiveInt = 21, index: str = "date"
+) -> OBBject[list[Data]]:
     """
     Calculate the rolling standard deviation of a target column within a given window size.
 
@@ -185,7 +183,7 @@ def stdev(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate standard deviation.
@@ -196,7 +194,7 @@ def stdev(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling standard deviation values.
     """
     # pylint: disable=import-outside-toplevel
@@ -244,8 +242,8 @@ def stdev(
     ],
 )
 def kurtosis(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
-) -> OBBject[List[Data]]:
+    data: list[Data], target: str, window: PositiveInt = 21, index: str = "date"
+) -> OBBject[list[Data]]:
     """
     Calculate the rolling kurtosis of a target column within a given window size.
 
@@ -257,7 +255,7 @@ def kurtosis(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate kurtosis.
@@ -268,7 +266,7 @@ def kurtosis(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling kurtosis values.
     """
     # pylint: disable=import-outside-toplevel
@@ -317,12 +315,12 @@ def kurtosis(
     ],
 )
 def quantile(
-    data: List[Data],
+    data: list[Data],
     target: str,
     window: PositiveInt = 21,
     quantile_pct: NonNegativeFloat = 0.5,
     index: str = "date",
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """
     Calculate the rolling quantile of a target column within a given window size at a specified quantile percentage.
 
@@ -332,7 +330,7 @@ def quantile(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate the quantile.
@@ -345,7 +343,7 @@ def quantile(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling quantile values with the median.
     """
     # pylint: disable=import-outside-toplevel
@@ -405,8 +403,8 @@ def quantile(
     ],
 )
 def mean(
-    data: List[Data], target: str, window: PositiveInt = 21, index: str = "date"
-) -> OBBject[List[Data]]:
+    data: list[Data], target: str, window: PositiveInt = 21, index: str = "date"
+) -> OBBject[list[Data]]:
     """Calculate the rolling average of a target column within a given window size.
 
     The rolling mean is a simple moving average that calculates the average of a target variable over a specified window.
@@ -415,7 +413,7 @@ def mean(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate the mean.
@@ -426,7 +424,7 @@ def mean(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling mean values.
     """
     # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/quantitative/openbb_quantitative/stats/stats_router.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/stats/stats_router.py
@@ -1,7 +1,5 @@
 """Rolling submenu of quantitative models for rolling statistics."""
 
-from typing import List
-
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.router import Router
@@ -34,9 +32,9 @@ router = Router(prefix="/stats")
     ],
 )
 def skew(
-    data: List[Data],
+    data: list[Data],
     target: str,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Get the skew of the data set.
 
     Skew is a statistical measure that reveals the degree of asymmetry of a distribution around its mean.
@@ -47,14 +45,14 @@ def skew(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         Time series data.
     target : str
         Target column name.
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         Rolling skew.
     """
     # pylint: disable=import-outside-toplevel
@@ -96,7 +94,7 @@ def skew(
         ),
     ],
 )
-def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
+def variance(data: list[Data], target: str) -> OBBject[list[Data]]:
     """Calculate the  variance of a target column.
 
     Variance measures the dispersion of a set of data points around their mean. It is a key metric for
@@ -104,14 +102,14 @@ def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate variance.
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling variance values.
     """
     # pylint: disable=import-outside-toplevel
@@ -153,7 +151,7 @@ def variance(data: List[Data], target: str) -> OBBject[List[Data]]:
         ),
     ],
 )
-def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
+def stdev(data: list[Data], target: str) -> OBBject[list[Data]]:
     """Calculate the rolling standard deviation of a target column.
 
     Standard deviation is a measure of the amount of variation or dispersion of a set of values.
@@ -162,14 +160,14 @@ def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate standard deviation.
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling standard deviation values.
     """
     # pylint: disable=import-outside-toplevel
@@ -211,7 +209,7 @@ def stdev(data: List[Data], target: str) -> OBBject[List[Data]]:
         ),
     ],
 )
-def kurtosis(data: List[Data], target: str) -> OBBject[List[Data]]:
+def kurtosis(data: list[Data], target: str) -> OBBject[list[Data]]:
     """Calculate the rolling kurtosis of a target column.
 
     Kurtosis measures the "tailedness" of the probability distribution of a real-valued random variable.
@@ -221,14 +219,14 @@ def kurtosis(data: List[Data], target: str) -> OBBject[List[Data]]:
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate kurtosis.
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the kurtosis value
     """
     # pylint: disable=import-outside-toplevel
@@ -271,10 +269,10 @@ def kurtosis(data: List[Data], target: str) -> OBBject[List[Data]]:
     ],
 )
 def quantile(
-    data: List[Data],
+    data: list[Data],
     target: str,
     quantile_pct: NonNegativeFloat = 0.5,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the quantile of a target column at a specified quantile percentage.
 
     Quantiles are points dividing the range of a probability distribution into  intervals with equal probabilities,
@@ -282,7 +280,7 @@ def quantile(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate the quantile.
@@ -291,7 +289,7 @@ def quantile(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         An object containing the rolling quantile values with the median.
     """
     # pylint: disable=import-outside-toplevel
@@ -336,9 +334,9 @@ def quantile(
     ],
 )
 def mean(
-    data: List[Data],
+    data: list[Data],
     target: str,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the average of a target column.
 
     The rolling mean is a simple moving average that calculates the average of a target variable.
@@ -347,14 +345,14 @@ def mean(
 
     Parameters
     ----------
-    data: List[Data]
+    data: list[Data]
         The time series data as a list of data points.
     target: str
         The name of the column for which to calculate the mean.
 
     Returns
     -------
-        OBBject[List[Data]]
+        OBBject[list[Data]]
             An object containing the mean value.
     """
     # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/technical/openbb_technical/technical_router.py
+++ b/openbb_platform/extensions/technical/openbb_technical/technical_router.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-lines,unused-import,too-many-arguments,too-many-positional-arguments
 
-from typing import Any, Dict, List, Literal, Optional
+from typing import Any, Literal, Optional
 
 from openbb_core.app.model.example import APIEx, PythonEx
 from openbb_core.app.model.obbject import OBBject
@@ -59,14 +59,14 @@ router = Router(prefix="", description="Technical Analysis tools.")
     ],
 )
 async def relative_rotation(
-    data: List[Data],
+    data: list[Data],
     benchmark: str,
     study: Literal["price", "volume", "volatility"] = "price",
     long_period: Optional[int] = 252,
     short_period: Optional[int] = 21,
     window: Optional[int] = 21,
     trading_periods: Optional[int] = 252,
-    chart_params: Optional[Dict[str, Any]] = None,
+    chart_params: Optional[dict[str, Any]] = None,
 ) -> OBBject[RelativeRotationData]:
     """Calculate the Relative Strength Ratio and Relative Strength Momentum for a group of symbols against a benchmark.
 
@@ -177,13 +177,13 @@ async def relative_rotation(
     ],
 )
 def atr(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: PositiveInt = 14,
     mamode: Literal["rma", "ema", "sma", "wma"] = "rma",
     drift: NonNegativeInt = 1,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Average True Range.
 
     Used to measure volatility, especially volatility caused by gaps or limit moves.
@@ -196,8 +196,8 @@ def atr(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to apply the indicator to.
+    data : list[Data]
+        list of data to apply the indicator to.
     index : str, optional
         Index column name, by default "date"
     length : PositiveInt, optional
@@ -211,8 +211,8 @@ def atr(
 
     Returns
     -------
-    OBBject[List[Data]]
-        List of data with the indicator applied.
+    OBBject[list[Data]]
+        list of data with the indicator applied.
     """
     # pylint: disable=import-outside-toplevel
     import pandas as pd
@@ -245,13 +245,13 @@ def atr(
     ],
 )
 def fib(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     close_column: Literal["close", "adj_close"] = "close",
     period: PositiveInt = 120,
     start_date: Optional[str] = None,
     end_date: Optional[str] = None,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Create Fibonacci Retracement Levels.
 
     This method draws from a classic technique to pinpoint significant price levels
@@ -262,8 +262,8 @@ def fib(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to apply the indicator to.
+    data : list[Data]
+        list of data to apply the indicator to.
     index : str, optional
         Index column name, by default "date"
     period : PositiveInt, optional
@@ -271,8 +271,8 @@ def fib(
 
     Returns
     -------
-    OBBject[List[Data]]
-        List of data with the indicator applied.
+    OBBject[list[Data]]
+        list of data with the indicator applied.
     """
     df = basemodel_to_df(data, index=index)
 
@@ -316,10 +316,10 @@ def fib(
     ],
 )
 def obv(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the On Balance Volume (OBV).
 
     Is a cumulative total of the up and down volume. When the close is higher than the
@@ -333,8 +333,8 @@ def obv(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to apply the indicator to.
+    data : list[Data]
+        list of data to apply the indicator to.
     index : str, optional
         Index column name, by default "date"
     offset : int, optional
@@ -342,8 +342,8 @@ def obv(
 
     Returns
     -------
-    OBBject[List[Data]]
-        List of data with the indicator applied.
+    OBBject[list[Data]]
+        list of data with the indicator applied.
     """
     # pylint: disable=import-outside-toplevel
     import pandas as pd
@@ -373,11 +373,11 @@ def obv(
     ],
 )
 def fisher(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: PositiveInt = 14,
     signal: PositiveInt = 1,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Perform the Fisher Transform.
 
     A technical indicator created by John F. Ehlers that converts prices into a Gaussian
@@ -388,8 +388,8 @@ def fisher(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to apply the indicator to.
+    data : list[Data]
+        list of data to apply the indicator to.
     index : str, optional
         Index column name, by default "date"
     length : PositiveInt, optional
@@ -399,8 +399,8 @@ def fisher(
 
     Returns
     -------
-    OBBject[List[Data]]
-        List of data with the indicator applied.
+    OBBject[list[Data]]
+        list of data with the indicator applied.
     """
     # pylint: disable=import-outside-toplevel
     import pandas as pd
@@ -431,12 +431,12 @@ def fisher(
     ],
 )
 def adosc(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     fast: PositiveInt = 3,
     slow: PositiveInt = 10,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Accumulation/Distribution Oscillator.
 
     Also known as the Chaikin Oscillator.
@@ -450,8 +450,8 @@ def adosc(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     fast : PositiveInt, optional
         Number of periods to be used for the fast calculation, by default 3.
     slow : PositiveInt, optional
@@ -461,7 +461,7 @@ def adosc(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -493,14 +493,14 @@ def adosc(
     ],
 )
 def bbands(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     std: NonNegativeFloat = 2,
     mamode: Literal["sma", "ema", "wma", "rma"] = "sma",
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Bollinger Bands.
 
     Consist of three lines. The middle band is a simple moving average (generally 20
@@ -518,8 +518,8 @@ def bbands(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     target : str
         Target column name.
     index : str, optional
@@ -535,7 +535,7 @@ def bbands(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -576,12 +576,12 @@ def bbands(
     ],
 )
 def zlma(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the zero lag exponential moving average (ZLEMA).
 
     Created by John Ehlers and Ric Way. The idea is do a
@@ -593,8 +593,8 @@ def zlma(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     target : str
         Target column name.
     index : str, optional
@@ -606,7 +606,7 @@ def zlma(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -645,11 +645,11 @@ def zlma(
     ],
 )
 def aroon(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: int = 25,
     scalar: float = 100,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Aroon Indicator.
 
     The word aroon is Sanskrit for "dawn's early light." The Aroon
@@ -666,8 +666,8 @@ def aroon(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index: str, optional
         Index column name to use with `data`, by default "date".
     length : int, optional
@@ -677,7 +677,7 @@ def aroon(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -709,12 +709,12 @@ def aroon(
     ],
 )
 def sma(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Simple Moving Average (SMA).
 
     Moving Averages are used to smooth the data in an array to
@@ -727,8 +727,8 @@ def sma(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     target : str
         Target column name.
     index : str, optional
@@ -740,7 +740,7 @@ def sma(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -779,13 +779,13 @@ def sma(
     ],
 )
 def demark(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     target: str = "close",
     show_all: bool = True,
     asint: bool = True,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Demark sequential indicator.
 
     This indicator offers a strategic way to spot potential reversals in market trends.
@@ -796,8 +796,8 @@ def demark(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     target : str, optional
@@ -811,7 +811,7 @@ def demark(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data, with fields: [{index}, {target}, "up", "down"]
     """
     # pylint: disable=import-outside-toplevel
@@ -842,11 +842,11 @@ def demark(
     ],
 )
 def vwap(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     anchor: str = "D",
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Volume Weighted Average Price (VWAP).
 
     Measures the average typical price by volume.
@@ -856,8 +856,8 @@ def vwap(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     anchor : str, optional
@@ -869,7 +869,7 @@ def vwap(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -910,13 +910,13 @@ def vwap(
     ],
 )
 def macd(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     fast: int = 12,
     slow: int = 26,
     signal: int = 9,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Moving Average Convergence Divergence (MACD).
 
     Difference between two Exponential Moving Averages. The Signal line is an
@@ -932,8 +932,8 @@ def macd(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     target : str
         Target column name.
     fast : int, optional
@@ -945,7 +945,7 @@ def macd(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -983,12 +983,12 @@ def macd(
     ],
 )
 def hma(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Hull Moving Average (HMA).
 
     Solves the age old dilemma of making a moving average more responsive to current
@@ -998,8 +998,8 @@ def hma(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     target : str
         Target column name.
     index : str, optional
@@ -1011,7 +1011,7 @@ def hma(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1056,12 +1056,12 @@ def hma(
     ],
 )
 def donchian(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     lower_length: PositiveInt = 20,
     upper_length: PositiveInt = 20,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Donchian Channels.
 
     Three lines generated by moving average calculations that comprise an indicator
@@ -1072,8 +1072,8 @@ def donchian(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     lower_length : PositiveInt, optional
@@ -1085,7 +1085,7 @@ def donchian(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1120,14 +1120,14 @@ def donchian(
     ],
 )
 def ichimoku(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     conversion: PositiveInt = 9,
     base: PositiveInt = 26,
     lagging: PositiveInt = 52,
     offset: PositiveInt = 26,
     lookahead: bool = False,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Ichimoku Cloud.
 
     Also known as Ichimoku Kinko Hyo, is a versatile indicator that defines support and
@@ -1138,8 +1138,8 @@ def ichimoku(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     conversion : PositiveInt, optional
@@ -1155,7 +1155,7 @@ def ichimoku(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     validate_data(data, [conversion, base, lagging])
@@ -1191,11 +1191,11 @@ def ichimoku(
     ],
 )
 def clenow(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     target: str = "close",
     period: PositiveInt = 90,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Clenow Volatility Adjusted Momentum.
 
     The Clenow Volatility Adjusted Momentum is a sophisticated approach to understanding market momentum with a twist.
@@ -1204,8 +1204,8 @@ def clenow(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     target : str, optional
@@ -1215,7 +1215,7 @@ def clenow(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1256,7 +1256,7 @@ def clenow(
         APIEx(parameters={"data": APIEx.mock_data("timeseries")}),
     ],
 )
-def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[Data]]:
+def ad(data: list[Data], index: str = "date", offset: int = 0) -> OBBject[list[Data]]:
     """Calculate the Accumulation/Distribution Line.
 
     Similar to the On Balance Volume (OBV).
@@ -1274,8 +1274,8 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     offset : int, optional
@@ -1283,7 +1283,7 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1314,12 +1314,12 @@ def ad(data: List[Data], index: str = "date", offset: int = 0) -> OBBject[List[D
     ],
 )
 def adx(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: int = 50,
     scalar: float = 100.0,
     drift: int = 1,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Average Directional Index (ADX).
 
     The ADX is a Welles Wilder style moving average of the Directional Movement Index (DX).
@@ -1328,8 +1328,8 @@ def adx(
 
     Parameters
     ----------
-    data : List[Data]
-        List of data to be used for the calculation.
+    data : list[Data]
+        list of data to be used for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
     length : int, optional
@@ -1341,7 +1341,7 @@ def adx(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1375,12 +1375,12 @@ def adx(
     ],
 )
 def wma(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Weighted Moving Average (WMA).
 
     A Weighted Moving Average puts more weight on recent data and less on past data.
@@ -1390,7 +1390,7 @@ def wma(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the calculation.
     target : str
         Target column name.
@@ -1403,7 +1403,7 @@ def wma(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The WMA data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1442,11 +1442,11 @@ def wma(
     ],
 )
 def cci(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: PositiveInt = 14,
     scalar: PositiveFloat = 0.015,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Commodity Channel Index (CCI).
 
     The CCI is designed to detect beginning and ending market trends.
@@ -1457,7 +1457,7 @@ def cci(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the CCI calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
@@ -1468,7 +1468,7 @@ def cci(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The CCI data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1500,13 +1500,13 @@ def cci(
     ],
 )
 def rsi(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 14,
     scalar: float = 100.0,
     drift: int = 1,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Relative Strength Index (RSI).
 
     RSI calculates a ratio of the recent upward price movements to the absolute price
@@ -1517,7 +1517,7 @@ def rsi(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the RSI calculation.
     target : str
         Target column name.
@@ -1532,7 +1532,7 @@ def rsi(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The RSI data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1571,12 +1571,12 @@ def rsi(
     ],
 )
 def stoch(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     fast_k_period: NonNegativeInt = 14,
     slow_d_period: NonNegativeInt = 3,
     slow_k_period: NonNegativeInt = 3,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Stochastic Oscillator.
 
     The Stochastic Oscillator measures where the close is in relation
@@ -1588,7 +1588,7 @@ def stoch(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the Stochastic Oscillator calculation.
     index : str, optional
         Index column name to use with `data`, by default "date".
@@ -1601,7 +1601,7 @@ def stoch(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The Stochastic Oscillator data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1639,13 +1639,13 @@ def stoch(
     ],
 )
 def kc(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     length: PositiveInt = 20,
     scalar: PositiveFloat = 20,
     mamode: Literal["ema", "sma", "wma", "hma", "zlma"] = "ema",
     offset: NonNegativeInt = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Keltner Channels.
 
     Keltner Channels are volatility-based bands that are placed
@@ -1656,7 +1656,7 @@ def kc(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the Keltner Channels calculation.
     index : str, optional
         Index column name to use with `data`, by default "date"
@@ -1671,7 +1671,7 @@ def kc(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The Keltner Channels data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1709,8 +1709,8 @@ def kc(
     ],
 )
 def cg(
-    data: List[Data], index: str = "date", length: PositiveInt = 14
-) -> OBBject[List[Data]]:
+    data: list[Data], index: str = "date", length: PositiveInt = 14
+) -> OBBject[list[Data]]:
     """Calculate the Center of Gravity.
 
     The Center of Gravity indicator, in short, is used to anticipate future price movements
@@ -1721,7 +1721,7 @@ def cg(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the COG calculation.
     index : str, optional
         Index column name to use with `data`, by default "date"
@@ -1730,7 +1730,7 @@ def cg(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The COG data.
     """
     # pylint: disable=import-outside-toplevel
@@ -1762,7 +1762,7 @@ def cg(
     ],
 )
 def cones(
-    data: List[Data],
+    data: list[Data],
     index: str = "date",
     lower_q: float = 0.25,
     upper_q: float = 0.75,
@@ -1776,7 +1776,7 @@ def cones(
     ] = "std",
     is_crypto: bool = False,
     trading_periods: Optional[int] = None,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the realized volatility quantiles over rolling windows of time.
 
     The cones indicator is designed to map out the ebb and flow of price movements through a detailed analysis of
@@ -1795,7 +1795,7 @@ def cones(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the calculation.
     index : str, optional
         Index column name to use with `data`, by default "date"
@@ -1832,7 +1832,7 @@ def cones(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The cones data.
     """
     if lower_q > upper_q:
@@ -1866,12 +1866,12 @@ def cones(
     ],
 )
 def ema(
-    data: List[Data],
+    data: list[Data],
     target: str = "close",
     index: str = "date",
     length: int = 50,
     offset: int = 0,
-) -> OBBject[List[Data]]:
+) -> OBBject[list[Data]]:
     """Calculate the Exponential Moving Average (EMA).
 
     EMA is a cumulative calculation, including all data. Past values have
@@ -1881,7 +1881,7 @@ def ema(
 
     Parameters
     ----------
-    data : List[Data]
+    data : list[Data]
         The data to use for the calculation.
     target : str
         Target column name.
@@ -1894,7 +1894,7 @@ def ema(
 
     Returns
     -------
-    OBBject[List[Data]]
+    OBBject[list[Data]]
         The calculated data.
     """
     # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/technical/openbb_technical/technical_views.py
+++ b/openbb_platform/extensions/technical/openbb_technical/technical_views.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=too-many-locals,use-dict-literal
 
-from typing import TYPE_CHECKING, Any, Dict, Tuple
+from typing import TYPE_CHECKING, Any
 
 from openbb_charting.core.to_chart import to_chart
 from openbb_charting.styles.colors import LARGE_CYCLER
@@ -15,42 +15,42 @@ class TechnicalViews:
     """Technical Views."""
 
     @staticmethod
-    def technical_sma(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_sma(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Plot simple moving average chart."""
         if "ma_type" not in kwargs:
             kwargs["ma_type"] = "sma"
         return _ta_ma(**kwargs)
 
     @staticmethod
-    def technical_ema(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_ema(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Exponential moving average chart."""
         if "ma_type" not in kwargs:
             kwargs["ma_type"] = "ema"
         return _ta_ma(**kwargs)
 
     @staticmethod
-    def technical_hma(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_hma(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Hull moving average chart."""
         if "ma_type" not in kwargs:
             kwargs["ma_type"] = "hma"
         return _ta_ma(**kwargs)
 
     @staticmethod
-    def technical_wma(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_wma(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Weighted moving average chart."""
         if "ma_type" not in kwargs:
             kwargs["ma_type"] = "wma"
         return _ta_ma(**kwargs)
 
     @staticmethod
-    def technical_zlma(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_zlma(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Zero lag moving average chart."""
         if "ma_type" not in kwargs:
             kwargs["ma_type"] = "zlma"
         return _ta_ma(**kwargs)
 
     @staticmethod
-    def technical_aroon(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_aroon(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Technical Aroon Chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.core.plotly_ta.ta_class import PlotlyTA
@@ -95,7 +95,7 @@ class TechnicalViews:
         return fig, content
 
     @staticmethod
-    def technical_macd(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_macd(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Plot moving average convergence divergence chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.core.plotly_ta.ta_class import PlotlyTA
@@ -138,7 +138,7 @@ class TechnicalViews:
         return fig, content
 
     @staticmethod
-    def technical_adx(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_adx(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Average directional movement index chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.core.plotly_ta.ta_class import PlotlyTA
@@ -178,7 +178,7 @@ class TechnicalViews:
         return fig, content
 
     @staticmethod
-    def technical_rsi(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_rsi(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Relative strength index chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.core.plotly_ta.ta_class import PlotlyTA
@@ -218,7 +218,7 @@ class TechnicalViews:
         return fig, content
 
     @staticmethod
-    def technical_cones(**kwargs) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    def technical_cones(**kwargs) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Volatility Cones Chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.core.chart_style import ChartStyle
@@ -337,7 +337,7 @@ class TechnicalViews:
     @staticmethod
     def technical_relative_rotation(
         **kwargs: Any,
-    ) -> Tuple["OpenBBFigure", Dict[str, Any]]:
+    ) -> tuple["OpenBBFigure", dict[str, Any]]:
         """Relative Rotation Chart."""
         # pylint: disable=import-outside-toplevel
         from openbb_charting.charts import relative_rotation  # noqa


### PR DESCRIPTION
1. **Why**?:

    - Changes introduced to package builder broke the logic for docstring generation.

2. **What**?:

    - Refactor `DocstringGenerator`
    - Fixes CLI where type discovery failed
    - Fixes openbb-platform-api utils tests, and a key error.

3. **Impact**:

    - Missing descriptions from the `extra_params` items are now back.
    - Improved docstrings for custom extensions.

4. **Testing Done**:

Before:

```sh
        """Get historical price data for a given stock. This includes open, high, low, close, and volume.

        Parameters
        ----------
        symbol : Union[str, List[str]]
            Symbol to get data for. Multiple comma separated items allowed for provider(s): alpha_vantage, cboe, fmp, polygon, tiingo, tmx, tradier, yfinance.
        start_date : Union[date, None, str]
            Start date of the data, in YYYY-MM-DD format.
        end_date : Union[date, None, str]
            End date of the data, in YYYY-MM-DD format.
        interval : Union[Literal['1m', '5m', '15m', '30m', '60m', '1d', '1W', '1M'], Literal['1m', '1d'],...

        adjustment : Union[Literal['splits_only', 'splits_and_dividends', 'unadjusted'], Literal['splits_on...

        extended_hours : bool

        use_cache : bool

        start_time : Optional[datetime.time]

        end_time : Optional[datetime.time]

        timezone : Optional[str]

        source : Literal['realtime', 'delayed', 'nasdaq_basic']

        sort : Literal['asc', 'desc']

        limit : int

        include_actions : bool

        chart : bool
            Whether to create a chart or not, by default False.
        provider : Optional[Literal['alpha_vantage', 'cboe', 'fmp', 'intrinio', 'polygon', 'tiingo', 'tmx...

        interval : Union[Literal['1m', '5m', '15m', '30m', '60m', '1d', '1W', '1M'], Literal['1m', '1d'], Literal['1m', '5m', '15m', '30m', '1h', '4h', '1d'], Literal['1m', '5m', '10m', '15m', '30m', '60m', '1h', '1d', '1W', '1M', '1Q', '1Y'], str, Literal['1m', '5m', '15m', '30m', '90m', '1h', '2h', '4h', '1d', '1W', '1M', '1Y'], Literal['1m', '2m', '5m', '15m', '30m', '60m', '1h', '1d', '1W', '1M'], int, Literal['1m', '5m', '15m', '1d', '1W', '1M'], Literal['1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1W', '1M', '1Q']]
            Time interval of the data to return. (provider: alpha_vantage, cboe, fmp, intrinio, polygon, tiingo, tmx, tradier, yfinance)
        adjustment : Union[Literal['splits_only', 'splits_and_dividends', 'unadjusted'], Literal['splits_only', 'unadjusted'], Literal['splits_only', 'splits_and_dividends']]
            The adjustment factor to apply. 'splits_only' is not supported for intraday data. (provider: alpha_vantage);
            The adjustment factor to apply. Default is splits only. (provider: polygon);
            The adjustment factor to apply. Only valid for daily data. (provider: tmx);
            The adjustment factor to apply. Default is splits only. (provider: yfinance)
        extended_hours : bool
            Include Pre and Post market data. (provider: alpha_vantage, polygon, tradier, yfinance)
        use_cache : bool
            When True, the company directories will be cached for 24 hours and are used to validate symbols. The results of the function are not cached. Set as False to bypass. (provider: cboe)
        start_time : Optional[datetime.time]
            Return intervals starting at the specified time on the `start_date` formatted as 'HH:MM:SS'. (provider: intrinio)
        end_time : Optional[datetime.time]
            Return intervals stopping at the specified time on the `end_date` formatted as 'HH:MM:SS'. (provider: intrinio)
        timezone : Optional[str]
            Timezone of the data, in the IANA format (Continent/City). (provider: intrinio)
        source : Literal['realtime', 'delayed', 'nasdaq_basic']
            The source of the data. (provider: intrinio)
        sort : Literal['asc', 'desc']
            Sort order of the data. This impacts the results in combination with the 'limit' parameter. The results are always returned in ascending order by date. (provider: polygon)
        limit : int
            The number of data entries to return. (provider: polygon)
        include_actions : bool
            Include dividends and stock splits in results. (provider: yfinance)

        Returns
        -------
        OBBject
            results : List[EquityHistorical]
                Serializable results.
            provider : Optional[Literal['alpha_vantage', 'cboe', 'fmp', 'intrinio', 'polygon', 'tiingo', 'tmx', 'tradier', 'yfinance']]
                Provider name.
            warnings : Optional[List[Warning_]]
                List of warnings.
            chart : Optional[Chart]
                Chart object.
            extra : Dict[str, Any]
                Extra info.

        EquityHistorical
        ----------------
        date : Union[date, datetime]
            The date of the data.
        open : float
            The open price.
        high : float
            The high price.
        low : float
            The low price.
        close : float
            The close price.
        volume : Optional[Union[float, int]]
            The trading volume.
        vwap : Optional[float]
            Volume Weighted Average Price over the period.
        adj_close : Optional[Union[Annotated[float, Gt(gt=0)], float]]
            The adjusted close price. (provider: alpha_vantage, fmp, intrinio, tiingo)
        dividend : Optional[Union[Annotated[float, Ge(ge=0)], float]]
            Dividend amount, if a dividend was paid. (provider: alpha_vantage, intrinio, tiingo, yfinance)
        split_ratio : Optional[Union[Annotated[float, Ge(ge=0)], float]]
            Split coefficient, if a split occurred. (provider: alpha_vantage);
            Ratio of the equity split, if a split occurred. (provider: intrinio);
            Ratio of the equity split, if a split occurred. (provider: tiingo);
            Ratio of the equity split, if a split occurred. (provider: yfinance)
        calls_volume : Optional[int]
            Number of calls traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        puts_volume : Optional[int]
            Number of puts traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        total_options_volume : Optional[int]
            Total number of options traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        unadjusted_volume : Optional[float]
            Unadjusted volume of the symbol. (provider: fmp)
        change : Optional[float]
            Change in the price from the previous close. (provider: fmp);
            Change in the price of the symbol from the previous day. (provider: intrinio);
            Change in price. (provider: tmx)
        change_percent : Optional[float]
            Change in the price from the previous close, as a normalized percent. (provider: fmp);
            Percent change in the price of the symbol from the previous day. (provider: intrinio);
            Change in price, as a normalized percentage. (provider: tmx)
        average : Optional[float]
            Average trade price of an individual equity during the interval. (provider: intrinio)
        adj_open : Optional[float]
            The adjusted open price. (provider: intrinio, tiingo)
        adj_high : Optional[float]
            The adjusted high price. (provider: intrinio, tiingo)
        adj_low : Optional[float]
            The adjusted low price. (provider: intrinio, tiingo)
        adj_volume : Optional[float]
            The adjusted volume. (provider: intrinio, tiingo)
        fifty_two_week_high : Optional[float]
            52 week high price for the symbol. (provider: intrinio)
        fifty_two_week_low : Optional[float]
            52 week low price for the symbol. (provider: intrinio)
        factor : Optional[float]
            factor by which to multiply equity prices before this date, in order to calculate historically-adjusted equity prices. (provider: intrinio)
        close_time : Optional[datetime]
            The timestamp that represents the end of the interval span. (provider: intrinio)
        interval : Optional[str]
            The data time frequency. (provider: intrinio)
        intra_period : Optional[bool]
            If true, the equity price represents an unfinished period (be it day, week, quarter, month, or year), meaning that the close price is the latest price available, not the official close price for the period (provider: intrinio)
        transactions : Optional[Union[Annotated[int, Gt(gt=0)], int]]
            Number of transactions for the symbol in the time period. (provider: polygon);
            Total number of transactions recorded. (provider: tmx)
        transactions_value : Optional[float]
            Nominal value of recorded transactions. (provider: tmx)
        last_price : Optional[float]
            The last price of the equity. (provider: tradier)

        Examples
        --------
        >>> from openbb import obb
        >>> obb.equity.price.historical(symbol='AAPL', provider='fmp')
        >>> obb.equity.price.historical(symbol='AAPL', interval='1d', provider='intrinio')
        """  # noqa: E501
```

After:

```sh
        """Get historical price data for a given stock. This includes open, high, low, close, and volume.

        Parameters
        ----------
        provider : str
            The provider to use, by default None. If None, the priority list configured in the settings is used. Default priority: alpha_vantage, cboe, fmp, intrinio, polygon, tiingo, tmx, tradier, yfinance.
        symbol : Union[str, List[str]]
            Symbol to get data for. Multiple comma separated items allowed for provider(s): alpha_vantage, cboe, fmp, polygon, tiingo, tmx, tradier, yfinance.
        start_date : Union[date, None, str]
            Start date of the data, in YYYY-MM-DD format.
        end_date : Union[date, None, str]
            End date of the data, in YYYY-MM-DD format.
        interval : str
            Time interval of the data to return. (provider: alpha_vantage, cboe, fmp, intrinio, polygon, tiingo, tmx, tradier, yfinance)
            Choices for alpha_vantage: '1m', '5m', '15m', '30m', '60m', '1d', '1W', '1M'
            Choices for cboe: '1m', '1d'
            Choices for fmp: '1m', '5m', '15m', '30m', '1h', '4h', '1d'
            Choices for intrinio: '1m', '5m', '10m', '15m', '30m', '60m', '1h', '1d', '1W', '1M', '1Q', '1Y'
            Choices for tradier: '1m', '5m', '15m', '1d', '1W', '1M'
            Choices for yfinance: '1m', '2m', '5m', '15m', '30m', '60m', '90m', '1h', '1d', '5d', '1W', '1M', '1Q'
        adjustment : str
            The adjustment factor to apply;
            'splits_only' is not supported for intraday data. (provider: alpha_vantage);
            Default is splits only. (provider: polygon);
            Only valid for daily data. (provider: tmx);
            Default is splits only. (provider: yfinance)
            Choices for alpha_vantage: 'splits_only', 'splits_and_dividends', 'unadjusted'
            Choices for polygon: 'splits_only', 'unadjusted'
            Choices for tmx: 'splits_only', 'splits_and_dividends', 'unadjusted'
            Choices for yfinance: 'splits_only', 'splits_and_dividends'
        extended_hours : bool
            Include Pre and Post market data. (provider: alpha_vantage, polygon, tradier, yfinance)
        use_cache : bool
            When True, the company directories will be cached for 24 hours and are used to validate symbols. The results of the function are not cached. Set as False to bypass. (provider: cboe)
        start_time : Optional[datetime.time]
            Return intervals starting at the specified time on the `start_date` formatted as 'HH:MM:SS'. (provider: intrinio)
        end_time : Optional[datetime.time]
            Return intervals stopping at the specified time on the `end_date` formatted as 'HH:MM:SS'. (provider: intrinio)
        timezone : Optional[str]
            Timezone of the data, in the IANA format (Continent/City). (provider: intrinio)
        source : Literal['realtime', 'delayed', 'nasdaq_basic']
            The source of the data. (provider: intrinio)
        sort : Literal['asc', 'desc']
            Sort order of the data. This impacts the results in combination with the 'limit' parameter. The results are always returned in ascending order by date. (provider: polygon)
        limit : int
            The number of data entries to return. (provider: polygon)
        include_actions : bool
            Include dividends and stock splits in results. (provider: yfinance)
        chart : bool
            Whether to create a chart or not, by default False.

        Returns
        -------
        OBBject
            results : List[EquityHistorical]
                Serializable results.
            provider : Optional[str]
                Provider name.
            warnings : Optional[List[Warning_]]
                List of warnings.
            chart : Optional[Chart]
                Chart object.
            extra : Dict[str, Any]
                Extra info.

        EquityHistorical
        ----------------
        date : Union[date, datetime]
            The date of the data.
        open : float
            The open price.
        high : float
            The high price.
        low : float
            The low price.
        close : float
            The close price.
        volume : Optional[Union[float, int]]
            The trading volume.
        vwap : Optional[float]
            Volume Weighted Average Price over the period.
        adj_close : Optional[Union[Annotated[float, Gt(gt=0)], float]]
            The adjusted close price. (provider: alpha_vantage, fmp, intrinio, tiingo)
        dividend : Optional[Union[Annotated[float, Ge(ge=0)], float]]
            Dividend amount, if a dividend was paid. (provider: alpha_vantage, intrinio, tiingo, yfinance)
        split_ratio : Optional[Union[Annotated[float, Ge(ge=0)], float]]
            Split coefficient, if a split occurred. (provider: alpha_vantage);
            Ratio of the equity split, if a split occurred. (provider: intrinio);
            Ratio of the equity split, if a split occurred. (provider: tiingo);
            Ratio of the equity split, if a split occurred. (provider: yfinance)
        calls_volume : Optional[int]
            Number of calls traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        puts_volume : Optional[int]
            Number of puts traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        total_options_volume : Optional[int]
            Total number of options traded during the most recent trading period. Only valid if interval is 1m. (provider: cboe)
        unadjusted_volume : Optional[float]
            Unadjusted volume of the symbol. (provider: fmp)
        change : Optional[float]
            Change in the price from the previous close. (provider: fmp);
            Change in the price of the symbol from the previous day. (provider: intrinio);
            Change in price. (provider: tmx)
        change_percent : Optional[float]
            Change in the price from the previous close, as a normalized percent. (provider: fmp);
            Percent change in the price of the symbol from the previous day. (provider: intrinio);
            Change in price, as a normalized percentage. (provider: tmx)
        average : Optional[float]
            Average trade price of an individual equity during the interval. (provider: intrinio)
        adj_open : Optional[float]
            The adjusted open price. (provider: intrinio, tiingo)
        adj_high : Optional[float]
            The adjusted high price. (provider: intrinio, tiingo)
        adj_low : Optional[float]
            The adjusted low price. (provider: intrinio, tiingo)
        adj_volume : Optional[float]
            The adjusted volume. (provider: intrinio, tiingo)
        fifty_two_week_high : Optional[float]
            52 week high price for the symbol. (provider: intrinio)
        fifty_two_week_low : Optional[float]
            52 week low price for the symbol. (provider: intrinio)
        factor : Optional[float]
            factor by which to multiply equity prices before this date, in order to calculate historically-adjusted equity prices. (provider: intrinio)
        close_time : Optional[datetime]
            The timestamp that represents the end of the interval span. (provider: intrinio)
        interval : Optional[str]
            The data time frequency. (provider: intrinio)
        intra_period : Optional[bool]
            If true, the equity price represents an unfinished period (be it day, week, quarter, month, or year), meaning that the close price is the latest price available, not the official close price for the period (provider: intrinio)
        transactions : Optional[Union[Annotated[int, Gt(gt=0)], int]]
            Number of transactions for the symbol in the time period. (provider: polygon);
            Total number of transactions recorded. (provider: tmx)
        transactions_value : Optional[float]
            Nominal value of recorded transactions. (provider: tmx)
        last_price : Optional[float]
            The last price of the equity. (provider: tradier)

        Examples
        --------
        >>> from openbb import obb
        >>> obb.equity.price.historical(symbol='AAPL', provider='fmp')
        >>> obb.equity.price.historical(symbol='AAPL', interval='1d', provider='intrinio')
```


Custom endpoint with dependency injection, where the only docstring was """Get OHLC bars."""

```sh
Signature:
obb.udf_yfinance.history(
    symbol: Annotated[str, OpenBBField(description='Symbol')],
    from_time: Annotated[int, OpenBBField(description='From timestamp')],
    resolution: Annotated[str, OpenBBField(description='Resolution')] = 'D',
    to_time: Annotated[int, OpenBBField(description='To timestamp')] = None,
    countback: Annotated[int, OpenBBField(description='Count back')] = None,
    **kwargs: Any,
) -> openbb_yfinance_udf.models.YFinanceUDFBar
Docstring:
Get OHLC bars.

Parameters
----------
symbol : str
    Symbol
from_time : int
    From timestamp
resolution : Optional[str]
    Resolution
to_time : Optional[int]
    To timestamp
countback : Optional[int]
    Count back

Returns
-------
YFinanceUDFBar
    s : str
        Status. Send 'ok' to return bar data.
    errmsg : Optional[str]
        Error message.
    t : Optional[list[int]]
        Timestamps.
    c : Optional[list[float]]
        Close prices.
    o : Optional[list[float]]
        Open prices.
    h : Optional[list[float]]
        High prices.
    l : Optional[list[float]]
        Low prices.
    v : Optional[list[float]]
        Volume.
    nextTime : Optional[int]
        Next timestamp.
```
