### PR TITLE
[BugFix] `etf.sectors(provider='tmx')` - Fix Key Error When No Info Found

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -462,7 +462,7 @@ def process_parameter(param: dict, providers: list[str]) -> dict:
 
             # If parameter is provider-specific but not valid for any of our current providers, skip it
             if not valid_for_current_providers:
-                return None
+                return {}
 
     return p
 

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -739,6 +739,7 @@ def data_schema_to_columns_defs(  # noqa: PLR0912  # pylint: disable=too-many-br
                 else "percent"
             )
             column_def["renderFn"] = "greenRed"
+            column_def["cellDataType"] = "number"
 
         if k in ["cik", "isin", "figi", "cusip", "sedol", "symbol"]:
             column_def["cellDataType"] = "text"
@@ -749,9 +750,6 @@ def data_schema_to_columns_defs(  # noqa: PLR0912  # pylint: disable=too-many-br
         if k in ["fiscal_year", "year", "year_born"]:
             column_def["cellDataType"] = "number"
             column_def["formatterFn"] = "none"
-
-        if "date" in column_def["headerTooltip"].lower():
-            column_def["cellDataType"] = "date"
 
         if (
             route

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/openapi.py
@@ -821,7 +821,7 @@ def post_query_schema_for_widget(
 
     new_params: dict = {}
 
-    def set_param(k, v, parent_name=None):
+    def set_param(k, v):
         """Set the parameter."""
         nonlocal new_params
 
@@ -934,7 +934,7 @@ def post_query_schema_for_widget(
             route_params: list[dict] = []
             providers = ["custom"]
 
-            for new_param, new_param_values in new_params.items():
+            for new_param_values in new_params.values():
                 _new_values = new_param_values.copy()
                 p = process_parameter(_new_values, providers)
                 if not p.get("exclude") and not p.get("x-widget_config", {}).get(

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_holdings.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_holdings.py
@@ -48,7 +48,9 @@ class TmxEtfHoldingsData(EtfHoldingsData):
     market_value: Optional[Union[float, str]] = Field(
         description="The market value of the holding.", default=None
     )
-    currency: Optional[str] = Field(description="The currency of the holding.")
+    currency: Optional[str] = Field(
+        default=None, description="The currency of the holding."
+    )
     share_percentage: Optional[float] = Field(
         description="The share percentage of the holding, as a normalized percentage.",
         default=None,

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_search.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_search.py
@@ -24,7 +24,7 @@ class TmxEtfSearchQueryParams(EtfSearchQueryParams):
 
     sort_by: Optional[
         Literal[
-            "nav",
+            "aum",
             "return_1m",
             "return_3m",
             "return_6m",

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
@@ -47,6 +47,7 @@ class TmxEtfSectorsFetcher(
     ) -> List[Dict]:
         """Return the raw data from the TMX endpoint."""
         # pylint: disable=import-outside-toplevel
+        from openbb_core.provider.utils.errors import EmptyDataError  # noqa
         from openbb_tmx.utils.helpers import get_all_etfs
         from pandas import DataFrame
 
@@ -65,6 +66,7 @@ class TmxEtfSectorsFetcher(
                 columns={"name": "sector", "percent": "weight"}
             )
             return target.to_dict(orient="records")
+        raise EmptyDataError(f"No sectors info found for ETF symbol: {query.symbol}.")
 
     @staticmethod
     def transform_data(

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
@@ -83,8 +83,8 @@ class TmxEtfSectorsFetcher(
         target = DataFrame(data)
         try:
             target["weight"] = target["weight"] / 100
-        except KeyError:  # pylint: disable=raise-missing-from
-            raise EmptyDataError(
+        except KeyError:
+            raise EmptyDataError(  # pylint: disable=raise-missing-from
                 f"No sectors info found for ETF symbol: {query.symbol}."
             )
 

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
@@ -59,11 +59,12 @@ class TmxEtfSectorsFetcher(
             .replace(".TSX", "")
         )
         _target = _data[_data["symbol"] == symbol]["sectors"]
+
         if len(_target) > 0:
             target = DataFrame.from_records(_target.iloc[0]).rename(
                 columns={"name": "sector", "percent": "weight"}
             )
-        return target.to_dict(orient="records")
+            return target.to_dict(orient="records")
 
     @staticmethod
     def transform_data(
@@ -73,14 +74,19 @@ class TmxEtfSectorsFetcher(
     ) -> List[TmxEtfSectorsData]:
         """Return the transformed data."""
         # pylint: disable=import-outside-toplevel
+        from openbb_core.provider.utils.errors import EmptyDataError  # noqa
+        from numpy import nan
         from pandas import DataFrame
 
         target = DataFrame(data)
-        target["weight"] = target["weight"] / 100
-        target["sector"] = (
-            target["sector"].astype(str).str.lower().str.replace(" ", "_")
-        )
-        target = target.fillna(value="N/A").replace("N/A", None)
+        try:
+            target["weight"] = target["weight"] / 100
+        except KeyError:
+            raise EmptyDataError(
+                f"No sectors info found for ETF symbol: {query.symbol}."
+            )
+
+        target = target.replace({nan: None})
         return [
             TmxEtfSectorsData.model_validate(d)
             for d in target.to_dict(orient="records")

--- a/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/etf_sectors.py
@@ -83,7 +83,7 @@ class TmxEtfSectorsFetcher(
         target = DataFrame(data)
         try:
             target["weight"] = target["weight"] / 100
-        except KeyError:
+        except KeyError:  # pylint: disable=raise-missing-from
             raise EmptyDataError(
                 f"No sectors info found for ETF symbol: {query.symbol}."
             )

--- a/openbb_platform/providers/tmx/openbb_tmx/models/index_sectors.py
+++ b/openbb_platform/providers/tmx/openbb_tmx/models/index_sectors.py
@@ -82,7 +82,7 @@ class TmxIndexSectorsFetcher(
             temp = data["indices"][query.symbol].get("sectors")
             results = [
                 {
-                    "sector": d.get("name").lower().replace(" ", "_"),
+                    "sector": d.get("name"),
                     "weight": d.get("weight"),
                 }
                 for d in temp


### PR DESCRIPTION
1. **Why**?:

    - KeyError caused by empty result.
    - Found a widget `columnDef` being defined as a date when it is a percent.

2. **What**?:

    - Fixes KeyError
    - Narrows scope of date-like field type definitions by `openbb-platform-api`


3. **Impact**:

    - Fixes bugs and improves accuracy. 

4. **Testing Done**:

    - You can check with:
      - `obb.etf.sectors("CASH", provider="tmx")
      - `obb.etf.info("CASH", provider="tmx")

    - Workspace backend widget, "Return YTD", was missing from a bar chart created by `etf.info`
      - `etf.sectors` was not returning None cleanly.
 

<img width="847" alt="Screenshot 2025-03-24 at 12 15 36 PM" src="https://github.com/user-attachments/assets/7afa2fff-7a64-471c-98c3-4f33e222d563" />
