### PR TITLE
[BugFix] Safely Access `openapi_extra` When None

### DIFF
--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -185,7 +185,11 @@ def build_api_wrapper(
     func: Callable = route.endpoint  # type: ignore
     path: str = route.path  # type: ignore
 
-    no_validate = route.openapi_extra.get("no_validate")
+    no_validate = (
+        openapi_extra.get("no_validate")
+        if (openapi_extra := getattr(route, "openapi_extra", None))
+        else None
+    )
     new_signature = build_new_signature(path=path, func=func)
     new_annotations_map = build_new_annotation_map(sig=new_signature)
     func.__signature__ = new_signature  # type: ignore

--- a/openbb_platform/core/openbb_core/app/router.py
+++ b/openbb_platform/core/openbb_core/app/router.py
@@ -423,7 +423,7 @@ class CommandMap:
 
         coverage_map: Dict[Any, Any] = {}
         for route in api_router.routes:
-            openapi_extra = getattr(route, "openapi_extra")
+            openapi_extra = getattr(route, "openapi_extra", None)
             if openapi_extra:
                 model = openapi_extra.get("model", None)
                 if model:

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -1693,36 +1693,6 @@ class DocstringGenerator:
         provider_param: Union[Parameter, dict] = {}
         chart_param: Union[Parameter, dict] = {}
 
-        def process_param(param_name, param_type, description, kwarg_info=None):
-            """Process parameter info and add provider-specific choices info."""
-            formatted_description = description
-
-            # Check if we have provider-specific choices information for this parameter
-            if kwarg_info and param_name in kwarg_info:
-                param_info = kwarg_info[param_name]
-                for provider, details in param_info.items():
-                    if "choices" in details and details["choices"]:
-                        multiple_items = details.get("multiple_items_allowed", False)
-                        multiple_text = (
-                            " Multiple comma separated items allowed."
-                            if multiple_items
-                            else ""
-                        )
-
-                        # For parameters with many choices (like form_type for SEC)
-                        if len(details["choices"]) > 20:
-                            formatted_description += (
-                                f" (provider: {provider}){multiple_text}"
-                            )
-                        # For parameters with reasonable number of choices
-                        else:
-                            choices_str = ", ".join(
-                                [f"'{c}'" for c in details["choices"]]
-                            )
-                            formatted_description += f"\nChoices for {provider}: {choices_str}{multiple_text}"
-
-            return formatted_description
-
         # Description summary
         if "description" in sections:
             docstring = summary.strip("\n").replace("\n    ", f"\n{create_indent(2)}")

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -320,7 +320,7 @@ class ImportDefinition:
     def get_function_hint_type_list(cls, route) -> List[Type]:
         """Get the hint type list from the function."""
 
-        no_validate = route.openapi_extra.get("no_validate")
+        no_validate = getattr(route, "openapi_extra.get", {}).get("no_validate")
 
         func = route.endpoint
         sig = signature(func)
@@ -533,7 +533,11 @@ class ClassDefinition:
                         if route.openapi_extra
                         else None
                     ),
-                    examples=(route.openapi_extra.get("examples", []) or []),
+                    examples=(
+                        route.openapi_extra.get("examples", [])
+                        if route.openapi_extra
+                        else []
+                    ),
                 )
             else:
                 doc += "    /" if path else "    /"

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -320,7 +320,7 @@ class ImportDefinition:
     def get_function_hint_type_list(cls, route) -> List[Type]:
         """Get the hint type list from the function."""
 
-        no_validate = getattr(route, "openapi_extra.get", {}).get("no_validate")
+        no_validate = getattr(route, "openapi_extra", {}).get("no_validate")
 
         func = route.endpoint
         sig = signature(func)


### PR DESCRIPTION
1. **Why**?:

    - There were a couple of spots where `openapi_extra` was being accessed as a dictionary when the value was None.

2. **What**?:

    - Fixes those instances to include the None check.

3. **Impact**:

    - Custom extensions, Platform endpoints will have items in the openapi_extra slot.

4. **Testing Done**:
    - Custom Router extension, create the function by directly accessing APIRouter instance.

`@router._api_router.get("/get_data_choices")`

