### PR TITLE
[BugFix] Fix missing docstring examples from `openbb-build` script.

### DIFF
--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -70,20 +70,20 @@ def main():
         except Exception as e:
             raise RuntimeError(  # noqa
                 "Failed to build the OpenBB platform static assets. \n"
-                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # noqa
-                f"{e.__traceback__.tb_lineno}"  # noqa
+                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # type:ignore
+                f"{e.__traceback__.tb_lineno}"  # type:ignore
                 if hasattr(e, "__traceback__")
-                and hasattr(e.__traceback__, "tb_frame")  # noqa
+                and hasattr(e.__traceback__, "tb_frame")  # type:ignore
                 and hasattr(
-                    e.__traceback__.tb_frame,  # noqa
+                    e.__traceback__.tb_frame,  # type:ignore
                     "f_code",
                 )
                 and hasattr(
-                    e.__traceback__.tb_frame.f_code,  # noqa
+                    e.__traceback__.tb_frame.f_code,  # type:ignore
                     "co_filename",
                 )
                 and hasattr(
-                    e.__traceback__,  # noqa
+                    e.__traceback__,  # type:ignore
                     "tb_lineno",
                 )
                 else f"Failed to build the OpenBB platform static assets. \n{e}"

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -68,10 +68,25 @@ def main():
             openbb.build()
 
         except Exception as e:
-            raise RuntimeError(
+            raise RuntimeError(  # noqa
                 "Failed to build the OpenBB platform static assets. \n"
-                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"
-                f"{e.__traceback__.tb_lineno}"
+                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # noqa
+                f"{e.__traceback__.tb_lineno}"  # noqa
+                if hasattr(e, "__traceback__")
+                and hasattr(e.__traceback__, "tb_frame")
+                and hasattr(
+                    e.__traceback__.tb_frame,
+                    "f_code",
+                )
+                and hasattr(
+                    e.__traceback__.tb_frame.f_code,
+                    "co_filename",
+                )
+                and hasattr(
+                    e.__traceback__,
+                    "tb_lineno",
+                )
+                else f"Failed to build the OpenBB platform static assets. \n{e}"
             ) from e
     sys.exit(0)
 

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -73,17 +73,17 @@ def main():
                 f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # noqa
                 f"{e.__traceback__.tb_lineno}"  # noqa
                 if hasattr(e, "__traceback__")
-                and hasattr(e.__traceback__, "tb_frame")
+                and hasattr(e.__traceback__, "tb_frame")  # noqa
                 and hasattr(
-                    e.__traceback__.tb_frame,
+                    e.__traceback__.tb_frame,  # noqa
                     "f_code",
                 )
                 and hasattr(
-                    e.__traceback__.tb_frame.f_code,
+                    e.__traceback__.tb_frame.f_code,  # noqa
                     "co_filename",
                 )
                 and hasattr(
-                    e.__traceback__,
+                    e.__traceback__,  # noqa
                     "tb_lineno",
                 )
                 else f"Failed to build the OpenBB platform static assets. \n{e}"

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -70,7 +70,7 @@ def main():
         except Exception as e:
             raise RuntimeError(  # noqa
                 "Failed to build the OpenBB platform static assets. \n"
-                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # type:ignore
+                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # type:ignore  # noqa: E1101
                 f"{e.__traceback__.tb_lineno}"  # type:ignore
                 if hasattr(e, "__traceback__")
                 and hasattr(e.__traceback__, "tb_frame")  # type:ignore
@@ -79,7 +79,7 @@ def main():
                     "f_code",
                 )
                 and hasattr(
-                    e.__traceback__.tb_frame.f_code,  # type:ignore
+                    e.__traceback__.tb_frame.f_code,  # type:ignore  # noqa: E1101
                     "co_filename",
                 )
                 and hasattr(

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -70,7 +70,7 @@ def main():
         except Exception as e:
             raise RuntimeError(  # noqa
                 "Failed to build the OpenBB platform static assets. \n"
-                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # type:ignore  # noqa: E1101
+                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"  # type:ignore  # pylint: disable=E1101
                 f"{e.__traceback__.tb_lineno}"  # type:ignore
                 if hasattr(e, "__traceback__")
                 and hasattr(e.__traceback__, "tb_frame")  # type:ignore
@@ -79,7 +79,7 @@ def main():
                     "f_code",
                 )
                 and hasattr(
-                    e.__traceback__.tb_frame.f_code,  # type:ignore  # noqa: E1101
+                    e.__traceback__.tb_frame.f_code,  # type:ignore  # pylint: disable=E1101
                     "co_filename",
                 )
                 and hasattr(

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -2,37 +2,77 @@
 
 # flake8: noqa: S603
 # pylint: disable=import-outside-toplevel,unused-import
-
+import logging
 import subprocess
 import sys
+
+logger = logging.getLogger(__name__)
+logger.setLevel(logging.INFO)
+handler = logging.StreamHandler()
+handler.setLevel(logging.INFO)
+formatter = logging.Formatter("%(message)s")
+handler.setFormatter(formatter)
+logger.addHandler(handler)
 
 
 def main():
     """Build the OpenBB platform static assets."""
     try:
-        import openbb  # noqa
-    except (
-        ImportError,
-        ModuleNotFoundError,
-        AttributeError,
-    ):
-        print(  # noqa: T201
+        logger.info("Attempting to import the OpenBB package...\n")
+        # Try importing openbb in a subprocess and capture output
+        result = subprocess.run(
+            [sys.executable, "-c", "import openbb"],
+            capture_output=True,
+            text=True,
+            check=True,
+        )
+        logger.info(result.stdout)
+        building_found = any(
+            line.startswith("Building") for line in result.stdout.splitlines()
+        )
+
+        if result.returncode != 0:
+            raise ModuleNotFoundError(result.stderr)
+
+    except ModuleNotFoundError:
+        logger.info(
             "\nOpenBB build script not found, installing from PyPI...\n",
         )
         subprocess.run(
             [sys.executable, "-m", "pip", "install", "openbb", "--no-deps"],
             check=True,
         )
-
         try:
-            subprocess.run(
-                [sys.executable, "-c", "import openbb; openbb.build()"],
-                check=True,
+            result = logger.info.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import openbb;openbb.build()",
+                ],
+                capture_output=True,
+                text=True,
+            )
+            logger.info(result.stdout)
+            building_found = any(
+                line.startswith("Building") for line in result.stdout.splitlines()
             )
         except Exception as e:
+            raise RuntimeError(f"Failed to import the OpenBB package. \n{e}") from e
+
+    if not building_found:
+        try:
+            import openbb  # noqa
+
+            logger.info("Did not build on import, triggering rebuild...\n")
+            openbb.build()
+
+        except Exception as e:
             raise RuntimeError(
-                f"Failed to build the OpenBB platform static assets. \n{e}"
+                "Failed to build the OpenBB platform static assets. \n"
+                f"{e} -> {e.__traceback__.tb_frame.f_code.co_filename}:"
+                f"{e.__traceback__.tb_lineno}"
             ) from e
+    sys.exit(0)
 
 
 if __name__ == "__main__":

--- a/openbb_platform/core/openbb_core/build.py
+++ b/openbb_platform/core/openbb_core/build.py
@@ -43,14 +43,15 @@ def main():
             check=True,
         )
         try:
-            result = logger.info.run(
+            result = subprocess.run(
                 [
                     sys.executable,
                     "-c",
-                    "import openbb;openbb.build()",
+                    "import openbb",
                 ],
                 capture_output=True,
                 text=True,
+                check=True,
             )
             logger.info(result.stdout)
             building_found = any(
@@ -60,10 +61,10 @@ def main():
             raise RuntimeError(f"Failed to import the OpenBB package. \n{e}") from e
 
     if not building_found:
+        logger.info("Did not build on import, triggering rebuild...\n")
         try:
             import openbb  # noqa
 
-            logger.info("Did not build on import, triggering rebuild...\n")
             openbb.build()
 
         except Exception as e:


### PR DESCRIPTION
This PR will address the missing examples section in the documentation pages, and docstrings.

The problem was that the build script was being run in separate processes, while `import openbb` in the main thread was also engaging it. 

The fix is to move the initial `import openbb` statement into a subprocess and monitor the stdout for confirmation if a build happened on import.

If a build has not happened, then `openbb-build` will then trigger a rebuild event in the main thread.

This makes sure that all actions involving writing to the static assets are contained to the same thread.

This can be tested by watching the static asset files and running `openbb-build` from the command line with `openbb-core`