### PR TITLE
[BugFix] Handle Dictionaries & Single Model Results Better In `to_dataframe`

### DIFF
--- a/openbb_platform/core/tests/app/model/test_obbject.py
+++ b/openbb_platform/core/tests/app/model/test_obbject.py
@@ -129,7 +129,7 @@ class MockDataFrame(Data):
                 "3": {"x": 3, "y": 1},
                 "4": {"x": 4, "y": 6},
             },
-            pd.DataFrame(
+            pd.DataFrame.from_dict(
                 {
                     "0": {"x": 0, "y": 2},
                     "1": {"x": 1, "y": 3},
@@ -137,13 +137,15 @@ class MockDataFrame(Data):
                     "3": {"x": 3, "y": 1},
                     "4": {"x": 4, "y": 6},
                 },
+                orient="index",
             ),
         ),
         # Test case 8: Dict of Lists
         (
             {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]},
-            pd.DataFrame(
-                {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]}
+            pd.DataFrame.from_dict(
+                {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]},
+                orient="index",
             ),
         ),
         # Test case 9: List of dict of data
@@ -305,7 +307,7 @@ def test_to_df_daylight_savings(results):
         # Test case 3: Dict of lists
         (
             {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]},
-            {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]},
+            {0: [0, 1, 2, 3, 4], 1: [2, 3, 0, 1, 6]},
         ),
         # Test case 4: No results
         ([], OpenBBError("Results not found.")),
@@ -335,7 +337,7 @@ def test_to_df_daylight_savings(results):
                 "3": {"x": 3, "y": 1},
                 "4": {"x": 4, "y": 6},
             },
-            {"x": [0, 1, 2, 3, 4], "y": [2, 3, 0, 1, 6]},
+            {"0": [0, 2], "1": [1, 3], "2": [2, 0], "3": [3, 1], "4": [4, 6]},
         ),
     ],
 )

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/helpers.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/helpers.py
@@ -38,7 +38,7 @@ def z_score_standardization(data: "Series") -> "Series":
 
 def calculate_returns(data: "Series") -> "Series":
     """Calculate the returns of a column."""
-    return ((1 + data.pct_change().dropna()).cumprod() - 1) * 100
+    return ((1 + data.pct_change(fill_method=None).fillna(0)).cumprod() - 1) * 100
 
 
 def should_share_axis(


### PR DESCRIPTION
1. **Why**?:

    - `to_dataframe()` was struggling when an oddly-shaped model was being passed in.

This would result in various ValueErrors:

```python
ValueError: All arrays must be of the same length

ValueError: If using all scalar values, you must pass an index. Ensure the data format matches the expected format.
```

2. **What**?:

    - This fix involves creating a Pandas Series from the content instead of a DataFrame, and then using `to_frame()`.
    - If the object is of BaseModel-type, the column will be named using the class.
    - If the object is a dictionary, we test for "orient" and then fallback on creating a Series where the column is named, "values".

Additionally, this handles a FutureWarning in the charting library, silenced with,`fill_method=None`

3. **Impact**:

    - Fewer conversion errors, CLI will work better.

4. **Testing Done**:

In CLI, you can do:

```sh
equity/price/historical --symbol AAPL/../../quantitative/capm --data OBB0 --target close
```

![Screenshot 2025-04-24 at 10 18 40 AM](https://github.com/user-attachments/assets/31bc2ebd-f87b-4de7-bd6f-510c354964b8)

