### PR TITLE
[BugFix] Fixes For FutureWarning Items

### DIFF
--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
@@ -1127,11 +1127,7 @@ class OpenBBFigure(go.Figure):
         for row, row_dict in self._subplot_xdates.items():
             for col, values in row_dict.items():
                 try:
-                    x_values = (
-                        to_datetime(concatenate(values))
-                        .to_pydatetime()
-                        .astype("datetime64[ms]")
-                    )
+                    x_values = to_datetime(concatenate(values)).to_pydatetime()
                     self.hide_date_gaps(
                         DataFrame(index=x_values.tolist()),
                         row=row,

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/plotly_ta/data_classes.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/plotly_ta/data_classes.py
@@ -388,6 +388,8 @@ class TA_Data:
                 ) from e
 
             if indicator_data is not None:
-                output = output.join(indicator_data).interpolate("linear")
+                output = output.join(indicator_data).infer_objects(copy=False)
+                numeric_cols = output.select_dtypes(include=["number"]).columns
+                output[numeric_cols] = output[numeric_cols].interpolate("linear")
 
         return output

--- a/openbb_platform/providers/intrinio/openbb_intrinio/models/market_snapshots.py
+++ b/openbb_platform/providers/intrinio/openbb_intrinio/models/market_snapshots.py
@@ -6,7 +6,7 @@ from datetime import (
     date as dateType,
     datetime,
 )
-from typing import Any, Dict, List, Optional, Union
+from typing import Any, Optional, Union
 
 from openbb_core.app.model.abstract.error import OpenBBError
 from openbb_core.provider.abstract.fetcher import Fetcher
@@ -85,13 +85,13 @@ class IntrinioMarketSnapshotsData(MarketSnapshotsData):
 class IntrinioMarketSnapshotsFetcher(
     Fetcher[
         IntrinioMarketSnapshotsQueryParams,
-        List[IntrinioMarketSnapshotsData],
+        list[IntrinioMarketSnapshotsData],
     ]
 ):
     """Transform the query, extract and transform the data from the Intrinio endpoints."""
 
     @staticmethod
-    def transform_query(params: Dict[str, Any]) -> IntrinioMarketSnapshotsQueryParams:
+    def transform_query(params: dict[str, Any]) -> IntrinioMarketSnapshotsQueryParams:
         """Transform the query params."""
         # pylint: disable=import-outside-toplevel
         from pytz import timezone
@@ -137,9 +137,9 @@ class IntrinioMarketSnapshotsFetcher(
     @staticmethod
     async def aextract_data(
         query: IntrinioMarketSnapshotsQueryParams,
-        credentials: Optional[Dict[str, str]],
+        credentials: Optional[dict[str, str]],
         **kwargs: Any,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """Return the raw data from the Intrinio endpoint."""
         # pylint: disable=import-outside-toplevel
         import asyncio  # noqa
@@ -165,7 +165,7 @@ class IntrinioMarketSnapshotsFetcher(
             raise OpenBBError(
                 f"Error: {response.get('error')}. Message: {response.get('message')}"
             )
-        urls = []
+        urls: list = []
         # Get the URL to the CSV file.
         if response.get("snapshots"):  # type: ignore
             for d in response["snapshots"]:  # type: ignore
@@ -176,7 +176,7 @@ class IntrinioMarketSnapshotsFetcher(
         if not urls:
             raise OpenBBError("No snapshots found.")
 
-        results = []
+        results: list = []
 
         async def response_callback(response, _):
             """Response Callback."""
@@ -231,7 +231,7 @@ class IntrinioMarketSnapshotsFetcher(
                         )
                     )
                     .dt.tz_convert("America/New_York")
-                    .dt.floor("S")
+                    .dt.floor("s")
                 )
 
             for c in ["trade_size", "total_trade_volume"]:
@@ -256,8 +256,8 @@ class IntrinioMarketSnapshotsFetcher(
     @staticmethod
     def transform_data(
         query: IntrinioMarketSnapshotsQueryParams,
-        data: List[Dict],
+        data: list[dict],
         **kwargs: Any,
-    ) -> List[IntrinioMarketSnapshotsData]:
+    ) -> list[IntrinioMarketSnapshotsData]:
         """Return the transformed data."""
         return [IntrinioMarketSnapshotsData.model_validate(d) for d in data]

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
@@ -124,7 +124,8 @@ class NasdaqEquitySearchFetcher(
         """Transform the data and filter the results."""
         # pylint: disable=import-outside-toplevel
         from io import StringIO  # noqa
-        from pandas import read_csv  # noqa
+        from numpy import nan
+        from pandas import read_csv
 
         directory = read_csv(StringIO(data), sep="|").iloc[:-1]
 
@@ -142,9 +143,8 @@ class NasdaqEquitySearchFetcher(
             ]
         directory["Market Category"] = directory["Market Category"].replace(" ", None)
         results = (
-            directory.astype(object)
-            .fillna("N/A")
-            .replace("N/A", None)
+            directory.infer_objects(copy=False)
+            .replace({nan: None})
             .to_dict(orient="records")
         )
 

--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py
@@ -134,6 +134,10 @@ class NasdaqEquitySearchFetcher(
         if query.is_etf is False:
             directory = directory[directory["ETF"] == "N"]
 
+        directory = directory[
+            ~directory["Security Name"].str.contains("test", case=False)
+        ]
+
         if query.query:
             directory = directory[
                 directory["Symbol"].str.contains(query.query, case=False)


### PR DESCRIPTION
This PR resolves the following warnings:

```sh
/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py:1133: UserWarning:
no explicit representation of timezones available for np.datetime64


/openbb_platform/obbject_extensions/charting/openbb_charting/core/plotly_ta/data_classes.py:391: FutureWarning:
DataFrame.interpolate with object dtype is deprecated and will raise in a future version. Call obj.infer_objects(copy=False) before interpolating instead.


/openbb_platform/providers/intrinio/openbb_intrinio/models/market_snapshots.py:234: FutureWarning: 'S' is deprecated and will be removed in a future version, please use 's' instead.


/openbb_platform/providers/nasdaq/openbb_nasdaq/models/equity_search.py:146: FutureWarning:
Downcasting object dtype arrays on .fillna, .ffill, .bfill is deprecated and will change in a future version. Call result.infer_objects(copy=False) instead. To opt-in to the future behavior, set `pd.set_option('future.no_silent_downcasting', True)`
```