### PR TITLE
[BugFix] Fix FOMC Minutes App and Default App Images

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/assets/default_apps.json
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/assets/default_apps.json
@@ -1,7 +1,7 @@
 [
   {
     "name": "FOMC Documents",
-    "img": "https://papers.ssrn.com/sol3/journalcovers/671301_22122.gif",
+    "img": "https://upload.wikimedia.org/wikipedia/commons/thumb/7/71/Flag_of_the_United_States_Federal_Reserve.svg/640px-Flag_of_the_United_States_Federal_Reserve.svg.png",
     "img_dark": "",
     "img_light": "",
     "description": "Read current and historical FOMC documents, beginning 1959.",
@@ -30,7 +30,7 @@
   },
   {
     "name": "Basic FRED Template",
-    "img": "https://www.ajcottleappraisers.com/wp-content/uploads/2024/03/fred.png",
+    "img": "https://tvblog-static.tradingview.com/uploads/2021/07/fred-preview.png",
     "description": "FRED (Federal Reserve Economic Data) offers U.S. and global economic data, including GDP, inflation (CPI, PCE), unemployment, and consumer spending. It tracks interest rates, money supply (M1, M2), stock indices, bond yields, exchange rates, housing prices (Case-Shiller), mortgage rates, and trade balances. Industry data covers manufacturing, energy, and real estate.",
     "authentication": "Get your FRED API KEY at https://fred.stlouisfed.org/docs/api/api_key.html",
     "allowCustomization": true,

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -53,15 +53,12 @@ if _app:
     app = _app
 
 WIDGETS_PATH = kwargs.pop("widgets-path", None)
-TEMPLATES_PATH = kwargs.pop("templates-path", None)
+TEMPLATES_PATH = kwargs.pop("apps-json", None) or kwargs.pop("templates-path", None)
 EDITABLE = kwargs.pop("editable", None) is True or WIDGETS_PATH is not None
 
 
 DEFAULT_TEMPLATES_PATH = (
-    Path(__file__)
-    .absolute()
-    .parent.joinpath("assets")
-    .joinpath("default_templates.json")
+    Path(__file__).absolute().parent.joinpath("assets").joinpath("default_apps.json")
 )
 COPILOTS = kwargs.pop("copilots", None)
 build = kwargs.pop("build", True)
@@ -102,11 +99,11 @@ widgets_json = get_widgets_json(
 TEMPLATES_PATH = (
     TEMPLATES_PATH
     + f"{'/' if TEMPLATES_PATH[-1] != '/' else ''}"
-    + "workspace_templates.json"
+    + f"{'workspace_apps.json' if '.json' not in TEMPLATES_PATH else ''}"
     if TEMPLATES_PATH
     else (
         current_settings["preferences"].get("data_directory", HOME + "/OpenBBUserData")
-        + "/workspace_templates.json"
+        + "/workspace_apps.json"
     )
 )
 
@@ -138,9 +135,9 @@ async def get_widgets():
 
 
 # If a custom implementation, you might want to override.
-@app.get("/templates.json")
-async def get_templates():
-    """Get the templates.json file."""
+@app.get("/apps.json")
+async def get_apps_json():
+    """Get the default apps.json file."""
     new_templates: list = []
     default_templates: list = []
     widgets = await get_widgets()

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/response_models.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/response_models.py
@@ -58,7 +58,7 @@ class PdfResponseModel(Data):
     """
     PDF Widget Response Model.
 
-    Supply the url_reference or content, and an optional filename.
+    Supply the url or content, and an optional filename.
 
     Fields
     ------
@@ -66,7 +66,7 @@ class PdfResponseModel(Data):
         The filename of the PDF content.
     content : bytes
         The PDF content to display in the PDF widget.
-    url_reference : str
+    url : str
         The URL reference to the PDF
 
     Returns
@@ -103,7 +103,7 @@ class PdfResponseModel(Data):
         description="The PDF content to display in the PDF widget.",
         json_schema_extra={"x-widget_config": {"exclude": True}},
     )
-    url_reference: Optional[str] = Field(
+    url: Optional[str] = Field(
         default=None,
         description="The URL reference to the PDF content.",
         json_schema_extra={"x-widget_config": {"exclude": True}},
@@ -123,11 +123,11 @@ class PdfResponseModel(Data):
         from io import BytesIO
 
         content = getattr(values, "content", None)
-        file_reference = getattr(values, "url_reference", None)
+        file_reference = getattr(values, "url", None)
         filename = getattr(values, "filename", "")
 
         if not content and not file_reference:
-            raise ValueError("Either 'content' or 'url_reference' must be provided.")
+            raise ValueError("Either 'content' or 'url' must be provided.")
 
         if file_reference and "://" not in file_reference:
             raise ValueError("Invalid URL reference provided")
@@ -141,9 +141,9 @@ class PdfResponseModel(Data):
 
         values.content = pdf
         if file_reference:
-            values.url_reference = file_reference
-        elif hasattr(values, "url_reference"):
-            del values.url_reference
+            values.url = file_reference
+        elif hasattr(values, "url"):
+            del values.url
         values.data_format = {"data_type": "pdf", "filename": filename}
 
         return values

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -27,7 +27,7 @@ Launcher specific arguments:
     --exclude                       JSON encoded list of API paths to exclude from widgets.json. Disable entire routes with '*' - e.g. '["/api/v1/*"]'.
     --no-filter                     Do not filter out widgets in widget_settings.json file.
     --widgets-path                  Absolute path to the widgets.json file. Default is ~/envs/{env}/assets/widgets.json. Supplying this sets --editable true.
-    --templates-path                Absolute path to the workspace_templates.json file. Default is ~/OpenBBUserData/workspace_templates.json.
+    --apps-json                     Absolute path to the workspace_apps.json file. Default is ~/OpenBBUserData/workspace_apps.json.
     --copilots-path                 Absolute path to the copilots.json file. Including this will add the /copilots endpoint to the API.
 
 
@@ -434,11 +434,11 @@ def parse_args():
         widget_path = str(cwd.joinpath(widget_path).resolve())
         _kwargs["widgets-path"] = widget_path
 
-    if (template_path := _kwargs.get("templates-path")) and not str(
-        template_path
-    ).startswith("/"):
+    if (
+        template_path := _kwargs.get("apps-json") or _kwargs.get("templates-path")
+    ) and not str(template_path).startswith("/"):
         template_path = str(cwd.joinpath(template_path).resolve())
-        _kwargs["templates-path"] = template_path
+        _kwargs["apps-json"] = template_path
 
     if _kwargs.get("widgets-path") and not _kwargs.get("editable"):
         _kwargs["editable"] = True

--- a/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/fomc_documents.py
+++ b/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/fomc_documents.py
@@ -69,6 +69,7 @@ class FederalReserveFomcDocumentsQueryParams(QueryParams):
                     "provider": "federal_reserve",
                 },
                 "show": False,
+                "roles": ["fileSelector"],
             }
         },
     }


### PR DESCRIPTION
This PR restores the FOMC Documents Workspace app from a breaking change upstream, and changes a couple of default apps' images so they fit in the box.

![Screenshot 2025-04-30 at 1 35 56 PM](https://github.com/user-attachments/assets/2591aab9-134d-4d61-97fd-a8ef83f8b39a)


You can test by opening the widget in a Workspace dashboard. Before, no API call made to get the actual choices of documents.

