### PR TITLE
[BugFix] Fix `to_df` in `OptionsChainsData`

### DIFF
--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -1,5 +1,8 @@
 """The OBBject."""
 
+# pylint: disable=too-many-branches, too-many-locals, too-many-statements
+
+from collections.abc import Hashable
 from typing import (
     TYPE_CHECKING,
     Any,
@@ -7,7 +10,6 @@ from typing import (
     ClassVar,
     Dict,
     Generic,
-    Hashable,
     List,
     Literal,
     Optional,
@@ -122,7 +124,7 @@ class OBBject(Tagged, Generic[T]):
         """
         return self.to_dataframe(index=index, sort_by=sort_by, ascending=ascending)
 
-    def to_dataframe(
+    def to_dataframe(  # noqa: PLR0912
         self,
         index: Optional[Union[str, None]] = "date",
         sort_by: Optional[str] = None,
@@ -182,7 +184,9 @@ class OBBject(Tagged, Generic[T]):
 
             # BaseModel
             if isinstance(res, BaseModel):
-                res_dict = res.model_dump(exclude_unset=True, exclude_none=True)
+                res_dict = res.model_dump(  # pylint: disable=no-member
+                    exclude_unset=True, exclude_none=True
+                )
                 # Model is serialized as a dict[str, list] or list[dict]
                 if (
                     (

--- a/openbb_platform/core/openbb_core/app/model/obbject.py
+++ b/openbb_platform/core/openbb_core/app/model/obbject.py
@@ -183,9 +183,22 @@ class OBBject(Tagged, Generic[T]):
             # BaseModel
             if isinstance(res, BaseModel):
                 res_dict = res.model_dump(exclude_unset=True, exclude_none=True)
-                series = Series(res_dict, name=res.__class__.__name__)
-                df = series.to_frame().reset_index()
-                sort_columns = False
+                # Model is serialized as a dict[str, list] or list[dict]
+                if (
+                    (
+                        isinstance(res_dict, dict)
+                        and res_dict
+                        and all(isinstance(v, list) for v in res_dict.values())
+                    )
+                    or isinstance(res_dict, list)
+                    and all(isinstance(item, dict) for item in res_dict)
+                ):
+                    df = DataFrame(res_dict)
+                    sort_columns = False
+                else:
+                    series = Series(res_dict, name=res.__class__.__name__)
+                    df = series.to_frame().reset_index()
+                    sort_columns = False
 
             # Dict[str, Any]
             elif isinstance(res, dict):


### PR DESCRIPTION
1. **Why**?:

    - The fix in #7099 failed to account for the case in OptionsChainsData.
      - This single model serializes as a `list[dict]`, but the logic handled as `dict[str, Any]`
    - Fixes #7108 


2. **What**?:

    - Apply conditional checks to the dumped model to handle `list[dict]` and `dict[str, list]` from a single model.

3. **Impact**:

    - Restores expected output from `obb.derivatives.options.chains(...).to_df()`

4. **Testing Done**:

![Screenshot 2025-05-03 at 10 12 39 AM](https://github.com/user-attachments/assets/7e0be70d-02ed-4a1c-a6c9-f73cf9ad3c27)
