### PR TITLE
Resolve Python Datetime warnings

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
@@ -5,6 +5,7 @@
 from datetime import (
     date as dateType,
     datetime,
+    timezone,
 )
 from typing import Any, Dict, List, Optional
 from warnings import warn
@@ -93,8 +94,8 @@ class YFinanceShareStatisticsData(ShareStatisticsData):
     )
     @classmethod
     def validate_first_trade_date(cls, v):
-        """Convert  dates from UTC timestamp."""
-        return datetime.utcfromtimestamp(v).date() if v else None
+        """Convert dates from UTC timestamp."""
+        return datetime.fromtimestamp(v, timezone.utc).date() if v else None
 
 
 class YFinanceShareStatisticsFetcher(


### PR DESCRIPTION
# Pull Request OpenBB
This small PR resolves the annoying `datetime` library warnings:
```python
DeprecationWarning: datetime.datetime.utcfromtimestamp() is deprecated and scheduled for removal in a future version. Use timezone-aware objects to represent datetimes in UTC: datetime.datetime.fromtimestamp(timestamp, datetime.UTC).
```