### PR TITLE
[BugFix] `openbb-platform-api` - Fix `FileExistsError` when specifying `.json` in the `widgets-path`

### DIFF
--- a/openbb_platform/extensions/platform_api/README.md
+++ b/openbb_platform/extensions/platform_api/README.md
@@ -68,9 +68,10 @@ Launcher specific arguments:
     --login                         Login to the OpenBB Platform.
     --exclude                       JSON encoded list of API paths to exclude from widgets.json. Disable entire routes with '*' - e.g. '["/api/v1/*"]'.
     --no-filter                     Do not filter out widgets in widget_settings.json file.
-    --widgets-path                  Absolute path to the widgets.json file. Default is ~/envs/{env}/assets/widgets.json. Supplying this sets --editable true.
-    --apps-json                     Absolute path to the workspace_apps.json file. Default is ~/OpenBBUserData/workspace_apps.json.
-    --copilots-path                 Absolute path to the copilots.json file. Including this will add the /copilots endpoint to the API.
+    --widgets-json                  Absolute/relative path to use as the widgets.json file. Default is ~/envs/{env}/assets/widgets.json, when --editable is 'true'.
+    --apps-json                     Absolute/relative path to use as the apps.json file. Default is ~/OpenBBUserData/workspace_apps.json.
+    --agents-json                   Absolute/relative path to use as the agents.json file. Including this will add the /agents endpoint to the API.
+
 
 All other arguments will be passed to uvicorn. Here are the most common ones:
 
@@ -582,7 +583,7 @@ openbb-api --editable --no-build
 If you would like to construct this file manually, create the file and define the path as an argument.
 
 ```sh
-openbb-api --widgets-path /Users/some_user/path/to/widgets.json
+openbb-api --widgets-json /Users/some_user/path/to/widgets.json
 ```
 
 

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -52,15 +52,13 @@ _app = kwargs.pop("app", None)
 if _app:
     app = _app
 
-WIDGETS_PATH = kwargs.pop("widgets-path", None)
-TEMPLATES_PATH = kwargs.pop("apps-json", None) or kwargs.pop("templates-path", None)
+WIDGETS_PATH = kwargs.pop("widgets-json", None) or kwargs.pop("widgets-path", None)
+APPS_PATH = kwargs.pop("apps-json", None) or kwargs.pop("templates-path", None)
 EDITABLE = kwargs.pop("editable", None) is True or WIDGETS_PATH is not None
-
-
-DEFAULT_TEMPLATES_PATH = (
+DEFAULT_APPS_PATH = (
     Path(__file__).absolute().parent.joinpath("assets").joinpath("default_apps.json")
 )
-COPILOTS = kwargs.pop("copilots", None)
+AGENTS_PATH = kwargs.pop("agents-json", None)
 build = kwargs.pop("build", True)
 build = False if kwargs.pop("no-build", None) else build
 login = kwargs.pop("login", False)
@@ -98,11 +96,9 @@ widgets_json = get_widgets_json(
 
 # A template file will be served from the OpenBBUserDataDirectory, if it exists.
 # If it doesn't exist, an empty list will be returned, and an empty file will be created.
-TEMPLATES_PATH = (
-    TEMPLATES_PATH
-    + f"{'/' if TEMPLATES_PATH[-1] != '/' else ''}"
-    + f"{'workspace_apps.json' if '.json' not in TEMPLATES_PATH else ''}"
-    if TEMPLATES_PATH
+APPS_PATH = (
+    APPS_PATH
+    if APPS_PATH
     else (
         current_settings.get("preferences", {}).get(
             "data_directory", HOME + "/OpenBBUserData"
@@ -141,23 +137,23 @@ async def get_widgets():
 # If a custom implementation, you might want to override.
 @app.get("/apps.json")
 async def get_apps_json():
-    """Get the default apps.json file."""
+    """Get the apps.json file."""
     new_templates: list = []
     default_templates: list = []
     widgets = await get_widgets()
 
-    if not os.path.exists(TEMPLATES_PATH):
-        os.makedirs(os.path.dirname(TEMPLATES_PATH), exist_ok=True)
-        # Write an empty file for the user to export templates to for any backend.
-        with open(TEMPLATES_PATH, "w", encoding="utf-8") as templates_file:
+    if not os.path.exists(APPS_PATH):
+        os.makedirs(os.path.dirname(APPS_PATH), exist_ok=True)
+        # Write an empty file for the user to add exported apps from Workspace to.
+        with open(APPS_PATH, "w", encoding="utf-8") as templates_file:
             templates_file.write(json.dumps([]))
 
-    if os.path.exists(DEFAULT_TEMPLATES_PATH):
-        with open(DEFAULT_TEMPLATES_PATH) as f:
+    if os.path.exists(DEFAULT_APPS_PATH):
+        with open(DEFAULT_APPS_PATH) as f:
             default_templates = json.load(f)
 
-    if os.path.exists(TEMPLATES_PATH):
-        with open(TEMPLATES_PATH) as templates_file:
+    if os.path.exists(APPS_PATH):
+        with open(APPS_PATH) as templates_file:
             templates = json.load(templates_file)
 
         if isinstance(templates, dict):
@@ -193,12 +189,16 @@ async def get_apps_json():
     return JSONResponse(content=[])
 
 
-if COPILOTS:
+if AGENTS_PATH:
 
-    @app.get("/copilots.json")
-    async def get_copilots():
-        """Get the copilots.json file."""
-        return JSONResponse(content=COPILOTS)
+    @app.get("/agents.json")
+    async def get_agents():
+        """Get the agents.json file."""
+        if os.path.exists(AGENTS_PATH):
+            with open(AGENTS_PATH) as f:
+                agents = json.load(f)
+            return JSONResponse(content=agents)
+        return JSONResponse(content=[])
 
 
 def launch_api(**_kwargs):  # noqa PRL0912

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -143,7 +143,9 @@ async def get_apps_json():
     widgets = await get_widgets()
 
     if not os.path.exists(APPS_PATH):
-        os.makedirs(os.path.dirname(APPS_PATH), exist_ok=True)
+        apps_dir = os.path.dirname(APPS_PATH)
+        if not os.path.exists(apps_dir):
+            os.makedirs(apps_dir, exist_ok=True)
         # Write an empty file for the user to add exported apps from Workspace to.
         with open(APPS_PATH, "w", encoding="utf-8") as templates_file:
             templates_file.write(json.dumps([]))

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -52,8 +52,14 @@ _app = kwargs.pop("app", None)
 if _app:
     app = _app
 
+
+# These are handled for backwards compatibility, and in ./utils/api::parse_args.
+# It should be handled by this point in the code execution, but in case the key
+# still exists for some reason, we will pop it so it doesn't get passed to uvicorn.run
+# It would be reasonable to remove special handling by V1.3
 WIDGETS_PATH = kwargs.pop("widgets-json", None) or kwargs.pop("widgets-path", None)
 APPS_PATH = kwargs.pop("apps-json", None) or kwargs.pop("templates-path", None)
+
 EDITABLE = kwargs.pop("editable", None) is True or WIDGETS_PATH is not None
 DEFAULT_APPS_PATH = (
     Path(__file__).absolute().parent.joinpath("assets").joinpath("default_apps.json")

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -368,7 +368,7 @@ def import_app(app_path: str, name: str = "app", factory: bool = False):
     return app
 
 
-def parse_args():  # noqa: PLR0912
+def parse_args():  # noqa: PLR0912  # pylint: disable=too-many-branches
     """Parse the launch script command line arguments."""
     args = sys.argv[1:].copy()
     cwd = Path.cwd()

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -26,9 +26,9 @@ Launcher specific arguments:
     --login                         Login to the OpenBB Platform.
     --exclude                       JSON encoded list of API paths to exclude from widgets.json. Disable entire routes with '*' - e.g. '["/api/v1/*"]'.
     --no-filter                     Do not filter out widgets in widget_settings.json file.
-    --widgets-path                  Absolute path to the widgets.json file. Default is ~/envs/{env}/assets/widgets.json. Supplying this sets --editable true.
-    --apps-json                     Absolute path to the workspace_apps.json file. Default is ~/OpenBBUserData/workspace_apps.json.
-    --copilots-path                 Absolute path to the copilots.json file. Including this will add the /copilots endpoint to the API.
+    --widgets-json                  Absolute/relative path to use as the widgets.json file. Default is ~/envs/{env}/assets/widgets.json, when --editable is 'true'.
+    --apps-json                     Absolute/relative path to use as the apps.json file. Default is ~/OpenBBUserData/workspace_apps.json.
+    --agents-json                   Absolute/relative path to use as the agents.json file. Including this will add the /agents endpoint to the API.
 
 
 The FastAPI app instance can be imported to another script, modified, and launched by using the --app argument.
@@ -219,15 +219,14 @@ def get_widgets_json(
             )
             widgets_json_path = parent_path.joinpath("assets", "widgets.json").resolve()
         else:
-            widgets_json_path = (
-                Path(widgets_path).absolute().joinpath("widgets.json").resolve()
-            )
+            widgets_json_path = Path(widgets_path).absolute().resolve()
 
         json_exists = widgets_json_path.exists()
 
         if not json_exists:
             widgets_json_path.parent.mkdir(parents=True, exist_ok=True)
             _build = True
+            json_exists = widgets_json_path.exists()
 
         existing_widgets_json: dict = {}
 
@@ -369,7 +368,7 @@ def import_app(app_path: str, name: str = "app", factory: bool = False):
     return app
 
 
-def parse_args():
+def parse_args():  # noqa: PLR0912
     """Parse the launch script command line arguments."""
     args = sys.argv[1:].copy()
     cwd = Path.cwd()
@@ -393,26 +392,6 @@ def parse_args():
             else:
                 _kwargs[key] = True
 
-    if isinstance(_kwargs.get("exclude"), str):
-        _kwargs["exclude"] = [_kwargs["exclude"]]
-
-    if _kwargs.get("copilots-path"):
-        _copilots_path = _kwargs.pop("copilots-path", None)
-
-        if not str(_copilots_path).endswith("copilots.json"):
-            _copilots_path = f"{_copilots_path}{'' if _copilots_path.endswith('/') else '/'}copilots.json"
-
-        if not str(_copilots_path).startswith("/"):
-            _copilots_path = str(cwd.joinpath(_copilots_path).resolve())
-
-        if not Path(_copilots_path).exists():
-            raise FileNotFoundError(
-                f"Error: The copilots file '{_copilots_path}' does not exist"
-            )
-
-        with open(_copilots_path, encoding="utf-8") as f:
-            _kwargs["copilots"] = json.load(f)
-
     if _kwargs.get("app"):
         _app_path = _kwargs.pop("app", None)
         _name = _kwargs.pop("name", "app")
@@ -428,19 +407,68 @@ def parse_args():
             )
         _kwargs["app"] = import_app(_app_path, _name, _factory)
 
-    if (widget_path := _kwargs.get("widgets-path")) and not str(widget_path).startswith(
-        "/"
-    ):
-        widget_path = str(cwd.joinpath(widget_path).resolve())
-        _kwargs["widgets-path"] = widget_path
+    if isinstance(_kwargs.get("exclude"), str):
+        _kwargs["exclude"] = [_kwargs["exclude"]]
 
-    if (
-        template_path := _kwargs.get("apps-json") or _kwargs.get("templates-path")
-    ) and not str(template_path).startswith("/"):
-        template_path = str(cwd.joinpath(template_path).resolve())
-        _kwargs["apps-json"] = template_path
+    if _kwargs.get("agents-json") or _kwargs.get("copilots-path"):
+        _agents_path = _kwargs.pop("agents-json", None) or _kwargs.pop(
+            "copilots-path", None
+        )
 
-    if _kwargs.get("widgets-path") and not _kwargs.get("editable"):
+        if not str(_agents_path).endswith(".json"):
+            _agents_path = (
+                f"{_agents_path}{'' if _agents_path.endswith('/') else '/'}agents.json"
+            )
+
+        if not str(_agents_path).startswith("/"):
+            _agents_path = str(cwd.joinpath(_agents_path).resolve())
+
+        _kwargs["agents-json"] = _agents_path
+
+    if _kwargs.get("widgets-json") or _kwargs.get("widgets-path"):
+        _widgets_path = _kwargs.pop("widgets-json", None) or _kwargs.pop(
+            "widgets-path", None
+        )
+
+        # If it's a file (endswith .json), use as is; else treat as directory and append widgets.json
+        if str(_widgets_path).endswith(".json"):
+            widgets_file_path = _widgets_path
+        else:
+            widgets_file_path = f"{_widgets_path}{'' if str(_widgets_path).endswith('/') else '/'}widgets.json"
+
+        # Resolve relative paths to absolute
+        if not str(widgets_file_path).startswith("/"):
+            widgets_file_path = str(cwd.joinpath(widgets_file_path).resolve())
+
+        _kwargs["widgets-json"] = widgets_file_path
+
+    if _kwargs.get("widgets-json"):
         _kwargs["editable"] = True
+        # If the file already exists, we assume that it is already built.
+        if os.path.exists(_kwargs["widgets-json"]):
+            _kwargs["no-build"] = True
+
+    # Handle apps-json and templates-path in the same way as widgets-path
+    if _kwargs.get("apps-json") or _kwargs.get("templates-path"):
+        _apps_path = _kwargs.pop("apps-json", None) or _kwargs.pop(
+            "templates-path", None
+        )
+
+        # If it's a file (endswith .json), use as is; else treat as directory and append apps.json
+        if str(_apps_path).endswith(".json"):
+            apps_file_path = _apps_path
+        else:
+            # Check if "workspace_apps.json" exists in the given path
+            possible_workspace_file = f"{_apps_path}{'' if str(_apps_path).endswith('/') else '/'}workspace_apps.json"
+            if os.path.isfile(possible_workspace_file):
+                apps_file_path = possible_workspace_file
+            else:
+                apps_file_path = f"{_apps_path}{'' if str(_apps_path).endswith('/') else '/'}apps.json"
+
+        # Resolve relative paths to absolute
+        if not str(apps_file_path).startswith("/"):
+            apps_file_path = str(cwd.joinpath(apps_file_path).resolve())
+
+        _kwargs["apps-json"] = apps_file_path
 
     return _kwargs

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -420,7 +420,7 @@ def parse_args():  # noqa: PLR0912  # pylint: disable=too-many-branches
                 f"{_agents_path}{'' if _agents_path.endswith('/') else '/'}agents.json"
             )
 
-        if not str(_agents_path).startswith("/"):
+        if str(_agents_path).startswith("./"):
             _agents_path = str(cwd.joinpath(_agents_path).resolve())
 
         _kwargs["agents-json"] = _agents_path
@@ -437,7 +437,7 @@ def parse_args():  # noqa: PLR0912  # pylint: disable=too-many-branches
             widgets_file_path = f"{_widgets_path}{'' if str(_widgets_path).endswith('/') else '/'}widgets.json"
 
         # Resolve relative paths to absolute
-        if not str(widgets_file_path).startswith("/"):
+        if str(widgets_file_path).startswith("./"):
             widgets_file_path = str(cwd.joinpath(widgets_file_path).resolve())
 
         _kwargs["widgets-json"] = widgets_file_path
@@ -466,7 +466,7 @@ def parse_args():  # noqa: PLR0912  # pylint: disable=too-many-branches
                 apps_file_path = f"{_apps_path}{'' if str(_apps_path).endswith('/') else '/'}apps.json"
 
         # Resolve relative paths to absolute
-        if not str(apps_file_path).startswith("/"):
+        if str(apps_file_path).startswith("./"):
             apps_file_path = str(cwd.joinpath(apps_file_path).resolve())
 
         _kwargs["apps-json"] = apps_file_path

--- a/openbb_platform/extensions/platform_api/pyproject.toml
+++ b/openbb_platform/extensions/platform_api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-platform-api"
-version = "1.1.9"
+version = "1.1.10"
 description = "OpenBB Platform API: Launch script and widgets builder for the OpenBB Platform API and Workspace Backend Connector."
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"


### PR DESCRIPTION
1. **Why**?

    - When launching `openbb-api` with `--widgets-path`, specifying the file, instead of just path, can create a `FileExistsError`

2. **What**?:

    - Adds handling for specifying an arbitrary JSON file to represent `widgets.json`, `apps.json`, and `agents.json` in the API.
    - Updates arguments (with backwards-compatibility) to be `--json`, instead of `--path`, making it more intuitive. Specifying as a path only will default to its standard filename.
      - `--widgets-json`
      - `--apps-json`
      - `--agents-json`

3. **Impact**:

    - Bug fix.
    - When specifying a `widgets.json` path, if the file already exists, the launcher will assume it is built.
      - Explicitly engage `--build` to rebuild and get prompted for diff action.
    - Parameter changes are expected to be backwards compatible.
    - More clarity for the end-user.

5. **Testing Done**:

Before, adding `--no-build` was necessary to defeat the user-input prompt, and unexpected results would occur when specifying a filename in the `--path` arguments.

Before:

![Screenshot 2025-05-19 at 4 24 11 PM](https://github.com/user-attachments/assets/71562ff8-31db-420f-a7fa-b6102d8a9c3e)


After:

![Screenshot 2025-05-19 at 4 26 20 PM](https://github.com/user-attachments/assets/6c90930c-34b2-4ffb-a4b3-57d2a7846abd)
