### PR TITLE
[Release] Patch `openbb-federal-reserve` With Missing Dependency

### DIFF
--- a/openbb_platform/providers/federal_reserve/poetry.lock
+++ b/openbb_platform/providers/federal_reserve/poetry.lock
@@ -212,6 +212,29 @@ files = [
 ]
 
 [[package]]
+name = "beautifulsoup4"
+version = "4.13.4"
+description = "Screen-scraping library"
+optional = false
+python-versions = ">=3.7.0"
+groups = ["main"]
+files = [
+    {file = "beautifulsoup4-4.13.4-py3-none-any.whl", hash = "sha256:9bbbb14bfde9d79f38b8cd5f8c7c85f4b8f2523190ebed90e950a8dea4cb1c4b"},
+    {file = "beautifulsoup4-4.13.4.tar.gz", hash = "sha256:dbb3c4e1ceae6aefebdaf2423247260cd062430a410e38c66f2baa50a8437195"},
+]
+
+[package.dependencies]
+soupsieve = ">1.2"
+typing-extensions = ">=4.0.0"
+
+[package.extras]
+cchardet = ["cchardet"]
+chardet = ["chardet"]
+charset-normalizer = ["charset-normalizer"]
+html5lib = ["html5lib"]
+lxml = ["lxml"]
+
+[[package]]
 name = "certifi"
 version = "2025.4.26"
 description = "Python package for providing Mozilla's CA Bundle."
@@ -1391,6 +1414,18 @@ files = [
 ]
 
 [[package]]
+name = "soupsieve"
+version = "2.7"
+description = "A modern CSS selector implementation for Beautiful Soup."
+optional = false
+python-versions = ">=3.8"
+groups = ["main"]
+files = [
+    {file = "soupsieve-2.7-py3-none-any.whl", hash = "sha256:6e60cc5c1ffaf1cebcc12e8188320b72071e922c2e897f737cadce79ad5d30c4"},
+    {file = "soupsieve-2.7.tar.gz", hash = "sha256:ad282f9b6926286d2ead4750552c8a6142bc4c783fd66b0293547c8fe6ae126a"},
+]
+
+[[package]]
 name = "starlette"
 version = "0.46.2"
 description = "The little ASGI library that shines."
@@ -1731,4 +1766,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.9.21,<3.13"
-content-hash = "0dc818ea9f9345947800f811a6a5759b31373774323601f620c01f1c09bce575"
+content-hash = "f80342233f5c33e65be69a15086cedbaf6726b8be7f408a9e93b93eaaad64379"

--- a/openbb_platform/providers/federal_reserve/pyproject.toml
+++ b/openbb_platform/providers/federal_reserve/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-federal-reserve"
-version = "1.4.2"
+version = "1.4.3"
 description = "US Federal Reserve Data Extension for OpenBB"
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"
@@ -9,7 +9,8 @@ packages = [{ include = "openbb_federal_reserve" }]
 
 [tool.poetry.dependencies]
 python = ">=3.9.21,<3.13"
-openbb-core = "^1.4.6"
+openbb-core = "^1.4.7"
+beautifulsoup4 = "^4.13.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
This PR is for a patch release of `openbb-federal-reserve`.

Reason: Missing BeautifulSoup4 as a top-level dependency.

No changes to the code.