### PR TITLE
[BugFix] `openbb-core`: Fix `UserSettings.preferences` Initialization

### DIFF
--- a/openbb_platform/core/openbb_core/api/auth/user.py
+++ b/openbb_platform/core/openbb_core/api/auth/user.py
@@ -14,7 +14,7 @@ security = HTTPBasic() if Env().API_AUTH else lambda: None
 
 
 async def authenticate_user(
-    credentials: Annotated[Optional[HTTPBasicCredentials], Depends(security)]
+    credentials: Annotated[Optional[HTTPBasicCredentials], Depends(security)],
 ):
     """Authenticate the user."""
     if credentials:
@@ -54,4 +54,4 @@ async def get_user_settings(
     user_service: Annotated[UserService, Depends(get_user_service)],
 ) -> UserSettings:
     """Get user settings."""
-    return user_service.default_user_settings
+    return user_service.read_from_file()

--- a/openbb_platform/core/openbb_core/app/model/user_settings.py
+++ b/openbb_platform/core/openbb_core/app/model/user_settings.py
@@ -1,5 +1,10 @@
 """User settings model."""
 
+import json
+import logging
+import os
+
+from openbb_core.app.constants import USER_SETTINGS_PATH
 from openbb_core.app.model.abstract.tagged import Tagged
 from openbb_core.app.model.credentials import Credentials
 from openbb_core.app.model.defaults import Defaults
@@ -15,6 +20,23 @@ class UserSettings(Tagged):
     credentials: Credentials = Field(default_factory=Credentials)
     preferences: Preferences = Field(default_factory=Preferences)
     defaults: Defaults = Field(default_factory=Defaults)
+
+    def __init__(self, **kwargs):
+        """Initialize user settings by loading directly from file if it exists."""
+        # Check if user settings file exists and load from it
+        if os.path.exists(USER_SETTINGS_PATH):
+            try:
+                with open(USER_SETTINGS_PATH) as f:
+                    file_settings = json.load(f)
+                # Initialize with settings from file
+                super().__init__(**{k: v for k, v in file_settings.items() if v})
+            except (json.JSONDecodeError, OSError) as e:
+                logging.error(f"Error loading user settings from file: {e}")
+                # Fall back to defaults if file can't be read
+                super().__init__(**kwargs)
+        else:
+            # Use defaults if file doesn't exist
+            super().__init__(**kwargs)
 
     def __repr__(self) -> str:
         """Human readable representation of the object."""

--- a/openbb_platform/core/openbb_core/app/model/user_settings.py
+++ b/openbb_platform/core/openbb_core/app/model/user_settings.py
@@ -1,8 +1,8 @@
 """User settings model."""
 
 import json
-import logging
 import os
+import warnings
 
 from openbb_core.app.constants import USER_SETTINGS_PATH
 from openbb_core.app.model.abstract.tagged import Tagged
@@ -31,7 +31,11 @@ class UserSettings(Tagged):
                 # Initialize with settings from file
                 super().__init__(**{k: v for k, v in file_settings.items() if v})
             except (json.JSONDecodeError, OSError) as e:
-                logging.error(f"Error loading user settings from file: {e}")
+                warnings.warn(
+                    f"Error loading user settings from file: {e}",
+                    stacklevel=2,
+                    category=UserWarning,
+                )
                 # Fall back to defaults if file can't be read
                 super().__init__(**kwargs)
         else:

--- a/openbb_platform/core/tests/api/test_auth/test_user_auth.py
+++ b/openbb_platform/core/tests/api/test_auth/test_user_auth.py
@@ -57,7 +57,7 @@ def test_get_user_service(mock_user_service):
 def test_get_user_settings_(mock_user_service):
     """Test get_user."""
     mock_user_settings = MagicMock(spec=UserSettings, profile=MagicMock(active=True))
-    mock_user_service.default_user_settings = mock_user_settings
+    mock_user_service.read_from_file.return_value = mock_user_settings
     mock_user_service.return_value = mock_user_service
     result = asyncio.run(get_user_settings(MagicMock(), mock_user_service))  # type: ignore[arg-type]
 


### PR DESCRIPTION
1. **Why**?:

    - `UserSettings` was initializing and persisting with only "default" values, instead of passing values from the `user_settings.json` file.
    - Example: `chart_style` always being "dark".

2. **What**?:

    - When `UserSettings` is initialized, prioritize the actual file settings over any defaults.

3. **Impact**:

    - The "preferences" items will now be properly loaded to serve before the function executes.

4. **Testing Done**:

    - Most easily tested with something like, `/equity/price/historical?symbol=AAPL&provider=yfinance&chart=True)`

Before:

![Screenshot 2025-05-20 at 9 19 20 PM](https://github.com/user-attachments/assets/f10d589d-eba4-4ac2-b78b-8e7142f7f2d9)

After:

![Screenshot 2025-05-20 at 9 21 04 PM](https://github.com/user-attachments/assets/7abf1fe2-433c-4278-85d8-26d375c7b247)
