### PR TITLE
Fix openbb-nasdaq README

### DIFF
--- a/openbb_platform/providers/nasdaq/README.md
+++ b/openbb_platform/providers/nasdaq/README.md
@@ -50,7 +50,7 @@ This package includes a standalone Workspace application for viewing market cale
 Launch it from the command line, with the environment active, by entering:
 
 ```sh
-openbb-api --app openbb_nasdaq.app:app --factory
+openbb-api --app openbb_nasdaq.app:main --factory
 ```
 
 This will start the FastAPI application via Uvicorn and serve the configuration files to Workspace when added as a backend data source.


### PR DESCRIPTION
This PR fixes an error in the README.md launch instruction.

```sh
openbb-api --app openbb_nasdaq.app:app --factory. ## should be `.app:main` ##
```