### PR TITLE
[Feature] Disable LoggingService by Default

### DIFF
--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -296,9 +296,6 @@ class StaticCommandRunner:
         kwargs: Dict[str, Any],
     ) -> OBBject:
         """Execute a function and return the output."""
-        # pylint: disable=import-outside-toplevel
-        from openbb_core.app.logs.logging_service import LoggingService
-
         user_settings = execution_context.user_settings
         system_settings = execution_context.system_settings
         raised_warnings: list = []
@@ -369,16 +366,21 @@ class StaticCommandRunner:
                             file=w.file,
                             line=w.line,
                         )
-            ls = LoggingService(system_settings, user_settings)
-            ls.log(
-                user_settings=user_settings,
-                system_settings=system_settings,
-                route=route,
-                func=func,
-                kwargs=kwargs,
-                exec_info=exc_info(),
-                custom_headers=custom_headers,
-            )
+
+            if system_settings.logging_suppress is False:
+                # pylint: disable=import-outside-toplevel
+                from openbb_core.app.logs.logging_service import LoggingService
+
+                ls = LoggingService(system_settings, user_settings)
+                ls.log(
+                    user_settings=user_settings,
+                    system_settings=system_settings,
+                    route=route,
+                    func=func,
+                    kwargs=kwargs,
+                    exec_info=exc_info(),
+                    custom_headers=custom_headers,
+                )
 
         return obbject
 

--- a/openbb_platform/core/openbb_core/app/logs/logging_service.py
+++ b/openbb_platform/core/openbb_core/app/logs/logging_service.py
@@ -77,6 +77,9 @@ class LoggingService(metaclass=SingletonMeta):
         user_settings : UserSettings
             User Settings, by default None
         """
+        if system_settings.logging_suppress is True:
+            return
+
         self._user_settings = user_settings
         self._system_settings = system_settings
         self._logging_settings = LoggingSettings(
@@ -85,6 +88,8 @@ class LoggingService(metaclass=SingletonMeta):
         )
         self._handlers_manager = self._setup_handlers()
         self._log_startup()
+
+        return
 
     @property
     def logging_settings(self) -> LoggingSettings:

--- a/openbb_platform/core/openbb_core/app/logs/models/logging_settings.py
+++ b/openbb_platform/core/openbb_core/app/logs/models/logging_settings.py
@@ -50,7 +50,6 @@ class LoggingSettings:
         self.python_version: str = system_settings.python_version
         self.platform_version: str = system_settings.version
         self.logging_suppress: bool = system_settings.logging_suppress
-        self.log_collect: bool = system_settings.log_collect
         # User
         self.user_id: Optional[str] = user_id
         self.user_logs_directory: Path = get_log_dir(user_data_directory)

--- a/openbb_platform/core/openbb_core/app/model/charts/charting_settings.py
+++ b/openbb_platform/core/openbb_core/app/model/charts/charting_settings.py
@@ -4,7 +4,6 @@ import importlib
 from pathlib import Path
 from typing import TYPE_CHECKING, Optional
 
-from openbb_core.app.logs.utils.utils import get_app_id
 from openbb_core.env import Env
 
 if TYPE_CHECKING:
@@ -41,20 +40,14 @@ class ChartingSettings:
         )
 
         # System
-        self.log_collect: bool = system_settings.log_collect
+        self.logging_suppress: bool = system_settings.logging_suppress
         self.version: str = system_settings.version
         self.python_version: str = system_settings.python_version
         self.test_mode = system_settings.test_mode
-        self.app_id: str = get_app_id(user_data_directory)
         self.debug_mode: bool = system_settings.debug_mode or Env().DEBUG_MODE
         self.headless: bool = system_settings.headless
         # User
-        self.user_email: Optional[str] = getattr(
-            user_settings.profile.hub_session, "email", None
-        )
-        self.user_uuid: Optional[str] = getattr(
-            user_settings.profile.hub_session, "user_uuid", None
-        )
+        self.user_data_directory: str = user_data_directory
         self.user_exports_directory = user_settings.preferences.export_directory
         self.user_styles_directory = user_settings.preferences.user_styles_directory
         # Theme

--- a/openbb_platform/core/openbb_core/app/model/system_settings.py
+++ b/openbb_platform/core/openbb_core/app/model/system_settings.py
@@ -42,8 +42,7 @@ class SystemSettings(Tagged):
     logging_rolling_clock: bool = False
     logging_verbosity: int = 20
     logging_sub_app: Literal["python", "api", "pro", "cli"] = "python"
-    logging_suppress: bool = False
-    log_collect: bool = True
+    logging_suppress: bool = True
 
     # API section
     api_settings: APISettings = Field(default_factory=APISettings)

--- a/openbb_platform/core/openbb_core/app/service/system_service.py
+++ b/openbb_platform/core/openbb_core/app/service/system_service.py
@@ -15,7 +15,6 @@ class SystemService(metaclass=SingletonMeta):
 
     SYSTEM_SETTINGS_PATH = SYSTEM_SETTINGS_PATH
     SYSTEM_SETTINGS_ALLOWED_FIELD_SET = {
-        "log_collect",
         "test_mode",
         "headless",
         "logging_sub_app",

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -94,8 +94,7 @@ class Account:  # noqa: D205, D400
         return hs
 
     # pylint: disable=R0917
-    # type: ignore[arg-type]
-    @_log_account_command
+    @_log_account_command  # type: ignore
     def login(
         self,
         email: Optional[str] = None,

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -53,18 +53,19 @@ class Account:  # noqa: D205, D400
             finally:
                 user_settings = self._base_app._command_runner.user_settings
                 system_settings = self._base_app._command_runner.system_settings
-                ls = LoggingService(
-                    user_settings=user_settings, system_settings=system_settings
-                )
-                ls.log(
-                    user_settings=user_settings,
-                    system_settings=system_settings,
-                    # pylint: disable=E1101
-                    route=f"/account/{func.__name__}",  # type: ignore[attr-defined]
-                    func=func,  # type: ignore[arg-type]
-                    kwargs={},  # don't want any credentials being logged by accident
-                    exec_info=exc_info(),
-                )
+                if system_settings.logging_suppress is False:
+                    ls = LoggingService(
+                        user_settings=user_settings, system_settings=system_settings
+                    )
+                    ls.log(
+                        user_settings=user_settings,
+                        system_settings=system_settings,
+                        # pylint: disable=E1101
+                        route=f"/account/{func.__name__}",  # type: ignore[attr-defined]
+                        func=func,  # type: ignore[arg-type]
+                        kwargs={},  # don't want any credentials being logged by accident
+                        exec_info=exc_info(),
+                    )
 
             return result
 

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -93,7 +93,8 @@ class Account:  # noqa: D205, D400
             hs.connect(email, password, pat)
         return hs
 
-    # type: ignore  pylint: disable=R0917
+    # pylint: disable=R0917
+    # type: ignore[arg-type]
     @_log_account_command
     def login(
         self,

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -93,7 +93,8 @@ class Account:  # noqa: D205, D400
             hs.connect(email, password, pat)
         return hs
 
-    @_log_account_command  # type: ignore
+    # type: ignore  pylint: disable=R0917
+    @_log_account_command
     def login(
         self,
         email: Optional[str] = None,

--- a/openbb_platform/core/tests/app/logs/test_handlers_manager.py
+++ b/openbb_platform/core/tests/app/logs/test_handlers_manager.py
@@ -40,7 +40,6 @@ def test_handlers_added_correctly():
         settings = Mock()
         settings.verbosity = 20
         settings.handler_list = ["stdout", "stderr", "noop", "file"]
-        settings.log_collect = True
         settings.logging_suppress = False
         logger = logging.getLogger("test_handlers_added_correctly")
         handlers_manager = HandlersManager(logger=logger, settings=settings)

--- a/openbb_platform/core/tests/app/logs/test_logging_service.py
+++ b/openbb_platform/core/tests/app/logs/test_logging_service.py
@@ -16,21 +16,22 @@ from pydantic import BaseModel
 class MockSystemSettings:
     """Mock system settings."""
 
+    logging_suppress: bool = False
+
     def __init__(self):
         """Initialize the mock system settings."""
-        self.logging_suppress = False
-        self.log_collect = True
+        self.custom_attribute = ""
 
 
 class MockLoggingSettings:
     """Mock logging settings."""
 
+    logging_suppress: bool = False
+
     def __init__(self, system_settings, user_settings):
         """Initialize the mock logging settings."""
         self.system_settings = system_settings
         self.user_settings = user_settings
-        self.logging_suppress = False
-        self.log_collect = True
 
 
 class MockOBBject(BaseModel):
@@ -63,6 +64,8 @@ def logging_service():
             user_settings=mock_user_settings,
         )
         _logging_service._logger = MagicMock()
+        _logging_service._setup_handlers = MagicMock()
+        _logging_service._handlers_manager = MagicMock()
 
         return _logging_service
 
@@ -94,8 +97,10 @@ def test_correctly_initialized():
 
 def test_logging_settings_setter(logging_service):
     """Test the logging_settings setter."""
-    custom_user_settings = "custom_user_settings"
-    custom_system_settings = "custom_system_settings"
+    custom_user_settings = Mock()
+    custom_user_settings.preferences = "custom_preferences"
+    custom_system_settings = MockSystemSettings()
+    custom_system_settings.custom_attribute = "custom_system_settings"
 
     with patch(
         "openbb_core.app.logs.logging_service.LoggingSettings",
@@ -106,8 +111,8 @@ def test_logging_settings_setter(logging_service):
             custom_user_settings,
         )
 
-    assert logging_service.logging_settings.system_settings == "custom_system_settings"  # type: ignore[attr-defined]
-    assert logging_service.logging_settings.user_settings == "custom_user_settings"  # type: ignore[attr-defined]
+    assert logging_service.logging_settings.system_settings.custom_attribute == "custom_system_settings"  # type: ignore[attr-defined]
+    assert logging_service.logging_settings.user_settings.preferences == "custom_preferences"  # type: ignore[attr-defined]
 
 
 def test_log_startup(logging_service):

--- a/openbb_platform/core/tests/app/test_command_runner.py
+++ b/openbb_platform/core/tests/app/test_command_runner.py
@@ -56,7 +56,7 @@ class MockExecutionContext:
 @pytest.fixture()
 def execution_context():
     """Set up execution context."""
-    sys = SystemSettings()
+    sys = SystemSettings(logging_suppress=False)
     user = UserSettings()
     cmd_map = CommandMap()
     return MockExecutionContext(cmd_map, "mock/route", sys, user)
@@ -76,7 +76,7 @@ def mock_func():
 
 def test_execution_context():
     """Test execution context."""
-    sys = SystemSettings()
+    sys = SystemSettings(logging_suppress=False)
     user = UserSettings()
     cmd_map = CommandMap()
     ctx = ExecutionContext(cmd_map, "mock/route", sys, user)
@@ -178,7 +178,7 @@ def test_parameters_builder_merge_args_and_kwargs(
     [
         (
             {"cc": "existing_cc"},
-            SystemSettings(),
+            SystemSettings(logging_suppress=False),
             UserSettings(),
             {"cc": "mock_cc"},
         ),
@@ -288,7 +288,7 @@ def test_command_runner():
 
 def test_command_runner_properties():
     """Test properties."""
-    sys = SystemSettings()
+    sys = SystemSettings(logging_suppress=False)
     user = UserSettings()
     cmd_map = CommandMap()
     runner = CommandRunner(cmd_map, sys, user)

--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/backend.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/backend.py
@@ -79,7 +79,6 @@ class Backend(PyWry):
             self.isatty = False
 
         self.WIDTH, self.HEIGHT = 1400, 762
-        self.logged_in: bool = False
 
         atexit.register(self.close)
 
@@ -142,12 +141,9 @@ class Backend(PyWry):
         theme: Optional[str] = None,
     ) -> dict:
         """Get the json update for the backend."""
-        if self.charting_settings.user_uuid and not self.logged_in:
-            self.logged_in = True
 
         return dict(
             theme=theme or self.charting_settings.chart_style,
-            log_id=self.charting_settings.app_id,
             pywry_version=self.__version__,
             platform_version=self.charting_settings.version,
             python_version=self.charting_settings.python_version,


### PR DESCRIPTION
This PR sets the default state of the LoggingService to be not initialized. By doing so, the `logs` folder will not be created on application initialization.

To turn the File logging on, enable in system_settings.json:

```json
{
  "logging_suppress": false
}
```

You can test that this works by deleting the folder: `~/OpenBBUserData/logs` and then starting the Python interface.

You should see that no new folder is created at startup, and no items are created during operation.
