### PR TITLE
[Feature] Future Warning For Discontinued Support For Python 3.9

### DIFF
--- a/openbb_platform/core/openbb_core/__init__.py
+++ b/openbb_platform/core/openbb_core/__init__.py
@@ -1,1 +1,11 @@
 """OpenBB Core."""
+
+import sys
+import warnings
+
+if sys.version_info < (3, 10):
+    warnings.warn(
+        "Support for Python versions below 3.10 will be deprecated in a future release of OpenBB Core.",
+        FutureWarning,
+        stacklevel=2,
+    )


### PR DESCRIPTION
This PR adds a FutureWarning on import of `openbb-core`, if Python 3.9 is being used, that support will be discontinued.

```
(obb3-9) darrenlee@Danglewood-i9 tests % python --version
Python 3.9.21
(obb3-9) darrenlee@Danglewood-i9 tests % ipython
Python 3.9.21 (main, Dec 11 2024, 10:23:52) 
Type 'copyright', 'credits' or 'license' for more information
IPython 8.18.1 -- An enhanced Interactive Python. Type '?' for help.

In [1]: from openbb import obb
/Users/darrenlee/github/OpenBB/openbb_platform/openbb/__init__.py:8: FutureWarning: Support for Python versions below 3.10 will be deprecated in a future release of OpenBB Core.
  from openbb_core.app.static.app_factory import (
```
