### PR TITLE
[BugFix] Fix `obb.quantitative.capm`: Name in `zipfile.open` is Case-Sensitive

### DIFF
--- a/openbb_platform/extensions/quantitative/openbb_quantitative/helpers.py
+++ b/openbb_platform/extensions/quantitative/openbb_quantitative/helpers.py
@@ -27,7 +27,7 @@ def get_fama_raw(start_date: str, end_date: str) -> "DataFrame":
     ) as url:
         # Download Zipfile and create pandas DataFrame
         with ZipFile(BytesIO(url.read())) as zipfile:
-            with zipfile.open("F-F_Research_Data_Factors.CSV") as zip_open:
+            with zipfile.open("F-F_Research_Data_Factors.csv") as zip_open:
                 df = read_csv(
                     zip_open,
                     header=0,


### PR DESCRIPTION
This fixes an error in `obb.quantitative.capm`, where the case in the filename to be opened by `zipfile.open` is incorrect.

To recreate:

```python
res = obb.equity.price.historical("AAPL", provider="yfinance")
obb.quantitative.capm(res.results, target="high")
```

```python
OpenBBError                               Traceback (most recent call last)
Cell In[3], line 1
----> 1 obb.quantitative.capm(res.results, target="high")

File ~/github/OpenBB/openbb_platform/core/openbb_core/app/static/utils/decorators.py:101, in exception_handler.<locals>.wrapper(*f_args, **f_kwargs)
     99         raise OpenBBError(f"\n[Error] -> {e}").with_traceback(tb) from None
    100     if isinstance(e, Exception):
--> 101         raise OpenBBError(
    102             f"\n[Unexpected Error] -> {e.__class__.__name__} -> {e}"
    103         ).with_traceback(tb) from None
    105 return None

File ~/miniconda3/envs/obb/lib/python3.12/zipfile/__init__.py:1532, in ZipFile.getinfo(self, name)
   1530 info = self.NameToInfo.get(name)
   1531 if info is None:
-> 1532     raise KeyError(
   1533         'There is no item named %r in the archive' % name)
   1535 return info

OpenBBError: 
[Unexpected Error] -> KeyError -> "There is no item named 'F-F_Research_Data_Factors.CSV' in the archive"
```


After:

```python
In [1]: from openbb import obb

In [2]: res = obb.equity.price.historical("AAPL")

In [3]: obb.quantitative.capm(res.results, target="high")
Out[3]: 
OBBject

id: 068687e7-1ad3-7458-8000-02b2e95c2b99
results: {'market_risk': -0.1124212263880442, 'systematic_risk': 0.176880350226868,...
provider: None
warnings: None
chart: None
extra: {'metadata': {'arguments': {'provider_choices': {}, 'standard_params': {}, '...
```
