### PR TITLE
[BugFix] Cleanup Test Imports

### DIFF
--- a/openbb_platform/extensions/crypto/integration/test_crypto_api.py
+++ b/openbb_platform/extensions/crypto/integration/test_crypto_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -21,7 +20,7 @@ def headers():
     return {"Authorization": f"Basic {base64_bytes.decode('ascii')}"}
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "asd"}),
@@ -40,7 +39,7 @@ def test_crypto_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/crypto/integration/test_crypto_python.py
+++ b/openbb_platform/extensions/crypto/integration/test_crypto_python.py
@@ -1,7 +1,6 @@
 """Test crypto extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 # pylint: disable=redefined-outer-name
@@ -16,7 +15,7 @@ def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
         return openbb.obb
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "asd"}),
@@ -34,7 +33,7 @@ def test_crypto_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/currency/integration/test_currency_api.py
+++ b/openbb_platform/extensions/currency/integration/test_currency_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -21,7 +20,7 @@ def headers():
     return {"Authorization": f"Basic {base64_bytes.decode('ascii')}"}
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -56,7 +55,7 @@ def test_currency_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -149,9 +148,9 @@ def test_currency_price_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"provider": "ecb"})],
+    [{"provider": "ecb"}],
 )
 @pytest.mark.integration
 def test_currency_reference_rates(params, headers):
@@ -165,7 +164,7 @@ def test_currency_reference_rates(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/currency/integration/test_currency_python.py
+++ b/openbb_platform/extensions/currency/integration/test_currency_python.py
@@ -1,7 +1,6 @@
 """Test currency extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 # pylint: disable=redefined-outer-name
@@ -18,7 +17,7 @@ def obb(pytestconfig):
         return openbb.obb
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -50,7 +49,7 @@ def test_currency_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -140,9 +139,9 @@ def test_currency_price_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"provider": "ecb"})],
+    [{"provider": "ecb"}],
 )
 @pytest.mark.integration
 def test_currency_reference_rates(params, obb):
@@ -153,7 +152,7 @@ def test_currency_reference_rates(params, obb):
     assert len(result.model_dump()["results"].items()) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/derivatives/integration/test_derivatives_api.py
+++ b/openbb_platform/extensions/derivatives/integration/test_derivatives_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -21,7 +20,7 @@ def headers():
     return {"Authorization": f"Basic {base64_bytes.decode('ascii')}"}
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -69,23 +68,21 @@ def test_derivatives_options_chains(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "symbol": "AAPL",
-                "provider": "intrinio",
-                "start_date": "2023-11-20",
-                "end_date": None,
-                "min_value": None,
-                "max_value": None,
-                "trade_type": None,
-                "sentiment": "neutral",
-                "limit": 1000,
-                "source": "delayed",
-            }
-        )
+        {
+            "symbol": "AAPL",
+            "provider": "intrinio",
+            "start_date": "2023-11-20",
+            "end_date": None,
+            "min_value": None,
+            "max_value": None,
+            "trade_type": None,
+            "sentiment": "neutral",
+            "limit": 1000,
+            "source": "delayed",
+        }
     ],
 )
 @pytest.mark.integration
@@ -100,7 +97,7 @@ def test_derivatives_options_unusual(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -136,7 +133,7 @@ def test_derivatives_futures_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -168,7 +165,7 @@ def test_derivatives_futures_curve(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "intrinio", "date": None, "only_traded": True}),
@@ -188,7 +185,7 @@ def test_derivatives_options_snapshots(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "deribit"}),
@@ -206,7 +203,7 @@ def test_derivatives_futures_instruments(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "deribit", "symbol": "ETH-PERPETUAL"}),

--- a/openbb_platform/extensions/derivatives/integration/test_derivatives_python.py
+++ b/openbb_platform/extensions/derivatives/integration/test_derivatives_python.py
@@ -1,7 +1,6 @@
 """Python interface integration tests for the derivatives extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 # pylint: disable=too-many-lines,redefined-outer-name
@@ -17,7 +16,7 @@ def obb(pytestconfig):
         return openbb.obb
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -73,23 +72,21 @@ def test_derivatives_options_chains(params, obb):
     assert len(getattr(result, "dataframe", [])) == len(result.contract_symbol)  # type: ignore
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "symbol": "AAPL",
-                "provider": "intrinio",
-                "start_date": "2023-11-20",
-                "end_date": None,
-                "min_value": None,
-                "max_value": None,
-                "trade_type": None,
-                "sentiment": "neutral",
-                "limit": 1000,
-                "source": "delayed",
-            }
-        )
+        {
+            "symbol": "AAPL",
+            "provider": "intrinio",
+            "start_date": "2023-11-20",
+            "end_date": None,
+            "min_value": None,
+            "max_value": None,
+            "trade_type": None,
+            "sentiment": "neutral",
+            "limit": 1000,
+            "source": "delayed",
+        }
     ],
 )
 @pytest.mark.integration
@@ -101,7 +98,7 @@ def test_derivatives_options_unusual(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -134,7 +131,7 @@ def test_derivatives_futures_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "yfinance", "symbol": "ES", "date": None}),
@@ -151,7 +148,7 @@ def test_derivatives_futures_curve(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "intrinio", "date": None, "only_traded": True}),
@@ -168,7 +165,7 @@ def test_derivatives_options_snapshots(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "deribit"}),
@@ -183,7 +180,7 @@ def test_derivatives_futures_instruments(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "deribit", "symbol": "ETH-PERPETUAL"}),

--- a/openbb_platform/extensions/econometrics/integration/test_econometrics_python.py
+++ b/openbb_platform/extensions/econometrics/integration/test_econometrics_python.py
@@ -4,7 +4,6 @@ import random
 from typing import Literal
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 from openbb_econometrics.utils import mock_multi_index_data
 
@@ -63,7 +62,7 @@ def get_data(menu: Literal["equity", "crypto"]):
     return funcs[menu]()
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "method": "pearson"}, "equity"),
@@ -83,7 +82,7 @@ def test_econometrics_correlation_matrix(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -109,7 +108,7 @@ def test_econometrics_ols_regression(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -134,7 +133,7 @@ def test_econometrics_ols_regression_summary(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -159,7 +158,7 @@ def test_econometrics_autocorrelation(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -194,7 +193,7 @@ def test_econometrics_residual_autocorrelation(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -226,7 +225,7 @@ def test_econometrics_cointegration(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -262,7 +261,7 @@ def test_econometrics_causality(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "column": "close", "regression": "c"}, "equity"),
@@ -284,7 +283,7 @@ def test_econometrics_unit_root(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},
@@ -304,7 +303,7 @@ def test_econometrics_panel_random_effects(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},
@@ -324,7 +323,7 @@ def test_econometrics_panel_between(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},
@@ -344,7 +343,7 @@ def test_econometrics_panel_pooled(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},
@@ -364,7 +363,7 @@ def test_econometrics_panel_fixed(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},
@@ -384,7 +383,7 @@ def test_econometrics_panel_first_difference(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {"data": "", "y_column": "income", "x_columns": ["age"]},

--- a/openbb_platform/extensions/econometrics/tests/test_econometrics_utils.py
+++ b/openbb_platform/extensions/econometrics/tests/test_econometrics_utils.py
@@ -2,7 +2,7 @@
 
 import numpy as np
 import pandas as pd
-from extensions.econometrics.openbb_econometrics.utils import (
+from openbb_econometrics.utils import (
     get_engle_granger_two_step_cointegration_test,
     mock_multi_index_data,
 )

--- a/openbb_platform/extensions/economy/integration/test_economy_api.py
+++ b/openbb_platform/extensions/economy/integration/test_economy_api.py
@@ -6,7 +6,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -24,7 +23,7 @@ def headers():
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -67,7 +66,7 @@ def test_economy_calendar(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -118,7 +117,7 @@ def test_economy_cpi(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"provider": "fmp"}],
 )
@@ -134,7 +133,7 @@ def test_economy_risk_premium(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -161,7 +160,7 @@ def test_economy_gdp_forecast(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -198,7 +197,7 @@ def test_economy_gdp_nominal(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -233,7 +232,7 @@ def test_economy_gdp_real(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -282,7 +281,7 @@ def test_economy_balance_of_payments(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -350,7 +349,7 @@ def test_economy_fred_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -390,7 +389,7 @@ def test_economy_fred_series(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "adjusted": True}),
@@ -416,7 +415,7 @@ def test_economy_money_measures(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -445,7 +444,7 @@ def test_economy_unemployment(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -472,7 +471,7 @@ def test_economy_composite_leading_indicator(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "provider": "oecd"}),
@@ -499,7 +498,7 @@ def test_economy_short_term_interest_rate(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "provider": "oecd"}),
@@ -526,11 +525,12 @@ def test_economy_long_term_interest_rate(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
-    argnames="params",
-    argvalues=[
+@pytest.mark.parametrize(
+    "params",
+    [
         (
             {
+                "provider": "fred",
                 "symbol": "156241",
                 "is_series_group": True,
                 "start_date": "2000-01-01",
@@ -541,12 +541,12 @@ def test_economy_long_term_interest_rate(params, headers):
                 "season": "nsa",
                 "aggregation_method": "eop",
                 "transform": "ch1",
-                "provider": "fred",
                 "limit": None,
             }
         ),
         (
             {
+                "provider": "fred",
                 "symbol": "CAICLAIMS",
                 "is_series_group": False,
                 "start_date": "1990-01-01",
@@ -557,7 +557,6 @@ def test_economy_long_term_interest_rate(params, headers):
                 "season": None,
                 "aggregation_method": None,
                 "transform": None,
-                "provider": "fred",
                 "limit": None,
             }
         ),
@@ -575,7 +574,7 @@ def test_economy_fred_regional(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -636,7 +635,7 @@ def test_economy_indicators(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "econdb", "use_cache": False}),
@@ -655,7 +654,7 @@ def test_economy_available_indicators(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -680,7 +679,7 @@ def test_economy_country_profile(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -719,7 +718,7 @@ def test_economy_central_bank_holdings(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -745,7 +744,7 @@ def test_economy_share_price_index(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -772,7 +771,7 @@ def test_economy_house_price_index(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -798,7 +797,7 @@ def test_economy_immediate_interest_rate(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -825,7 +824,7 @@ def test_economy_interest_rates(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -854,7 +853,7 @@ def test_economy_retail_prices(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -883,7 +882,7 @@ def test_economy_survey_university_of_michigan(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -908,7 +907,7 @@ def test_economy_survey_sloos(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -935,7 +934,7 @@ def test_economy_survey_economic_conditions_chicago(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -963,7 +962,7 @@ def test_economy_survey_manufacturing_outlook_texas(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -991,7 +990,7 @@ def test_economy_survey_manufacturing_outlook_ny(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1016,7 +1015,7 @@ def test_economy_primary_dealer_positioning(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1040,7 +1039,7 @@ def test_economy_survey_nonfarm_payrolls(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1064,7 +1063,7 @@ def test_economy_pce(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1097,7 +1096,7 @@ def test_economy_fred_release_table(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1123,7 +1122,7 @@ def test_economy_survey_bls_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1151,7 +1150,7 @@ def test_economy_survey_bls_series(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1174,7 +1173,7 @@ def test_economy_export_destinations(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1200,7 +1199,7 @@ def test_economy_primary_dealer_fails(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1233,7 +1232,7 @@ def test_economy_port_volume(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1261,7 +1260,7 @@ def test_economy_direction_of_trade(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1318,7 +1317,7 @@ def test_economy_fomc_documents_download(headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1351,7 +1350,7 @@ def test_economy_shipping_port_volume(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1376,7 +1375,7 @@ def test_economy_shipping_chokepoint_volume(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1398,7 +1397,7 @@ def test_economy_shipping_chokepoint_info(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/economy/integration/test_economy_python.py
+++ b/openbb_platform/extensions/economy/integration/test_economy_python.py
@@ -1,7 +1,6 @@
 """Test economy extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -18,7 +17,7 @@ def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -60,7 +59,7 @@ def test_economy_calendar(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -108,7 +107,7 @@ def test_economy_cpi(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "fmp"}),
@@ -123,7 +122,7 @@ def test_economy_risk_premium(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -149,7 +148,7 @@ def test_economy_gdp_forecast(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -185,7 +184,7 @@ def test_economy_gdp_nominal(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -219,7 +218,7 @@ def test_economy_gdp_real(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -267,7 +266,7 @@ def test_economy_balance_of_payments(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -334,7 +333,7 @@ def test_economy_fred_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -373,7 +372,7 @@ def test_economy_fred_series(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "adjusted": True}),
@@ -398,7 +397,7 @@ def test_economy_money_measures(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -426,7 +425,7 @@ def test_economy_unemployment(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -452,7 +451,7 @@ def test_economy_composite_leading_indicator(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -478,7 +477,7 @@ def test_economy_short_term_interest_rate(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -504,11 +503,12 @@ def test_economy_long_term_interest_rate(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
-    argnames="params",
-    argvalues=[
+@pytest.mark.parametrize(
+    "params",
+    [
         (
             {
+                "provider": "fred",
                 "symbol": "156241",
                 "is_series_group": True,
                 "start_date": "2000-01-01",
@@ -519,12 +519,12 @@ def test_economy_long_term_interest_rate(params, obb):
                 "season": "nsa",
                 "aggregation_method": "eop",
                 "transform": "ch1",
-                "provider": "fred",
                 "limit": None,
             }
         ),
         (
             {
+                "provider": "fred",
                 "symbol": "CAICLAIMS",
                 "is_series_group": False,
                 "start_date": "1990-01-01",
@@ -535,7 +535,6 @@ def test_economy_long_term_interest_rate(params, obb):
                 "season": None,
                 "aggregation_method": "avg",
                 "transform": "chg",
-                "provider": "fred",
                 "limit": None,
             }
         ),
@@ -552,7 +551,7 @@ def test_economy_fred_regional(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -576,7 +575,7 @@ def test_economy_country_profile(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "econdb", "use_cache": False}),
@@ -594,7 +593,7 @@ def test_economy_available_indicators(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -654,7 +653,7 @@ def test_economy_indicators(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -692,7 +691,7 @@ def test_economy_central_bank_holdings(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -717,7 +716,7 @@ def test_economy_share_price_index(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -743,7 +742,7 @@ def test_economy_house_price_index(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -768,7 +767,7 @@ def test_economy_immediate_interest_rate(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -794,7 +793,7 @@ def test_economy_interest_rates(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -822,7 +821,7 @@ def test_economy_retail_prices(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -848,7 +847,7 @@ def test_economy_survey_university_of_michigan(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -872,7 +871,7 @@ def test_economy_survey_sloos(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -898,7 +897,7 @@ def test_economy_survey_economic_conditions_chicago(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -925,7 +924,7 @@ def test_economy_survey_manufacturing_outlook_texas(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -952,7 +951,7 @@ def test_economy_survey_manufacturing_outlook_ny(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -976,7 +975,7 @@ def test_economy_primary_dealer_positioning(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -999,7 +998,7 @@ def test_economy_survey_nonfarm_payrolls(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1022,7 +1021,7 @@ def test_economy_pce(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1054,7 +1053,7 @@ def test_economy_fred_release_table(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1079,7 +1078,7 @@ def test_economy_survey_bls_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1106,7 +1105,7 @@ def test_economy_survey_bls_series(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1128,7 +1127,7 @@ def test_economy_export_destinations(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1153,7 +1152,7 @@ def test_economy_primary_dealer_fails(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1185,7 +1184,7 @@ def test_economy_port_volume(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1212,7 +1211,7 @@ def test_economy_direction_of_trade(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1255,7 +1254,7 @@ def test_economy_fomc_documents(params, obb):
     assert len(result) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1278,7 +1277,7 @@ def test_economy_shipping_port_info(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1297,7 +1296,7 @@ def test_economy_shipping_chokepoint_info(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1319,7 +1318,7 @@ def test_economy_shipping_chokepoint_volume(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/equity/integration/test_equity_api.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -21,7 +20,7 @@ def headers():
     return {"Authorization": f"Basic {base64_bytes.decode('ascii')}"}
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12, "provider": "fmp"}),
@@ -85,7 +84,7 @@ def test_equity_fundamental_balance(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "limit": 10, "provider": "fmp", "period": "annual"}],
 )
@@ -101,7 +100,7 @@ def test_equity_fundamental_balance_growth(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-05", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -120,7 +119,7 @@ def test_equity_calendar_dividend(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-05", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -138,7 +137,7 @@ def test_equity_calendar_splits(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-09", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -166,7 +165,7 @@ def test_equity_calendar_earnings(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -229,7 +228,7 @@ def test_equity_fundamental_cash(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "limit": 10, "provider": "fmp", "period": "annual"}],
 )
@@ -245,7 +244,7 @@ def test_equity_fundamental_cash_growth(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -283,7 +282,7 @@ def test_equity_fundamental_management_compensation(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "fmp"}],
 )
@@ -299,7 +298,7 @@ def test_equity_fundamental_historical_splits(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -361,7 +360,7 @@ def test_equity_fundamental_dividends(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "fmp"}],
 )
@@ -377,7 +376,7 @@ def test_equity_fundamental_employee_count(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL,MSFT", "period": "annual", "limit": 30}],
 )
@@ -393,7 +392,7 @@ def test_equity_estimates_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -427,7 +426,7 @@ def test_equity_estimates_forward_sales(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -470,7 +469,7 @@ def test_equity_estimates_forward_eps(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12, "provider": "fmp"}),
@@ -534,7 +533,7 @@ def test_equity_fundamental_income(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "limit": 10, "period": "annual", "provider": "fmp"}],
 )
@@ -550,7 +549,7 @@ def test_equity_fundamental_income_growth(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -603,7 +602,7 @@ def test_equity_ownership_insider_trading(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -636,7 +635,7 @@ def test_equity_ownership_institutional(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -671,7 +670,7 @@ def test_equity_calendar_ipo(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -700,7 +699,7 @@ def test_equity_fundamental_metrics(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -719,7 +718,7 @@ def test_equity_fundamental_management(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "date": "2023-01-01", "page": 1, "provider": "fmp"}],
 )
@@ -735,7 +734,7 @@ def test_equity_ownership_major_holders(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 10, "provider": "fmp", "with_grade": True}),
@@ -772,7 +771,7 @@ def test_equity_estimates_price_target(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -815,7 +814,7 @@ def test_equity_estimates_analyst_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -842,7 +841,7 @@ def test_equity_estimates_consensus(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12, "provider": "fmp"}),
@@ -869,7 +868,7 @@ def test_equity_fundamental_ratios(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "period": "annual", "provider": "fmp"}],
 )
@@ -885,7 +884,7 @@ def test_equity_fundamental_revenue_per_geography(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "period": "annual", "provider": "fmp"}],
 )
@@ -903,7 +902,7 @@ def test_equity_fundamental_revenue_per_segment(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -979,7 +978,7 @@ def test_equity_fundamental_filings(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -999,7 +998,7 @@ def test_equity_ownership_share_statistics(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "year": 2023}],
 )
@@ -1015,7 +1014,7 @@ def test_equity_fundamental_transcript(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL"}],
 )
@@ -1031,7 +1030,7 @@ def test_equity_compare_peers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"group": "country", "metric": "overview", "provider": "finviz"}],
 )
@@ -1047,7 +1046,7 @@ def test_equity_compare_groups(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1238,7 +1237,7 @@ def test_equity_price_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "fmp"}],
 )
@@ -1254,7 +1253,7 @@ def test_equity_fundamental_multiples(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "ebit", "limit": 100, "provider": "intrinio"}),
@@ -1272,7 +1271,7 @@ def test_equity_fundamental_search_attributes(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1354,7 +1353,7 @@ def test_equity_fundamental_historical_attributes(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1413,7 +1412,7 @@ def test_equity_fundamental_latest_attributes(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "AAPl", "is_symbol": True, "provider": "cboe", "use_cache": False}),
@@ -1443,7 +1442,7 @@ def test_equity_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1529,7 +1528,7 @@ def test_equity_screener(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"source": "iex", "provider": "intrinio", "symbol": "AAPL"}),
@@ -1552,7 +1551,7 @@ def test_equity_price_quote(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "MSFT", "provider": "intrinio"}),
@@ -1575,7 +1574,7 @@ def test_equity_profile(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"sort": "desc", "provider": "yfinance", "limit": 10}),
@@ -1594,7 +1593,7 @@ def test_equity_discovery_gainers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1610,7 +1609,7 @@ def test_equity_discovery_losers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1626,7 +1625,7 @@ def test_equity_discovery_active(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -1645,7 +1644,7 @@ def test_equity_price_performance(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1661,7 +1660,7 @@ def test_equity_discovery_undervalued_large_caps(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1677,7 +1676,7 @@ def test_equity_discovery_undervalued_growth(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1695,7 +1694,7 @@ def test_equity_discovery_aggressive_small_caps(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1711,7 +1710,7 @@ def test_equity_discovery_growth_tech(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"limit": 10, "provider": "nasdaq"}],
 )
@@ -1727,7 +1726,7 @@ def test_equity_discovery_top_retail(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1764,7 +1763,7 @@ def test_equity_discovery_filings(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -1791,7 +1790,7 @@ def test_equity_shorts_fails_to_deliver(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "stockgrid"}],
 )
@@ -1807,7 +1806,7 @@ def test_equity_shorts_short_volume(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "finra"}],
 )
@@ -1823,7 +1822,7 @@ def test_equity_shorts_short_interest(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1852,7 +1851,7 @@ def test_equity_price_nbbo(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -1876,7 +1875,7 @@ def test_equity_darkpool_otc(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "fmp", "market": "euronext"}),
@@ -1896,7 +1895,7 @@ def test_equity_market_snapshots(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 5, "provider": "fmp"}),
@@ -1922,7 +1921,7 @@ def test_equity_fundamental_historical_eps(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"provider": "tiingo", "symbol": "AAPL", "limit": 10}],
 )
@@ -1938,7 +1937,7 @@ def test_equity_fundamental_trailing_dividend_yield(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1987,7 +1986,7 @@ def test_equity_fundamental_reported_financials(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2012,7 +2011,7 @@ def test_equity_ownership_form_13f(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2041,7 +2040,7 @@ def test_equity_estimates_forward_pe(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2074,7 +2073,7 @@ def test_equity_estimates_forward_ebitda(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2113,7 +2112,7 @@ def test_equity_compare_company_facts(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2147,7 +2146,7 @@ def test_equity_historical_market_cap(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2171,7 +2170,7 @@ def test_equity_discovery_latest_financial_reports(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2204,7 +2203,7 @@ def test_equity_ownership_government_trades(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2234,7 +2233,7 @@ def test_equity_fundamental_management_discussion_analysis(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/equity/integration/test_equity_python.py
+++ b/openbb_platform/extensions/equity/integration/test_equity_python.py
@@ -3,7 +3,6 @@
 from datetime import date, timedelta
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 # pylint: disable=too-many-lines,redefined-outer-name
@@ -19,7 +18,7 @@ def obb(pytestconfig):
         return openbb.obb
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12}),
@@ -80,7 +79,7 @@ def test_equity_fundamental_balance(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 10, "provider": "fmp", "period": "annual"}),
@@ -95,7 +94,7 @@ def test_equity_fundamental_balance_growth(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-05", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -111,7 +110,7 @@ def test_equity_calendar_dividend(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-05", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -126,7 +125,7 @@ def test_equity_calendar_splits(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-11-09", "end_date": "2023-11-10", "provider": "fmp"}),
@@ -151,7 +150,7 @@ def test_equity_calendar_earnings(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -211,7 +210,7 @@ def test_equity_fundamental_cash(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 10, "provider": "fmp", "period": "annual"}),
@@ -226,7 +225,7 @@ def test_equity_fundamental_cash_growth(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -261,7 +260,7 @@ def test_equity_fundamental_management_compensation(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -276,7 +275,7 @@ def test_equity_fundamental_historical_splits(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -335,7 +334,7 @@ def test_equity_fundamental_dividends(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -350,7 +349,7 @@ def test_equity_fundamental_employee_count(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL,MSFT", "period": "annual", "limit": 30}),
@@ -365,7 +364,7 @@ def test_equity_estimates_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12}),
@@ -426,7 +425,7 @@ def test_equity_fundamental_income(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "limit": 10, "period": "annual", "provider": "fmp"}],
 )
@@ -439,7 +438,7 @@ def test_equity_fundamental_income_growth(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -489,7 +488,7 @@ def test_equity_ownership_insider_trading(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -519,7 +518,7 @@ def test_equity_ownership_institutional(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -551,7 +550,7 @@ def test_equity_calendar_ipo(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 100}),
@@ -581,7 +580,7 @@ def test_equity_fundamental_metrics(params, obb):
         assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -597,7 +596,7 @@ def test_equity_fundamental_management(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "date": "2023-01-01", "page": 1, "provider": "fmp"}),
@@ -612,7 +611,7 @@ def test_equity_ownership_major_holders(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 10, "provider": "fmp", "with_grade": True}),
@@ -646,7 +645,7 @@ def test_equity_estimates_price_target(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -672,7 +671,7 @@ def test_equity_estimates_analyst_search(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -696,7 +695,7 @@ def test_equity_estimates_consensus(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -727,7 +726,7 @@ def test_equity_estimates_forward_sales(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -767,7 +766,7 @@ def test_equity_estimates_forward_eps(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -797,7 +796,7 @@ def test_equity_estimates_forward_ebitda(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "period": "annual", "limit": 12, "provider": "fmp"}),
@@ -821,7 +820,7 @@ def test_equity_fundamental_ratios(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -842,7 +841,7 @@ def test_equity_fundamental_revenue_per_geography(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -863,7 +862,7 @@ def test_equity_fundamental_revenue_per_segment(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -936,7 +935,7 @@ def test_equity_fundamental_filings(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -953,7 +952,7 @@ def test_equity_ownership_share_statistics(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "year": 2023}),
@@ -968,7 +967,7 @@ def test_equity_fundamental_transcript(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -983,7 +982,7 @@ def test_equity_compare_peers(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"group": "country", "metric": "overview", "provider": "finviz"}],
 )
@@ -996,7 +995,7 @@ def test_equity_compare_groups(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1183,7 +1182,7 @@ def test_equity_price_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -1198,7 +1197,7 @@ def test_equity_fundamental_multiples(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "ebit", "limit": 100, "provider": "intrinio"}),
@@ -1213,7 +1212,7 @@ def test_equity_fundamental_search_attributes(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1292,7 +1291,7 @@ def test_equity_fundamental_historical_attributes(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1351,7 +1350,7 @@ def test_equity_fundamental_latest_attributes(params, obb):
         assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "AAPL", "is_symbol": True, "provider": "cboe", "use_cache": False}),
@@ -1378,7 +1377,7 @@ def test_equity_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1461,7 +1460,7 @@ def test_equity_screener(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -1482,7 +1481,7 @@ def test_equity_price_quote(params, obb):
     assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "MSFT", "provider": "intrinio"}),
@@ -1505,7 +1504,7 @@ def test_equity_profile(params, obb):
         assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"sort": "desc", "provider": "yfinance", "limit": 10}),
@@ -1523,7 +1522,7 @@ def test_equity_discovery_gainers(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1538,7 +1537,7 @@ def test_equity_discovery_losers(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1553,7 +1552,7 @@ def test_equity_discovery_active(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "provider": "fmp"}),
@@ -1571,7 +1570,7 @@ def test_equity_price_performance(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1586,7 +1585,7 @@ def test_equity_discovery_undervalued_large_caps(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1601,7 +1600,7 @@ def test_equity_discovery_undervalued_growth(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1616,7 +1615,7 @@ def test_equity_discovery_aggressive_small_caps(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"sort": "desc", "provider": "yfinance", "limit": 10}],
 )
@@ -1631,7 +1630,7 @@ def test_equity_discovery_growth_tech(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"limit": 10, "provider": "nasdaq"}],
 )
@@ -1646,7 +1645,7 @@ def test_equity_discovery_top_retail(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1685,7 +1684,7 @@ def test_equity_discovery_filings(params, obb):
         assert result.results is not None
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -1711,7 +1710,7 @@ def test_equity_shorts_fails_to_deliver(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "stockgrid"}],
 )
@@ -1726,7 +1725,7 @@ def test_equity_shorts_short_volume(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"symbol": "AAPL", "provider": "finra"}],
 )
@@ -1741,7 +1740,7 @@ def test_equity_shorts_short_interest(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1767,7 +1766,7 @@ def test_equity_price_nbbo(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL"}),
@@ -1785,7 +1784,7 @@ def test_equity_darkpool_otc(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "fmp", "market": "euronext"}),
@@ -1802,7 +1801,7 @@ def test_equity_market_snapshots(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "AAPL", "limit": 5, "provider": "fmp"}),
@@ -1827,7 +1826,7 @@ def test_equity_fundamental_historical_eps(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"provider": "tiingo", "symbol": "AAPL", "limit": 10}],
 )
@@ -1842,7 +1841,7 @@ def test_equity_fundamental_trailing_dividend_yield(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1888,7 +1887,7 @@ def test_equity_fundamental_reported_financials(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1912,7 +1911,7 @@ def test_equity_ownership_form_13f(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1940,7 +1939,7 @@ def test_equity_estimates_forward_pe(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -1978,7 +1977,7 @@ def test_equity_compare_company_facts(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2011,7 +2010,7 @@ def test_equity_historical_market_cap(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2034,7 +2033,7 @@ def test_equity_discovery_latest_financial_reports(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2066,7 +2065,7 @@ def test_equity_ownership_government_trades(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -2093,7 +2092,7 @@ def test_equity_fundamental_management_discussion_analysis(params, obb):
     assert len(result.results.content) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/etf/integration/test_etf_api.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -22,7 +21,7 @@ def headers():
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "", "provider": "fmp"}),
@@ -56,7 +55,7 @@ def test_etf_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -237,7 +236,7 @@ def test_etf_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -258,7 +257,7 @@ def test_etf_info(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -277,7 +276,7 @@ def test_etf_sectors(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "QQQ", "cik": None, "provider": "fmp"}),
@@ -295,7 +294,7 @@ def test_etf_holdings_date(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -365,7 +364,7 @@ def test_etf_holdings(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "SPY,VOO,QQQ,IWM,IWN,GOVT,JNK", "provider": "fmp"}),
@@ -392,7 +391,7 @@ def test_etf_price_performance(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -411,9 +410,9 @@ def test_etf_countries(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_gainers(params, headers):
@@ -427,9 +426,9 @@ def test_etf_discovery_gainers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_losers(params, headers):
@@ -443,9 +442,9 @@ def test_etf_discovery_losers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_active(params, headers):
@@ -459,7 +458,7 @@ def test_etf_discovery_active(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "SPY,VOO,QQQ,IWM,IWN", "provider": "fmp"}),

--- a/openbb_platform/extensions/etf/integration/test_etf_python.py
+++ b/openbb_platform/extensions/etf/integration/test_etf_python.py
@@ -1,7 +1,6 @@
 """Test etf extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -18,7 +17,7 @@ def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": None, "provider": "fmp"}),
@@ -51,7 +50,7 @@ def test_etf_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -229,7 +228,7 @@ def test_etf_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -249,7 +248,7 @@ def test_etf_info(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -267,7 +266,7 @@ def test_etf_sectors(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "QQQ", "cik": None, "provider": "fmp"}),
@@ -284,7 +283,7 @@ def test_etf_holdings_date(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -353,7 +352,7 @@ def test_etf_holdings(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "SPY,VOO,QQQ,IWM,IWN,GOVT,JNK", "provider": "fmp"}),
@@ -379,7 +378,7 @@ def test_etf_price_performance(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "IOO", "provider": "fmp"}),
@@ -397,9 +396,9 @@ def test_etf_countries(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_gainers(params, obb):
@@ -412,9 +411,9 @@ def test_etf_discovery_gainers(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_losers(params, obb):
@@ -427,9 +426,9 @@ def test_etf_discovery_losers(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"sort": "desc", "limit": 10})],
+    [{"sort": "desc", "limit": 10}],
 )
 @pytest.mark.integration
 def test_etf_discovery_active(params, obb):
@@ -442,7 +441,7 @@ def test_etf_discovery_active(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "SPY,VOO,QQQ,IWM,IWN", "provider": "fmp"}),

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -21,9 +20,9 @@ def headers():
     return {"Authorization": f"Basic {base64_bytes.decode('ascii')}"}
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06", "provider": "fmp"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06", "provider": "fmp"}],
 )
 @pytest.mark.integration
 def test_fixedincome_government_treasury_rates(params, headers):
@@ -39,7 +38,7 @@ def test_fixedincome_government_treasury_rates(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -73,7 +72,7 @@ def test_fixedincome_sofr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -107,7 +106,7 @@ def test_fixedincome_rate_sofr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -134,7 +133,7 @@ def test_fixedincome_rate_estr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -160,7 +159,7 @@ def test_fixedincome_rate_sonia(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -188,7 +187,7 @@ def test_fixedincome_rate_ameribor(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -223,7 +222,7 @@ def test_fixedincome_rate_effr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [({}), ({"long_run": True, "provider": "fred"})],
 )
@@ -239,9 +238,9 @@ def test_fixedincome_rate_effr_forecast(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06"}],
 )
 @pytest.mark.integration
 def test_fixedincome_rate_iorb(params, headers):
@@ -255,7 +254,7 @@ def test_fixedincome_rate_iorb(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -281,16 +280,14 @@ def test_fixedincome_rate_dpcredit(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "interest_rate_type": "lending",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "interest_rate_type": "lending",
+        }
     ],
 )
 @pytest.mark.integration
@@ -305,7 +302,7 @@ def test_fixedincome_rate_ecb(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "yield"}),
@@ -335,9 +332,9 @@ def test_fixedincome_corporate_ice_bofa(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "aaa"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "aaa"}],
 )
 @pytest.mark.integration
 def test_fixedincome_corporate_moody(params, headers):
@@ -351,21 +348,19 @@ def test_fixedincome_corporate_moody(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "overnight",
-                "category": "financial",
-                "transform": None,
-                "aggregation_method": None,
-                "frequency": None,
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "overnight",
+            "category": "financial",
+            "transform": None,
+            "aggregation_method": None,
+            "frequency": None,
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -382,7 +377,7 @@ def test_fixedincome_corporate_commercial_paper(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -424,9 +419,9 @@ def test_fixedincome_corporate_spot_rates(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"date": "2023-01-01", "yield_curve": "spot"})],
+    [{"date": "2023-01-01", "yield_curve": "spot"}],
 )
 @pytest.mark.integration
 def test_fixedincome_corporate_hqm(params, headers):
@@ -440,9 +435,9 @@ def test_fixedincome_corporate_hqm(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06", "maturity": "3m"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06", "maturity": "3m"}],
 )
 @pytest.mark.integration
 def test_fixedincome_spreads_tcm(params, headers):
@@ -456,17 +451,15 @@ def test_fixedincome_spreads_tcm(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "10y",
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "10y",
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -481,17 +474,15 @@ def test_fixedincome_spreads_tcm_effr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "3m",
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "3m",
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -506,7 +497,7 @@ def test_fixedincome_spreads_treasury_effr(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -596,26 +587,24 @@ def test_fixedincome_government_treasury_prices(params, headers):
 @pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "provider": "tmx",
-                "issuer_name": "federal",
-                "issue_date_min": None,
-                "issue_date_max": None,
-                "last_traded_min": None,
-                "coupon_min": 3,
-                "coupon_max": None,
-                "currency": None,
-                "issued_amount_min": None,
-                "issued_amount_max": None,
-                "maturity_date_min": None,
-                "maturity_date_max": None,
-                "isin": None,
-                "lei": None,
-                "country": None,
-                "use_cache": False,
-            }
-        )
+        {
+            "provider": "tmx",
+            "issuer_name": "federal",
+            "issue_date_min": None,
+            "issue_date_max": None,
+            "last_traded_min": None,
+            "coupon_min": 3,
+            "coupon_max": None,
+            "currency": None,
+            "issued_amount_min": None,
+            "issued_amount_max": None,
+            "maturity_date_min": None,
+            "maturity_date_max": None,
+            "isin": None,
+            "lei": None,
+            "country": None,
+            "use_cache": False,
+        }
     ],
 )
 @pytest.mark.integration
@@ -630,7 +619,7 @@ def test_fixedincome_corporate_bond_prices(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"date": "2023-05-01,2024-05-01", "provider": "fmp"}),
@@ -673,7 +662,7 @@ def test_fixedincome_government_yield_curve(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -701,7 +690,7 @@ def test_fixedincome_bond_indices(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -727,7 +716,7 @@ def test_fixedincome_mortgage_indices(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -761,7 +750,7 @@ def test_fixedincome_rate_overnight_bank_funding(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
+++ b/openbb_platform/extensions/fixedincome/integration/test_fixedincome_python.py
@@ -1,7 +1,6 @@
 """Test fixed income extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 # pylint: disable=redefined-outer-name
@@ -18,7 +17,7 @@ def obb(pytestconfig):
         return openbb.obb
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "provider": "fmp"}),
@@ -33,7 +32,7 @@ def test_fixedincome_government_treasury_rates(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -64,7 +63,7 @@ def test_fixedincome_sofr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -95,7 +94,7 @@ def test_fixedincome_rate_sofr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -119,7 +118,7 @@ def test_fixedincome_rate_estr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -142,7 +141,7 @@ def test_fixedincome_rate_sonia(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -167,7 +166,7 @@ def test_fixedincome_rate_ameribor(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -199,7 +198,7 @@ def test_fixedincome_rate_effr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({}),
@@ -215,7 +214,7 @@ def test_fixedincome_rate_effr_forecast(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -230,7 +229,7 @@ def test_fixedincome_rate_iorb(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06"}),
@@ -255,16 +254,14 @@ def test_fixedincome_rate_dpcredit(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "interest_rate_type": "lending",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "interest_rate_type": "lending",
+        }
     ],
 )
 @pytest.mark.integration
@@ -278,7 +275,7 @@ def test_fixedincome_rate_ecb(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "yield"}),
@@ -307,9 +304,9 @@ def test_fixedincome_corporate_ice_bofa(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "aaa"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06", "index_type": "aaa"}],
 )
 @pytest.mark.integration
 def test_fixedincome_corporate_moody(params, obb):
@@ -322,21 +319,19 @@ def test_fixedincome_corporate_moody(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "overnight",
-                "category": "financial",
-                "transform": None,
-                "aggregation_method": None,
-                "frequency": None,
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "overnight",
+            "category": "financial",
+            "transform": None,
+            "aggregation_method": None,
+            "frequency": None,
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -350,7 +345,7 @@ def test_fixedincome_corporate_commercial_paper(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -391,9 +386,9 @@ def test_fixedincome_corporate_spot_rates(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"date": "2023-01-01", "yield_curve": "spot"})],
+    [{"date": "2023-01-01", "yield_curve": "spot"}],
 )
 @pytest.mark.integration
 def test_fixedincome_corporate_hqm(params, obb):
@@ -406,9 +401,9 @@ def test_fixedincome_corporate_hqm(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"start_date": "2023-01-01", "end_date": "2023-06-06", "maturity": "3m"})],
+    [{"start_date": "2023-01-01", "end_date": "2023-06-06", "maturity": "3m"}],
 )
 @pytest.mark.integration
 def test_fixedincome_spreads_tcm(params, obb):
@@ -421,17 +416,15 @@ def test_fixedincome_spreads_tcm(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "10y",
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "10y",
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -445,17 +438,15 @@ def test_fixedincome_spreads_tcm_effr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "start_date": "2023-01-01",
-                "end_date": "2023-06-06",
-                "maturity": "3m",
-                "provider": "fred",
-            }
-        )
+        {
+            "start_date": "2023-01-01",
+            "end_date": "2023-06-06",
+            "maturity": "3m",
+            "provider": "fred",
+        }
     ],
 )
 @pytest.mark.integration
@@ -469,7 +460,7 @@ def test_fixedincome_spreads_treasury_effr(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -555,26 +546,24 @@ def test_fixedincome_government_treasury_prices(params, obb):
 @pytest.mark.parametrize(
     "params",
     [
-        (
-            {
-                "provider": "tmx",
-                "issuer_name": "federal",
-                "issue_date_min": None,
-                "issue_date_max": None,
-                "last_traded_min": None,
-                "coupon_min": 3,
-                "coupon_max": None,
-                "currency": None,
-                "issued_amount_min": None,
-                "issued_amount_max": None,
-                "maturity_date_min": None,
-                "maturity_date_max": None,
-                "isin": None,
-                "lei": None,
-                "country": None,
-                "use_cache": False,
-            }
-        )
+        {
+            "provider": "tmx",
+            "issuer_name": "federal",
+            "issue_date_min": None,
+            "issue_date_max": None,
+            "last_traded_min": None,
+            "coupon_min": 3,
+            "coupon_max": None,
+            "currency": None,
+            "issued_amount_min": None,
+            "issued_amount_max": None,
+            "maturity_date_min": None,
+            "maturity_date_max": None,
+            "isin": None,
+            "lei": None,
+            "country": None,
+            "use_cache": False,
+        }
     ],
 )
 @pytest.mark.integration
@@ -588,7 +577,7 @@ def test_fixedincome_corporate_bond_prices(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"date": "2023-05-01,2024-05-01", "provider": "fmp"}),
@@ -630,7 +619,7 @@ def test_fixedincome_government_yield_curve(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -657,7 +646,7 @@ def test_fixedincome_bond_indices(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -682,7 +671,7 @@ def test_fixedincome_mortgage_indices(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -713,7 +702,7 @@ def test_fixedincome_rate_overnight_bank_funding(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/index/integration/test_index_api.py
+++ b/openbb_platform/extensions/index/integration/test_index_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -22,7 +21,7 @@ def headers():
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "dowjones", "provider": "fmp"}),
@@ -42,7 +41,7 @@ def test_index_constituents(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -127,7 +126,7 @@ def test_index_price_historical(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "cboe", "use_cache": False}),
@@ -148,7 +147,7 @@ def test_index_available(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "D", "is_symbol": True, "provider": "cboe", "use_cache": False}),
@@ -166,7 +165,7 @@ def test_index_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "cboe", "region": "us"}),
@@ -185,7 +184,7 @@ def test_index_snapshots(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -210,7 +209,7 @@ def test_index_sp500_multiples(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"provider": "tmx", "symbol": "^TX60", "use_cache": False}),

--- a/openbb_platform/extensions/index/integration/test_index_python.py
+++ b/openbb_platform/extensions/index/integration/test_index_python.py
@@ -1,7 +1,6 @@
 """Test economy extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -18,7 +17,7 @@ def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "dowjones", "provider": "fmp"}),
@@ -35,7 +34,7 @@ def test_index_constituents(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -117,7 +116,7 @@ def test_index_price_historical(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({}),
@@ -136,7 +135,7 @@ def test_index_available(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -158,7 +157,7 @@ def test_index_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"region": "us", "provider": "cboe"}),
@@ -174,7 +173,7 @@ def test_index_snapshots(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -196,7 +195,7 @@ def test_index_sp500_multiples(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "^TX60", "provider": "tmx"}),

--- a/openbb_platform/extensions/news/integration/test_news_api.py
+++ b/openbb_platform/extensions/news/integration/test_news_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -22,7 +21,7 @@ def headers():
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -103,7 +102,7 @@ def test_news_world(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/news/integration/test_news_python.py
+++ b/openbb_platform/extensions/news/integration/test_news_python.py
@@ -1,7 +1,6 @@
 """Test news extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -18,7 +17,7 @@ def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -95,7 +94,7 @@ def test_news_world(params, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/quantitative/integration/test_quantitative_api.py
+++ b/openbb_platform/extensions/quantitative/integration/test_quantitative_api.py
@@ -7,7 +7,6 @@ from typing import Literal
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -81,7 +80,7 @@ def get_data(menu: Literal["equity", "crypto"]):
     return funcs[menu]()
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -101,7 +100,7 @@ def test_quantitative_normality(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "high"}, "equity"),
@@ -121,7 +120,7 @@ def test_quantitative_capm(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -157,7 +156,7 @@ def test_quantitative_performance_omega_ratio(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "5", "index": "date"}, "equity"),
@@ -177,7 +176,7 @@ def test_quantitative_rolling_kurtosis(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -213,7 +212,7 @@ def test_quantitative_unitroot_test(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -253,7 +252,7 @@ def test_quantitative_performance_sharpe_ratio(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -295,7 +294,7 @@ def test_quantitative_performance_sortino_ratio(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "220", "index": "date"}, "equity"),
@@ -314,7 +313,7 @@ def test_quantitative_rolling_skew(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "220", "index": "date"}, "equity"),
@@ -333,7 +332,7 @@ def test_quantitative_rolling_variance(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "220", "index": "date"}, "equity"),
@@ -352,7 +351,7 @@ def test_quantitative_rolling_stdev(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "220", "index": "date"}, "equity"),
@@ -371,7 +370,7 @@ def test_quantitative_rolling_mean(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -409,7 +408,7 @@ def test_quantitative_rolling_quantile(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -434,7 +433,7 @@ def test_quantitative_summary(params, data_type):
 ############
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "index": "date"}, "equity"),
@@ -453,7 +452,7 @@ def test_quantitative_stats_skew(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "index": "date"}, "equity"),
@@ -472,7 +471,7 @@ def test_quantitative_stats_kurtosis(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "index": "date"}, "equity"),
@@ -491,7 +490,7 @@ def test_quantitative_stats_mean(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "index": "date"}, "equity"),
@@ -510,7 +509,7 @@ def test_quantitative_stats_stdev(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "index": "date"}, "equity"),
@@ -529,7 +528,7 @@ def test_quantitative_stats_variance(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (

--- a/openbb_platform/extensions/quantitative/integration/test_quantitative_python.py
+++ b/openbb_platform/extensions/quantitative/integration/test_quantitative_python.py
@@ -4,7 +4,6 @@ import random
 from typing import Literal
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -62,7 +61,7 @@ def get_data(menu: Literal["equity", "crypto"]):
     return funcs[menu]()
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -80,7 +79,7 @@ def test_quantitative_normality(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -98,7 +97,7 @@ def test_quantitative_capm(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -132,7 +131,7 @@ def test_quantitative_performance_omega_ratio(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "5", "index": "date"}, "equity"),
@@ -151,7 +150,7 @@ def test_quantitative_rolling_kurtosis(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -185,7 +184,7 @@ def test_quantitative_unitroot_test(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -221,7 +220,7 @@ def test_quantitative_performance_sharpe_ratio(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -259,7 +258,7 @@ def test_quantitative_performance_sortino_ratio(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close", "window": "220", "index": "date"}, "equity"),
@@ -277,7 +276,7 @@ def test_quantitative_rolling_skew(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -314,7 +313,7 @@ def test_quantitative_rolling_quantile(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -332,7 +331,7 @@ def test_quantitative_summary(params, data_type, obb):
     assert isinstance(result, OBBject)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -367,7 +366,7 @@ def test_quantitative_rolling_stdev(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -402,7 +401,7 @@ def test_quantitative_rolling_mean(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -437,7 +436,7 @@ def test_quantitative_rolling_variance(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -455,7 +454,7 @@ def test_quantitative_stats_skew(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -473,7 +472,7 @@ def test_quantitative_stats_kurtosis(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -491,7 +490,7 @@ def test_quantitative_stats_variance(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -509,7 +508,7 @@ def test_quantitative_stats_stdev(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "target": "close"}, "equity"),
@@ -527,7 +526,7 @@ def test_quantitative_stats_mean(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (

--- a/openbb_platform/extensions/regulators/integration/test_regulators_api.py
+++ b/openbb_platform/extensions/regulators/integration/test_regulators_api.py
@@ -4,7 +4,6 @@ import base64
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -22,7 +21,7 @@ def headers():
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "TSLA", "provider": "sec", "use_cache": None}),
@@ -41,7 +40,7 @@ def test_regulators_sec_cik_map(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "berkshire hathaway", "provider": "sec", "use_cache": None}),
@@ -59,7 +58,7 @@ def test_regulators_sec_institutions_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "2022", "provider": "sec", "url": "", "use_cache": None}),
@@ -85,7 +84,7 @@ def test_regulators_sec_schema_files(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "0000909832", "provider": "sec", "use_cache": None}),
@@ -104,9 +103,9 @@ def test_regulators_sec_symbol_map(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"provider": "sec"})],
+    [{"provider": "sec"}],
 )
 @pytest.mark.integration
 def test_regulators_sec_rss_litigation(params, headers):
@@ -120,9 +119,9 @@ def test_regulators_sec_rss_litigation(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"query": "oil", "use_cache": False, "provider": "sec"})],
+    [{"query": "oil", "use_cache": False, "provider": "sec"}],
 )
 @pytest.mark.integration
 def test_regulators_sec_sic_search(params, headers):
@@ -136,7 +135,7 @@ def test_regulators_sec_sic_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "grain", "provider": "cftc"}),
@@ -154,7 +153,7 @@ def test_regulators_cftc_cot_search(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -181,7 +180,7 @@ def test_regulators_cftc_cot(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -205,7 +204,7 @@ def test_regulators_sec_filing_headers(params, headers):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/regulators/integration/test_regulators_python.py
+++ b/openbb_platform/extensions/regulators/integration/test_regulators_python.py
@@ -1,7 +1,6 @@
 """Test Regulators extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -19,7 +18,7 @@ def obb(pytestconfig):
 # pylint: disable=redefined-outer-name
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"symbol": "TSLA", "provider": "sec", "use_cache": None}),
@@ -36,7 +35,7 @@ def test_regulators_sec_cik_map(params, obb):
     assert isinstance(result.results.cik, str)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "berkshire hathaway", "provider": "sec", "use_cache": None}),
@@ -51,7 +50,7 @@ def test_regulators_sec_institutions_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -81,7 +80,7 @@ def test_regulators_sec_schema_files(params, obb):
     assert len(result.results.files) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "0000909832", "provider": "sec", "use_cache": None}),
@@ -98,9 +97,9 @@ def test_regulators_sec_symbol_map(params, obb):
     assert isinstance(result.results.symbol, str)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"provider": "sec"})],
+    [{"provider": "sec"}],
 )
 @pytest.mark.integration
 def test_regulators_sec_rss_litigation(params, obb):
@@ -111,9 +110,9 @@ def test_regulators_sec_rss_litigation(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
-    [({"query": "oil", "use_cache": False, "provider": "sec"})],
+    [{"query": "oil", "use_cache": False, "provider": "sec"}],
 )
 @pytest.mark.integration
 def test_regulators_sec_sic_search(params, obb):
@@ -124,7 +123,7 @@ def test_regulators_sec_sic_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         ({"query": "grain", "provider": "cftc"}),
@@ -139,7 +138,7 @@ def test_regulators_cftc_cot_search(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -163,7 +162,7 @@ def test_regulators_cftc_cot(params, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -187,7 +186,7 @@ def test_regulators_sec_filing_headers(params, obb):
     assert hasattr(result.results, "cover_page")
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/technical/integration/test_technical_api.py
+++ b/openbb_platform/extensions/technical/integration/test_technical_api.py
@@ -9,7 +9,6 @@ from typing import Literal
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -71,7 +70,7 @@ def get_crypto_data():
     return data["crypto_data"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -111,7 +110,7 @@ def test_technical_atr(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -151,7 +150,7 @@ def test_technical_fib(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "offset": ""}, "equity"),
@@ -171,7 +170,7 @@ def test_technical_obv(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "signal": ""}, "equity"),
@@ -191,7 +190,7 @@ def test_technical_fisher(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -229,7 +228,7 @@ def test_technical_adosc(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -271,7 +270,7 @@ def test_technical_bbands(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -309,7 +308,7 @@ def test_technical_zlma(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "scalar": ""}, "equity"),
@@ -337,7 +336,7 @@ def test_technical_aroon(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -375,7 +374,7 @@ def test_technical_sma(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -415,7 +414,7 @@ def test_technical_demark(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "anchor": "", "offset": ""}, "equity"),
@@ -435,7 +434,7 @@ def test_technical_vwap(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -475,7 +474,7 @@ def test_technical_macd(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -513,7 +512,7 @@ def test_technical_hma(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -551,7 +550,7 @@ def test_technical_donchian(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -593,7 +592,7 @@ def test_technical_ichimoku(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "date", "target": "close", "period": "10"}, "equity"),
@@ -621,7 +620,7 @@ def test_technical_clenow(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "offset": ""}, "equity"),
@@ -641,7 +640,7 @@ def test_technical_ad(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -679,7 +678,7 @@ def test_technical_adx(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -717,7 +716,7 @@ def test_technical_wma(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "scalar": ""}, "equity"),
@@ -745,7 +744,7 @@ def test_technical_cci(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -785,7 +784,7 @@ def test_technical_rsi(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -823,7 +822,7 @@ def test_technical_stoch(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -863,7 +862,7 @@ def test_technical_kc(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": ""}, "equity"),
@@ -883,7 +882,7 @@ def test_technical_cg(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -925,7 +924,7 @@ def test_technical_cones(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -963,7 +962,7 @@ def test_technical_ema(params, data_type):
     assert result.status_code == 200
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/technical/integration/test_technical_python.py
+++ b/openbb_platform/extensions/technical/integration/test_technical_python.py
@@ -4,7 +4,6 @@ import random
 from typing import Literal
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_core.app.model.obbject import OBBject
 
 
@@ -62,7 +61,7 @@ def get_data(menu: Literal["stocks", "crypto"]):
     return funcs[menu]()
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -101,7 +100,7 @@ def test_technical_atr(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -140,7 +139,7 @@ def test_technical_fib(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "offset": ""}, "stocks"),
@@ -159,7 +158,7 @@ def test_technical_obv(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "signal": ""}, "stocks"),
@@ -178,7 +177,7 @@ def test_technical_fisher(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -215,7 +214,7 @@ def test_technical_adosc(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -256,7 +255,7 @@ def test_technical_bbands(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -293,7 +292,7 @@ def test_technical_zlma(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "scalar": ""}, "stocks"),
@@ -320,7 +319,7 @@ def test_technical_aroon(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -357,7 +356,7 @@ def test_technical_sma(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -396,7 +395,7 @@ def test_technical_demark(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "anchor": "", "offset": ""}, "stocks"),
@@ -415,7 +414,7 @@ def test_technical_vwap(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -454,7 +453,7 @@ def test_technical_macd(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -491,7 +490,7 @@ def test_technical_hma(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -528,7 +527,7 @@ def test_technical_donchian(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -569,7 +568,7 @@ def test_technical_ichimoku(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "target": "", "period": ""}, "stocks"),
@@ -596,7 +595,7 @@ def test_technical_clenow(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -633,7 +632,7 @@ def test_technical_adx(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "offset": ""}, "stocks"),
@@ -652,7 +651,7 @@ def test_technical_ad(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -689,7 +688,7 @@ def test_technical_wma(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": "", "scalar": ""}, "stocks"),
@@ -716,7 +715,7 @@ def test_technical_cci(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -755,7 +754,7 @@ def test_technical_rsi(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -792,7 +791,7 @@ def test_technical_stoch(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -831,7 +830,7 @@ def test_technical_kc(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         ({"data": "", "index": "", "length": ""}, "stocks"),
@@ -850,7 +849,7 @@ def test_technical_cg(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -891,7 +890,7 @@ def test_technical_cones(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params, data_type",
     [
         (
@@ -928,7 +927,7 @@ def test_technical_ema(params, data_type, obb):
     assert len(result.results) > 0
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/extensions/tests/conftest.py
+++ b/openbb_platform/extensions/tests/conftest.py
@@ -5,7 +5,7 @@ from typing import Dict, List
 import pytest
 from openbb_core.app.router import CommandMap
 
-from extensions.tests.utils.helpers import list_openbb_extensions
+from .utils.helpers import list_openbb_extensions
 
 cm = CommandMap()
 commands = list(cm.map.keys())

--- a/openbb_platform/extensions/tests/test_docstring_examples.py
+++ b/openbb_platform/extensions/tests/test_docstring_examples.py
@@ -2,7 +2,7 @@
 
 import pytest
 
-from extensions.tests.utils.helpers import check_docstring_examples
+from .utils.helpers import check_docstring_examples
 
 
 @pytest.mark.integration

--- a/openbb_platform/extensions/tests/test_integration_tests_api.py
+++ b/openbb_platform/extensions/tests/test_integration_tests_api.py
@@ -2,9 +2,9 @@
 
 from typing import Literal
 
-from openbb_charting import Charting
+import pytest
 
-from extensions.tests.utils.integration_tests_testers import (
+from .utils.integration_tests_testers import (
     check_missing_integration_test_params,
     check_missing_integration_test_providers,
     check_missing_integration_tests,
@@ -39,8 +39,14 @@ def test_api_interface_wrong_integration_test_params() -> None:
     run_test("api", check_wrong_integration_test_params)
 
 
+@pytest.mark.skipif(
+    "openbb_charting" not in __import__("sys").modules,
+    reason="Charting extension not installed",
+)
 def test_charting_extension_function_coverage() -> None:
     """Test if all charting extension functions are covered by integration tests."""
+    from openbb_charting import Charting  # pylint: disable=import-outside-toplevel
+
     functions = Charting.functions()
 
     test_names = [f"test_charting_{func}" for func in functions]

--- a/openbb_platform/extensions/tests/test_integration_tests_python.py
+++ b/openbb_platform/extensions/tests/test_integration_tests_python.py
@@ -2,9 +2,9 @@
 
 from typing import Literal
 
-from openbb_charting import Charting
+import pytest
 
-from extensions.tests.utils.integration_tests_testers import (
+from .utils.integration_tests_testers import (
     check_missing_integration_test_params,
     check_missing_integration_test_providers,
     check_missing_integration_tests,
@@ -39,8 +39,14 @@ def test_python_interface_wrong_integration_test_params() -> None:
     run_test("python", check_wrong_integration_test_params)
 
 
+@pytest.mark.skipif(
+    "openbb_charting" not in __import__("sys").modules,
+    reason="Charting extension not installed",
+)
 def test_charting_extension_function_coverage() -> None:
     """Test if all charting extension functions are covered by integration tests."""
+    from openbb_charting import Charting  # pylint: disable=import-outside-toplevel
+
     functions = Charting.functions()
 
     test_names = [f"test_charting_{func}" for func in functions]

--- a/openbb_platform/extensions/tests/test_routers.py
+++ b/openbb_platform/extensions/tests/test_routers.py
@@ -1,6 +1,6 @@
 """Test the routers."""
 
-from extensions.tests.utils.router_testers import (
+from .utils.router_testers import (
     check_router_command_examples,
     check_router_function_models,
     check_router_model_functions_signature,

--- a/openbb_platform/extensions/tests/utils/integration_tests_api_generator.py
+++ b/openbb_platform/extensions/tests/utils/integration_tests_api_generator.py
@@ -5,12 +5,13 @@ import os
 from pathlib import Path
 from typing import Dict, List, Literal, Type, Union, get_type_hints
 
+import pytest
 import requests
 from openbb_charting import Charting
 from openbb_core.app.provider_interface import ProviderInterface
 from openbb_core.app.router import CommandMap
 
-from extensions.tests.utils.integration_tests_generator import get_test_params
+from .integration_tests_generator import get_test_params
 
 
 def get_http_method(api_paths: Dict[str, dict], route: str):
@@ -36,7 +37,6 @@ import pytest
 import requests
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
-from extensions.tests.conftest import parametrize
 
 
 @pytest.fixture(scope="session")
@@ -81,7 +81,7 @@ def write_test_w_template(
     """
 
     template = f"""
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{params_str}],
 )
@@ -103,6 +103,7 @@ def test_{test_name_extra}{route.replace("/", "_")[1:]}(params, headers):
         f.write(template)
 
 
+@pytest.fixture(scope="function")
 def test_exists(route: str, path: str):
     """Check if a test exists."""
     with open(path) as f:

--- a/openbb_platform/extensions/tests/utils/integration_tests_generator.py
+++ b/openbb_platform/extensions/tests/utils/integration_tests_generator.py
@@ -14,7 +14,7 @@ from typing import (
     get_type_hints,
 )
 
-from openbb_charting import Charting
+import pytest
 from openbb_core.app.provider_interface import ProviderInterface
 from openbb_core.app.router import CommandMap
 from pydantic.fields import FieldInfo
@@ -22,7 +22,7 @@ from pydantic_core import PydanticUndefined
 
 ROOT_DIR = Path(__file__).parent.parent.parent.parent
 
-TEST_TEMPLATE = """\n\n@parametrize(
+TEST_TEMPLATE = """\n\n@pytest.mark.parametrize(
     "params",
     [
         {params}
@@ -67,8 +67,6 @@ def create_integration_test_files(extensions: List[PosixPath]) -> None:
                     f'''"""Test {extension_name} extension."""
 import pytest
 from openbb_core.app.model.obbject import OBBject
-from extensions.tests.conftest import parametrize
-
 
 @pytest.fixture(scope="session")
 def obb(pytestconfig):  # pylint: disable=inconsistent-return-statements
@@ -280,6 +278,10 @@ def write_commands_integration_tests() -> None:
     add_test_commands_to_file(extensions)
 
 
+@pytest.mark.skipif(
+    "openbb_charting" not in __import__("sys").modules,
+    reason="Charting extension not installed",
+)
 def write_charting_extension_integration_tests():
     """Write charting extension integration tests."""
     import openbb_charting  # pylint: disable=import-outside-toplevel

--- a/openbb_platform/extensions/tests/utils/integration_tests_testers.py
+++ b/openbb_platform/extensions/tests/utils/integration_tests_testers.py
@@ -18,7 +18,7 @@ from typing import (
 from openbb_core.app.provider_interface import ProviderInterface
 from openbb_core.app.router import CommandMap
 
-from extensions.tests.utils.integration_tests_generator import (
+from .integration_tests_generator import (
     find_extensions,
     get_test_params_data_processing,
 )
@@ -77,6 +77,8 @@ def check_missing_providers(
     missing_providers: List[str] = []
     providers = list(command_params.keys())
     providers.remove("openbb")
+    if not providers:
+        return []
 
     for test_params in function_params:
         provider = test_params.get("provider", None)
@@ -92,7 +94,9 @@ def check_missing_providers(
         if len(providers) == 1 and len(function_params) == 1:
             pass
         else:
-            missing_providers.append(f"Missing providers for {function}: {providers}")
+            missing_providers.append(
+                f"Missing providers for {function}: {providers}  --? {function_params}"
+            )
 
     return missing_providers
 
@@ -241,7 +245,11 @@ def check_integration_tests(
                     model
                 ]
                 try:
-                    function_params = functions[function].pytestmark[1].args[1]
+                    function_params = (
+                        functions[function].pytestmark[1].args[1]
+                        if len(functions[function].pytestmark[1].args) > 1
+                        else []
+                    )
                 except IndexError:
                     # Another decorator is below the parametrize decorator
                     function_params = functions[function].pytestmark[2].args[1]

--- a/openbb_platform/extensions/tests/utils/router_testers.py
+++ b/openbb_platform/extensions/tests/utils/router_testers.py
@@ -6,7 +6,7 @@ from typing import Any, Dict, List, Optional
 
 from openbb_core.app.provider_interface import ProviderInterface
 
-from extensions.tests.utils.helpers import (
+from .helpers import (
     collect_router_functions,
     collect_routers,
     find_decorator,

--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_api.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_api.py
@@ -5,7 +5,6 @@ import json
 
 import pytest
 import requests
-from extensions.tests.conftest import parametrize
 from openbb_core.env import Env
 from openbb_core.provider.utils.helpers import get_querystring
 
@@ -46,7 +45,7 @@ def get_equity_data():
     return data["stocks_data"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -77,7 +76,7 @@ def test_charting_equity_price_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -108,7 +107,7 @@ def test_charting_currency_price_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -139,7 +138,7 @@ def test_charting_etf_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -170,7 +169,7 @@ def test_charting_index_price_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -201,7 +200,7 @@ def test_charting_crypto_price_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -234,7 +233,7 @@ def test_charting_technical_adx(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [{"data": "", "index": "date", "length": "30", "scalar": "110", "chart": True}],
 )
@@ -258,7 +257,7 @@ def test_charting_technical_aroon(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -291,7 +290,7 @@ def test_charting_technical_ema(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -324,7 +323,7 @@ def test_charting_technical_hma(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -358,7 +357,7 @@ def test_charting_technical_macd(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -392,7 +391,7 @@ def test_charting_technical_rsi(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -425,7 +424,7 @@ def test_charting_technical_sma(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -458,7 +457,7 @@ def test_charting_technical_wma(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -491,7 +490,7 @@ def test_charting_technical_zlma(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -521,7 +520,7 @@ def test_charting_technical_cones(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -552,7 +551,7 @@ def test_charting_economy_fred_series(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -597,7 +596,7 @@ def test_charting_technical_relative_rotation(params):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -631,7 +630,7 @@ def test_charting_equity_price_performance(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -661,7 +660,7 @@ def test_charting_etf_price_performance(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -695,7 +694,7 @@ def test_charting_etf_holdings(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -734,7 +733,7 @@ def test_charting_fixedincome_government_yield_curve(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -765,7 +764,7 @@ def test_charting_derivatives_futures_historical(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -805,7 +804,7 @@ def test_charting_derivatives_futures_curve(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -836,7 +835,7 @@ def test_charting_equity_historical_market_cap(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -869,7 +868,7 @@ def test_charting_economy_survey_bls_series(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -908,7 +907,7 @@ def test_charting_econometrics_correlation_matrix(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -939,7 +938,7 @@ def test_charting_economy_shipping_port_info(params, headers):
     assert list(chart.keys()) == ["content", "format"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
+++ b/openbb_platform/obbject_extensions/charting/integration/test_charting_python.py
@@ -1,7 +1,6 @@
 """Test charting extension."""
 
 import pytest
-from extensions.tests.conftest import parametrize
 from openbb_charting.core.openbb_figure import OpenBBFigure
 from openbb_core.app.model.obbject import OBBject
 
@@ -37,7 +36,7 @@ def get_equity_data():
     return data["stocks_data"]
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -60,7 +59,7 @@ def test_charting_equity_price_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -83,7 +82,7 @@ def test_charting_currency_price_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -106,7 +105,7 @@ def test_charting_crypto_price_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -129,7 +128,7 @@ def test_charting_index_price_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -152,7 +151,7 @@ def test_charting_etf_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -182,7 +181,7 @@ def test_charting_technical_adx(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -211,7 +210,7 @@ def test_charting_technical_aroon(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -241,7 +240,7 @@ def test_charting_technical_ema(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -271,7 +270,7 @@ def test_charting_technical_hma(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -302,7 +301,7 @@ def test_charting_technical_macd(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -333,7 +332,7 @@ def test_charting_technical_rsi(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -363,7 +362,7 @@ def test_charting_technical_sma(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -393,7 +392,7 @@ def test_charting_technical_wma(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -423,7 +422,7 @@ def test_charting_technical_zlma(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -448,7 +447,7 @@ def test_charting_technical_cones(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -471,7 +470,7 @@ def test_charting_economy_fred_series(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -513,7 +512,7 @@ def test_charting_technical_relative_rotation(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)  # type: ignore
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -536,7 +535,7 @@ def test_charting_equity_price_performance(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -559,7 +558,7 @@ def test_charting_etf_price_performance(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -582,7 +581,7 @@ def test_charting_etf_holdings(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -613,7 +612,7 @@ def test_charting_fixedincome_government_yield_curve(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -636,7 +635,7 @@ def test_charting_derivatives_futures_historical(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -668,7 +667,7 @@ def test_charting_derivatives_futures_curve(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -693,7 +692,7 @@ def test_charting_equity_historical_market_cap(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -718,7 +717,7 @@ def test_charting_economy_survey_bls_series(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         {
@@ -732,7 +731,7 @@ def test_charting_economy_survey_bls_series(params, obb):
 def test_charting_econometrics_correlation_matrix(params, obb):
     """Test chart econometrics correlation matrix."""
 
-    symbols = "XRT,XLB,XLI,XLH,XLC,XLY,XLU,XLK".split(",")
+    symbols = ["XRT", "XLB", "XLI", "XLH", "XLC", "XLY", "XLU", "XLK"]
     params["data"] = (
         obb.equity.price.historical(symbol=symbols, provider="yfinance")
         .to_df()
@@ -747,7 +746,7 @@ def test_charting_econometrics_correlation_matrix(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (
@@ -771,7 +770,7 @@ def test_charting_economy_shipping_port_info(params, obb):
     assert isinstance(result.chart.fig, OpenBBFigure)
 
 
-@parametrize(
+@pytest.mark.parametrize(
     "params",
     [
         (

--- a/openbb_platform/obbject_extensions/charting/tests/test_charting_core_ta_helpers.py
+++ b/openbb_platform/obbject_extensions/charting/tests/test_charting_core_ta_helpers.py
@@ -2,7 +2,7 @@
 
 import pandas as pd
 import pytest
-from obbject_extensions.charting.openbb_charting.core.plotly_ta.ta_helpers import (
+from openbb_charting.core.plotly_ta.ta_helpers import (
     check_columns,
 )
 

--- a/openbb_platform/providers/tests/test_provider_fetcher.py
+++ b/openbb_platform/providers/tests/test_provider_fetcher.py
@@ -7,7 +7,6 @@ from typing import Dict
 
 from openbb_core.provider.abstract.provider import Provider
 from openbb_core.provider.registry import RegistryLoader
-
 from providers.tests.utils.unit_tests_generator import (
     check_pattern_in_file,
     get_provider_fetchers,

--- a/openbb_platform/providers/tests/utils/unit_tests_generator.py
+++ b/openbb_platform/providers/tests/utils/unit_tests_generator.py
@@ -11,7 +11,7 @@ from openbb_core.provider.utils.helpers import to_snake_case
 from pydantic.fields import FieldInfo
 from pydantic_core import PydanticUndefined
 
-from providers.tests.utils.credentials_schema import test_credentials
+from .credentials_schema import test_credentials
 
 PROVIDERS_PATH = Path(__file__).parent.parent.parent.resolve()
 

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
@@ -2,8 +2,7 @@
 
 import pandas as pd
 import pytest
-
-from providers.yfinance.openbb_yfinance.utils.helpers import (
+from openbb_yfinance.utils.helpers import (
     df_transform_numbers,
     get_futures_data,
 )
@@ -33,4 +32,4 @@ def test_df_transform_numbers():
     )
     transformed = df_transform_numbers(data, ["Value", "% Change"])
     assert transformed["Value"].equals(pd.Series([1e6, 2.5e9, 3e12]))
-    assert transformed["% Change"].equals(pd.Series([1/100, -2/100, 3.5/100]))
+    assert transformed["% Change"].equals(pd.Series([1 / 100, -2 / 100, 3.5 / 100]))


### PR DESCRIPTION
This PR updates the test files:

- Replaces those using an import of `parametrize`, from `conftest.py`, with `@pytest.mark.parametrize`.
- Replaces imports such as, `from providers.yfinance.etc.`, with package, or relative, import.
- Fixes params in `test_economy_fred_regional` that had parameter names assigned, instead of being positional-only.

The motivation for this PR is for implementing support for higher versions of Python. I have also checked for compatibility with Pytest 8.4. 
