### PR TITLE
[BugFix] `openbb-charting`: Fix Margin In Serialized Chart Output

### DIFF
--- a/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/core/openbb_figure.py
@@ -1178,10 +1178,12 @@ class OpenBBFigure(go.Figure):
         kwargs.update(
             dict(
                 config={
+                    "displayModeBar": False,
+                    "edits": {
+                        "colorbarPosition": True,
+                        "legendPosition": True,
+                    },
                     "scrollZoom": True,
-                    "displaylogo": False,
-                    "editable": True,
-                    "displayModeBar": "hover",
                 },
                 include_plotlyjs=kwargs.pop("include_plotlyjs", False),
                 full_html=False,
@@ -1224,18 +1226,28 @@ class OpenBBFigure(go.Figure):
 
     def to_plotly_json(self) -> dict:
         """Serialize, then deserialize, the figure to JSON. Returns as a Python dictionary."""
-        fig = json.loads(self.to_json())
+
+        if "t" in self.layout.margin and (
+            self.layout.margin["t"] is None or (self.layout.margin["t"] < 50)
+        ):
+            self.layout.margin["t"] = 50
+
+        fig = super().to_json() or "{}"
+        fig = json.loads(fig)
 
         fig.update(
             {
                 "config": {
-                    "displayModeBar": "hover",
-                    "displaylogo": False,
-                    "editable": True,
+                    "displayModeBar": False,
+                    "edits": {
+                        "colorbarPosition": True,
+                        "legendPosition": True,
+                    },
                     "scrollZoom": True,
                 }
             }
         )
+
         return fig
 
     @staticmethod


### PR DESCRIPTION
This PR fixes a top margin that is too small in the serialized Plotly chart output. Also disables the modebar for Workspace display, it just ends up in the way.

Before:

![Screenshot 2025-07-07 at 7 50 00 PM](https://github.com/user-attachments/assets/1d797bef-2b49-4a3f-8d21-782837353a1e)

After:

![Screenshot 2025-07-07 at 7 53 44 PM](https://github.com/user-attachments/assets/07a1bc15-1ec0-4405-83f9-87a3487314c3)
