### PR TITLE
[Feature] Add PLC0415 To Ruff Ignore

### DIFF
--- a/ruff.toml
+++ b/ruff.toml
@@ -28,7 +28,7 @@ select = [
     "T20",
 ]
 # These ignores should be seen as temporary solutions to problems that will NEED fixed
-ignore = ["PLR2004", "PLR0913", "PLR0915", "UP035", "UP006"]
+ignore = ["PLR2004", "PLR0913", "PLR0915", "UP035", "UP006", "PLC0415"]
 
 [lint.per-file-ignores]
 "**/tests/*" = ["S101"]


### PR DESCRIPTION
This PR add "PLC0415" to the ignore section in `ruff.toml` - AKA, "import-outside-toplevel". This appears to be a new rule.  In the future we may want to consider consolidating the lint actions into a single source, or at least subbing Ruff in for Pylint.

The purpose for this exclusion is:

- We don't want `ruff --fix` to make changes to the import structures, or for CI actions relying on Ruff to view this as an error.
- Pylint is watching for this pattern, and we ignore at the function level where we are explicitly lazy-loading packages.
- Adding an additional line for ruff in every occurrence is not desirable.
