### PR TITLE
[BugFix] Fix`SecForm13FHRFetcher`: TypeError: Expected numeric dtype, got object instead.

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/parse_13f.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/parse_13f.py
@@ -187,7 +187,7 @@ async def parse_13f_hr(filing: str):
         data.loc[:, "putCall"] = data["putCall"].fillna("--")
 
     # Add the period ending so that the filing is identified when multiple are requested.
-    data["period_ending"] = to_datetime(period_ending, yearfirst=False).date()
+    data.loc[:, "period_ending"] = to_datetime(period_ending, yearfirst=False).date()
     df = DataFrame(data)
     # Aggregate the data because there are multiple entries for each security and we need the totals.
     # We break it down by CUSIP, security type, and option type.
@@ -220,8 +220,8 @@ async def parse_13f_hr(filing: str):
         if col in df.columns and all(df[col] == 0):
             df.drop(columns=col, inplace=True)
 
-    total_value = df["value"].sum()
-    df["weight"] = round(df["value"] / total_value, 6)
+    total_value = df.value.sum()
+    df.loc[:, "weight"] = round(df.value.astype(float) / total_value, 6)
 
     return (
         df.reset_index()


### PR DESCRIPTION
This PR fixes a bug that the tests running in #7169 found.  I would have expected tests to have previously revealed this, but it could likely be attributed to a higher pandas version.

To test this, upgrade the version of pandas to the latest, in your `obb` environment, and then run the SEC provider's unit test.

`pytest test_sec_fetchers.py::test_sec_form_13FHR_fetcher`

Before will raise a TypeError.

```
TypeError: Expected numeric dtype, got object instead.
```

After, passes.
