### PR TITLE
[BugFix] `openbb-platform-api`: Fix `check_for_platform_extensions` Filter

### DIFF
--- a/openbb_platform/extensions/platform_api/README.md
+++ b/openbb_platform/extensions/platform_api/README.md
@@ -81,7 +81,7 @@ All other arguments will be passed to uvicorn. Here are the most common ones:
                                       [default: 6900]
     --ssl_keyfile TEXT              SSL key file.
     --ssl_certfile TEXT             SSL certificate file.
-    --ssl_keyfile-password TEXT     SSL keyfile password.
+    --ssl_keyfile_password TEXT     SSL keyfile password.
     --ssl_version INTEGER           SSL version to use.
                                       (see stdlib ssl module's)
                                       [default: 17]

--- a/openbb_platform/extensions/platform_api/README.md
+++ b/openbb_platform/extensions/platform_api/README.md
@@ -1,6 +1,6 @@
 # OpenBB Platform API Launcher
 
-This package is responsible for launching and configuring an OpenBB Platform environment, or FastAPI instance, to use as an OpenBB Workspace [custom backend](https://docs.openbb.co/terminal/custom-backend).
+This package is responsible for launching and configuring an OpenBB Platform environment, or FastAPI instance, to use as an OpenBB Workspace [custom backend](https://docs.openbb.co/workspace/data-integration).
 
 ## Installation
 
@@ -79,21 +79,23 @@ All other arguments will be passed to uvicorn. Here are the most common ones:
                                       [default: 127.0.0.1]
     --port INTEGER                  Port number.
                                       [default: 6900]
-    --ssl-keyfile TEXT              SSL key file.
-    --ssl-certfile TEXT             SSL certificate file.
-    --ssl-keyfile-password TEXT     SSL keyfile password.
-    --ssl-version INTEGER           SSL version to use.
+    --ssl_keyfile TEXT              SSL key file.
+    --ssl_certfile TEXT             SSL certificate file.
+    --ssl_keyfile-password TEXT     SSL keyfile password.
+    --ssl_version INTEGER           SSL version to use.
                                       (see stdlib ssl module's)
                                       [default: 17]
-    --ssl-cert-reqs INTEGER         Whether client certificate is required.
+    --ssl_cert_reqs INTEGER         Whether client certificate is required.
                                       (see stdlib ssl module's)
                                       [default: 0]
-    --ssl-ca-certs TEXT             CA certificates file.
-    --ssl-ciphers TEXT              Ciphers to use.
+    --ssl_ca_certs TEXT             CA certificates file.
+    --ssl_ciphers TEXT              Ciphers to use.
                                       (see stdlib ssl module's)
                                       [default: TLSv1]
 
 Run `uvicorn --help` to get the full list of arguments.
+
+**Note** Replace, '-', with, '_' in the command line arguments of `uvicorn` (as per `uvicorn.run`)
 
 ### API Over HTTPS
 
@@ -110,7 +112,7 @@ Two files will be created, in the current working directory, that are passed as 
 openbb-api --ssl_keyfile localhost.key --ssl_certfile localhost.crt
 ```
 
-**Note**: Adjust the command to include the full path to the file if the current working directory is not where they are located.
+**Note** Adjust the command to include the full path to the file if the current working directory is not where they are located.
 
 The certificate - `localhost.crt` - will need to be added to system's trust store. The process for this will depend on the operating system and the user account privilege.
 

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -111,9 +111,6 @@ def check_for_platform_extensions(fastapi_app, widgets_to_exclude) -> list:
 
 
 widget_exclude_filter = check_for_platform_extensions(app, widget_exclude_filter)
-
-print(widget_exclude_filter)
-
 openapi = app.openapi()
 
 # We don't need the current settings,

--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -94,15 +94,12 @@ if not dont_filter and os.path.exists(WIDGET_SETTINGS):
 def check_for_platform_extensions(fastapi_app, widgets_to_exclude) -> list:
     """Check for data-processing Platform extensions and add them to the widget exclude filter."""
     to_check_for = ["econometrics", "quantitative", "technical"]
-    tags = (
-        [
-            d.get("name") if isinstance(d, dict) and d.get("name") else d
-            for d in fastapi_app.openapi_tags
-            if d and d in to_check_for
-        ]
-        if fastapi_app.openapi_tags
-        else []
-    )
+    openapi_tags = fastapi_app.openapi_tags or []
+    tags: list = []
+    for tag in openapi_tags:
+        if any(mod in tag.get("name", "") for mod in to_check_for):
+            tags.append(tag.get("name", ""))
+
     if tags and (any(f"openbb_{mod}" in sys.modules for mod in to_check_for)):
         api_prefix = SystemService().system_settings.api_settings.prefix
         for tag in tags:
@@ -114,6 +111,8 @@ def check_for_platform_extensions(fastapi_app, widgets_to_exclude) -> list:
 
 
 widget_exclude_filter = check_for_platform_extensions(app, widget_exclude_filter)
+
+print(widget_exclude_filter)
 
 openapi = app.openapi()
 

--- a/openbb_platform/extensions/platform_api/pyproject.toml
+++ b/openbb_platform/extensions/platform_api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-platform-api"
-version = "1.1.11"
+version = "1.1.12"
 description = "OpenBB Platform API: Launch script and widgets builder for the OpenBB Platform API and Workspace Backend Connector."
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"

--- a/openbb_platform/extensions/platform_api/pyproject.toml
+++ b/openbb_platform/extensions/platform_api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-platform-api"
-version = "1.1.12"
+version = "1.1.13"
 description = "OpenBB Platform API: Launch script and widgets builder for the OpenBB Platform API and Workspace Backend Connector."
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"


### PR DESCRIPTION
This PR fixes a filter that is not catching properly. Econometics, Quantitative, and Technical routers are all supposed to be filtered out of the widgets created by `openbb-api`.

You can check this by launching `openbb-api` and then searching for `technical` or `econometrics` in the generated `widgets.json`.