### PR TITLE
[BugFix] Fix Hub Session Not Being Set After Login

### DIFF
--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -40,7 +40,6 @@ class Account:  # noqa: D205, D400
         """Human readable representation of the object."""
         return self.__doc__ or ""
 
-    @staticmethod
     def _log_account_command(func):  # pylint: disable=E0213
         """Log account command."""
 

--- a/openbb_platform/core/openbb_core/app/static/account.py
+++ b/openbb_platform/core/openbb_core/app/static/account.py
@@ -40,6 +40,7 @@ class Account:  # noqa: D205, D400
         """Human readable representation of the object."""
         return self.__doc__ or ""
 
+    @staticmethod
     def _log_account_command(func):  # pylint: disable=E0213
         """Log account command."""
 
@@ -139,6 +140,10 @@ class Account:  # noqa: D205, D400
                     self._hub_service.session.model_dump(mode="json"), f, indent=4
                 )
 
+        self._base_app._command_runner.user_settings.profile.hub_session = getattr(
+            self._base_app._account._hub_service, "_session", None
+        )
+
         if return_settings:
             return self._base_app._command_runner.user_settings
         return None
@@ -189,6 +194,7 @@ class Account:  # noqa: D205, D400
             self._base_app.user.defaults.update(incoming.defaults)
         if return_settings:
             return self._base_app._command_runner.user_settings
+
         return None
 
     @_log_account_command  # type: ignore

--- a/openbb_platform/core/tests/app/static/test_app_factory.py
+++ b/openbb_platform/core/tests/app/static/test_app_factory.py
@@ -2,7 +2,7 @@
 
 # pylint: disable=redefined-outer-name
 
-from unittest.mock import patch
+from unittest.mock import PropertyMock, patch
 
 import pytest
 from openbb_core.app.model.hub.hub_session import HubSession
@@ -46,13 +46,10 @@ def test_app_account(app_factory):
     assert isinstance(account, Account)
 
 
-# flake8: noqa: S106
-def test_app_account_login(app_factory, mocker):
+# flake8: noqa: S106 # pylint: disable=W0212
+@patch("openbb_core.app.static.account.HubService", autospec=True)
+def test_app_account_login(mock_hub_service, app_factory):
     """Test app account login."""
-    # Mock the HubService and its methods
-    mock_hub_service = mocker.patch(
-        "openbb_core.app.static.account.HubService", autospec=True
-    )
     mock_hub_service.return_value.pull.return_value = UserSettings()
     mock_hub_service.return_value.connect.return_value = None
 
@@ -64,10 +61,9 @@ def test_app_account_login(app_factory, mocker):
         email="test@example.com",
         primary_usage="mock_usage",
     )
-    mocker.patch.object(
-        mock_hub_service.return_value, "_session", mock_session, create=True
-    )
-    type(mock_hub_service.return_value).session = mocker.PropertyMock(
+    # We need to mock the _session attribute and session property on the HubService instance
+    mock_hub_service.return_value._session = mock_session
+    type(mock_hub_service.return_value).session = PropertyMock(
         return_value=mock_session
     )
 

--- a/openbb_platform/core/tests/app/static/test_app_factory.py
+++ b/openbb_platform/core/tests/app/static/test_app_factory.py
@@ -2,12 +2,16 @@
 
 # pylint: disable=redefined-outer-name
 
+from unittest.mock import patch
+
 import pytest
+from openbb_core.app.model.hub.hub_session import HubSession
 from openbb_core.app.model.system_settings import SystemSettings
 from openbb_core.app.model.user_settings import UserSettings
 from openbb_core.app.static.account import Account
 from openbb_core.app.static.app_factory import create_app
 from openbb_core.app.static.coverage import Coverage
+from pydantic import SecretStr
 
 
 @pytest.fixture(scope="module")
@@ -40,6 +44,59 @@ def test_app_account(app_factory):
     account = app_factory.account
     assert account
     assert isinstance(account, Account)
+
+
+# flake8: noqa: S106
+def test_app_account_login(app_factory, mocker):
+    """Test app account login."""
+    # Mock the HubService and its methods
+    mock_hub_service = mocker.patch(
+        "openbb_core.app.static.account.HubService", autospec=True
+    )
+    mock_hub_service.return_value.pull.return_value = UserSettings()
+    mock_hub_service.return_value.connect.return_value = None
+
+    # Mock the session object
+    mock_session = HubSession(
+        access_token=SecretStr("mock_token"),
+        token_type="bearer",
+        user_uuid="mock_user_uuid",
+        email="test@example.com",
+        primary_usage="mock_usage",
+    )
+    mocker.patch.object(
+        mock_hub_service.return_value, "_session", mock_session, create=True
+    )
+    type(mock_hub_service.return_value).session = mocker.PropertyMock(
+        return_value=mock_session
+    )
+
+    # Get the account object from the app factory
+    account = app_factory.account
+    assert account
+    assert hasattr(account, "login")
+    assert callable(account.login)
+
+    # Call the login method
+    account.login(email="test@example.com", password="password", remember_me=True)
+
+    # Assert that the hub_session is set in the user settings
+    assert app_factory.user.profile.hub_session is not None
+    assert (
+        app_factory.user.profile.hub_session.access_token.get_secret_value()
+        == "mock_token"
+    )
+
+    # Assert that the HubService was called correctly
+    mock_hub_service.return_value.connect.assert_called_once_with(
+        "test@example.com", "password", None
+    )
+    mock_hub_service.return_value.pull.assert_called_once()
+
+    # Test logout
+    with patch("openbb_core.app.static.account.Path.unlink") as mock_unlink:
+        account.logout()
+        mock_unlink.assert_called_once()
 
 
 def test_app_coverage(app_factory):


### PR DESCRIPTION
This PR fixes an issue where the HubSession was not being set in the BaseApp after logging in.

Test this from the Python interface with:

```python
from openbb import obb

obb.account.login(pat="yourpat")

obb.user.profile.hub_session
```

Before, it will be None

After, it will be the valid HubSession object.

This adds a test to cover the scenario.