### PR TITLE
[Feature] `openbb-platform-api`:  Adds Marker in Headers of Workspace Config File Endpoints

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/main.py
@@ -75,6 +75,8 @@ uvicorn_settings = (
     SystemService().system_settings.python_settings.model_dump().get("uvicorn", {})
 )
 
+obb_headers = {"X-Backend-Type": "OpenBB Platform"}
+
 for key, value in uvicorn_settings.items():
     if key not in kwargs and key != "app" and value is not None:
         kwargs[key] = value
@@ -150,14 +152,15 @@ async def get_widgets():
     global FIRST_RUN  # noqa PLW0603  # pylint: disable=global-statement
     if FIRST_RUN is True:
         FIRST_RUN = False
-        return JSONResponse(content=widgets_json)
+        return JSONResponse(content=widgets_json, headers=obb_headers)
     if EDITABLE:
         return JSONResponse(
             content=get_widgets_json(
                 False, openapi, widget_exclude_filter, EDITABLE, WIDGETS_PATH
-            )
+            ),
+            headers=obb_headers,
         )
-    return JSONResponse(content=widgets_json)
+    return JSONResponse(content=widgets_json, headers=obb_headers)
 
 
 # If a custom implementation, you might want to override.
@@ -212,9 +215,9 @@ async def get_apps_json():
                     new_templates.append(template)
 
         if new_templates:
-            return JSONResponse(content=new_templates)
+            return JSONResponse(content=new_templates, headers=obb_headers)
 
-    return JSONResponse(content=[])
+    return JSONResponse(content=[], headers=obb_headers)
 
 
 if AGENTS_PATH:
@@ -225,8 +228,8 @@ if AGENTS_PATH:
         if os.path.exists(AGENTS_PATH):
             with open(AGENTS_PATH) as f:
                 agents = json.load(f)
-            return JSONResponse(content=agents)
-        return JSONResponse(content=[])
+            return JSONResponse(content=agents, headers=obb_headers)
+        return JSONResponse(content=[], headers=obb_headers)
 
 
 def launch_api(**_kwargs):  # noqa PRL0912


### PR DESCRIPTION
This PR adds a header to the output of the 3 config file endpoints used by Workspace. Its purpose is to be a simple marker for identifying the backend connector as one generated by this extension.

Added to, `/widgets.json`, `/apps.json`, and `/agents.json`:

```
{"X-Backend-Type": "OpenBB Platform"}
```

<img width="2492" height="946" alt="image" src="https://github.com/user-attachments/assets/70879bae-bf9a-44c2-a84c-ee76b3822ecd" />
