### PR TITLE
remove hub from README file, and update the extension tables

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,6 @@ output = obb.equity.price.historical("AAPL")
 df = output.to_dataframe()
 ```
 
-You can sign up to the [OpenBB Hub](https://my.openbb.co/login) to get the most out of the OpenBB ecosystem.
-
 Data integrations available can be found here: <https://docs.openbb.co/platform/reference>
 
 ---
@@ -75,7 +73,7 @@ This will launch a FastAPI server, via Uvicorn, at `127.0.0.1:6900`.
 
 You can check that it works by going to <http://127.0.0.1:6900>.
 
-#### Integrate OpenBB Platform backend to OpenBB Workspace
+#### Integrate OpenBB Platform Backend to OpenBB Workspace
 
 Sign-in to the [OpenBB Workspace](https://pro.openbb.co/), and follow the following steps:
 

--- a/openbb_platform/README.md
+++ b/openbb_platform/README.md
@@ -6,7 +6,7 @@
 | OpenBB is committed to build the future of investment research by focusing on an open source infrastructure accessible to everyone, everywhere. |
 | :---------------------------------------------------------------------------------------------------------------------------------------------: |
 |              ![OpenBBLogo](https://user-images.githubusercontent.com/25267873/218899768-1f0964b8-326c-4f35-af6f-ea0946ac970b.png)               |
-|                                                 Check our website at [openbb.co](www.openbb.co)                                                 |
+|                                                 Check our website at [openbb.co](https://www.openbb.co)                                         |
 
 ## Overview
 
@@ -16,20 +16,21 @@ Please find the complete documentation at [docs.openbb.co](https://docs.openbb.c
 
 ## Installation
 
-The command below provides access to the core functionalities behind the OpenBB Platform.
+### PyPI
+
+The command below provides access to the core functionalities behind the OpenBB Platform, and a selection of sources.
 
 ```bash
 pip install openbb
 ```
 
-This will install the following data providers:
-
-These packages are what will be installed when `pip install openbb` is run
+This will install the core, router modules, and the following data providers:
 
 | Extension Name | Description | Installation Command | Minimum Subscription Type Required |
 |----------------|-------------|----------------------|------------------------------------|
 | openbb-benzinga | [Benzinga](https://www.benzinga.com/apis/en-ca/) data connector | pip install openbb-benzinga | Paid |
 | openbb-bls | [Bureau of Labor Statistics](https://www.bls.gov/developers/home.htm) data connector | pip install openbb-bls | Free |
+| openbb-congress-gov | [US Congress API](https://api.congress.gov/sign-up/) data connector | pip install openbb-congress-gov | Free |
 | openbb-cftc | [Commodity Futures Trading Commission](https://publicreporting.cftc.gov/stories/s/r4w3-av2u) data connector | pip install openbb-cftc | Free |
 | openbb-econdb | [EconDB](https://econdb.com) data connector | pip install openbb-econdb | None |
 | openbb-imf | [IMF](https://data.imf.org) data connector | pip install openbb-imf | None |
@@ -43,16 +44,20 @@ These packages are what will be installed when `pip install openbb` is run
 | openbb-tradingeconomics | [TradingEconomics](https://tradingeconomics.com/api) data connector | pip install openbb-tradingeconomics | Paid |
 | openbb-yfinance | [Yahoo Finance](https://finance.yahoo.com/) data connector | pip install openbb-yfinance | None |
 
-### Community Providers
+### Extras
 
-These packages are not installed when `pip install openbb` is run.  They are available for installation separately or by running `pip install openbb[all]`
+These packages are not installed when `pip install openbb` is run.  They are available for installation separately or by running `pip install openbb[all]`.
 
 | Extension Name | Description | Installation Command | Minimum Subscription Type Required |
 |----------------|-------------|----------------------|------------------------------------|
+| openbb-mcp-server | Run the OpenBB Platform as a [MCP server](https://pypi.org/project/openbb-mcp-server/) | pip install openbb-mcp-server | None |
+| openbb-charting | Integrated [Plotly charting library](https://pypi.org/project/openbb-charting/) and dedicated window rendering. | pip install openbb-charting | None |
 | openbb-alpha-vantage | [Alpha Vantage](https://www.alphavantage.co/) data connector | pip install openbb-alpha-vantage | Free |
 | openbb-biztoc | [Biztoc](https://api.biztoc.com/#biztoc-default) News data connector | pip install openbb-biztoc | Free |
 | openbb-cboe | [Cboe](https://www.cboe.com/delayed_quotes/) data connector | pip install openbb-cboe | None |
+| openbb-deribit | [Deribit](https://docs.deribit.com/) data connector | pip install openbb-deribit | None | - |
 | openbb-ecb | [ECB](https://data.ecb.europa.eu/) data connector | pip install openbb-ecb | None |
+| openbb-famafrench | [Ken French Data Library](https://mba.tuck.dartmouth.edu/pages/faculty/ken.french/data_library.html) connector | pip install openbb-famafrench | None | - |
 | openbb-federal-reserve | [Federal Reserve](https://www.federalreserve.gov/) data connector | pip install openbb-federal-reserve | None |
 | openbb-finra | [FINRA](https://www.finra.org/finra-data) data connector | pip install openbb-finra | None / Free |
 | openbb-finviz | [Finviz](https://finviz.com) data connector | pip install openbb-finviz | None |
@@ -63,21 +68,11 @@ These packages are not installed when `pip install openbb` is run.  They are ava
 | openbb-tmx | [TMX](https://money.tmx.com) data connector | pip install openbb-tmx | None |
 | openbb-tradier | [Tradier](https://tradier.com) data connector | pip install openbb-tradier | None |
 | openbb-wsj | [Wall Street Journal](https://www.wsj.com/) data connector | pip install openbb-wsj | None |
-To install extensions that expand the core functionalities specify the extension name or use `all` to install all.
+
 
 ```bash
-# Install a single extension, e.g. openbb-charting and yahoo finance
-pip install openbb[charting]
-pip install openbb-yfinance
+pip install openbb-equity openbb-yfinance
 ```
-
-Alternatively, you can install all extensions at once.
-
-```bash
-pip install openbb[all]
-```
-
-> Note: These instruction are specific to v4. For installation instructions and documentation for v3 go to our [website](https://docs.openbb.co/sdk).
 
 ## Python
 
@@ -85,52 +80,27 @@ pip install openbb[all]
 >>> from openbb import obb
 >>> output = obb.equity.price.historical("AAPL")
 >>> df = output.to_dataframe()
->>> df.head()
-              open    high     low  ...  change_percent             label  change_over_time
-date                                ...
-2022-09-19  149.31  154.56  149.10  ...         3.46000  September 19, 22          0.034600
-2022-09-20  153.40  158.08  153.08  ...         2.28000  September 20, 22          0.022800
-2022-09-21  157.34  158.74  153.60  ...        -2.30000  September 21, 22         -0.023000
-2022-09-22  152.38  154.47  150.91  ...         0.23625  September 22, 22          0.002363
-2022-09-23  151.19  151.47  148.56  ...        -0.50268  September 23, 22         -0.005027
-
-[5 rows x 12 columns]
+>>> df.tail()
 ```
+
+| date       |    open |   high |    low |   close |
+|:-----------|--------:|-------:|-------:|--------:|
+| 2025-09-30 | 254.86  | 255.92 | 253.11 |  254.63 |
+| 2025-10-01 | 255.04  | 258.79 | 254.93 |  255.45 |
+| 2025-10-02 | 256.58  | 258.18 | 254.15 |  257.13 |
+| 2025-10-03 | 254.67  | 259.24 | 253.95 |  258.02 |
+| 2025-10-06 | 257.945 | 259.07 | 255.05 |  256.69 |
+
 
 ## API keys
 
-To fully leverage the OpenBB Platform you need to get some API keys to connect with data providers. Here are the 3 options on where to set them:
+To fully leverage the OpenBB Platform you need to get some API keys to connect with data providers (listed above).
 
-1. OpenBB Hub
-2. Runtime
-3. Local file
+Here's how to set them:
 
-### 1. OpenBB Hub
+### Local file
 
-Set your keys at [OpenBB Hub](https://my.openbb.co/app/platform/credentials) and get your personal access token from <https://my.openbb.co/app/platform/pat> to connect with your account.
-
-```python
->>> from openbb import obb
->>> openbb.account.login(pat="OPENBB_PAT")
-
->>> # Persist changes in OpenBB Hub
->>> obb.account.save()
-```
-
-### 2. Runtime
-
-```python
->>> from openbb import obb
->>> obb.user.credentials.fmp_api_key = "REPLACE_ME"
->>> obb.user.credentials.polygon_api_key = "REPLACE_ME"
-
->>> # Persist changes in ~/.openbb_platform/user_settings.json
->>> obb.account.save()
-```
-
-### 3. Local file
-
-You can specify the keys directly in the `~/.openbb_platform/user_settings.json` file.
+Specify the keys directly in the `~/.openbb_platform/user_settings.json` file.
 
 Populate this file with the following template and replace the values with your keys:
 
@@ -145,9 +115,21 @@ Populate this file with the following template and replace the values with your 
 }
 ```
 
+### Runtime
+
+Credentials can be set for the current session only, using the Python interface.
+
+```python
+>>> from openbb import obb
+>>> obb.user.credentials.fred_api_key = "REPLACE_ME"
+>>> obb.user.credentials.polygon_api_key = "REPLACE_ME"
+```
+
+Go to the [documention](https://docs.openbb.co/platform/settings/user_settings/api_keys) for more details.
+
 ## REST API
 
-The OpenBB Platform comes with a ready to use REST API built with FastAPI. Start the application using this command:
+The OpenBB Platform comes with a ready-to-use REST API built with FastAPI. Start the application using this command:
 
 ```bash
 uvicorn openbb_core.api.rest_api:app --host 0.0.0.0 --port 8000 --reload
@@ -155,19 +137,22 @@ uvicorn openbb_core.api.rest_api:app --host 0.0.0.0 --port 8000 --reload
 
 API documentation is found under "/docs", from the root of the server address, and is viewable in any browser supporting HTTP over localhost, such as Chrome.
 
-Check `openbb-core` [README](https://pypi.org/project/openbb-core/) for additional info.
+See the [documentation](https://docs.openbb.co/platform/settings/system_settings#api-settings) for runtime settings and configurations.
 
-## Install for development
+## Local Development
 
-To develop the OpenBB Platform you need to have the following:
+To develop with the source code, you need to have the following:
 
 - Git
-- Python 3.9 or higher
-- Virtual Environment with `poetry` installed
-  - To install these packages activate your virtual environment and run `pip install poetry toml`
+- Python 3.10 - 3.13.
+- Virtual Environment with `poetry` installed.
+  - Activate your virtual environment and run, `pip install poetry`.
+- A local copy of the [GitHub repository](https://github.com/OpenBB-finance/OpenBB.git)
 
-How to install the platform in editable mode?
+Install the repository in for local development by using the installation script.
 
-  1. Activate your virtual environment
-  1. Navigate into the `openbb_platform` folder
-  1. Run `python dev_install.py` to install the packages in editable mode
+  1. Activate your virtual environment.
+  2. Navigate into the `openbb_platform` folder.
+  3. Run `python dev_install.py -e` to install all packages in editable mode.
+
+See the [documentation](https://docs.openbb.co/platform/developer_guide/architecture_overview) for an overview of the architecture and how to get started building your own extensions.

--- a/openbb_platform/README.md
+++ b/openbb_platform/README.md
@@ -149,7 +149,7 @@ To develop with the source code, you need to have the following:
   - Activate your virtual environment and run, `pip install poetry`.
 - A local copy of the [GitHub repository](https://github.com/OpenBB-finance/OpenBB.git)
 
-Install the repository in for local development by using the installation script.
+Install the repository for local development by using the installation script.
 
   1. Activate your virtual environment.
   2. Navigate into the `openbb_platform` folder.

--- a/openbb_platform/README.md
+++ b/openbb_platform/README.md
@@ -125,7 +125,7 @@ Credentials can be set for the current session only, using the Python interface.
 >>> obb.user.credentials.polygon_api_key = "REPLACE_ME"
 ```
 
-Go to the [documention](https://docs.openbb.co/platform/settings/user_settings/api_keys) for more details.
+Go to the [documentation](https://docs.openbb.co/platform/settings/user_settings/api_keys) for more details.
 
 ## REST API
 


### PR DESCRIPTION
This PR updates the README.md file to remove the deprecated Hub feature. It also updates the extension tables with some missing items. This document will be updated again with the major release, not intended to be future-proof.