### PR TITLE
[BugFix] Fix `dev_install.py` To Use Poetry V2 Syntax `--regenerate`

### DIFF
--- a/openbb_platform/dev_install.py
+++ b/openbb_platform/dev_install.py
@@ -142,7 +142,7 @@ def install_platform_local(_extras: bool = False):
         extras_args = ["-E", "all"] if _extras else []
 
         subprocess.run(
-            CMD + ["lock"],
+            CMD + ["lock", "--regenerate"],
             cwd=PLATFORM_PATH,
             check=True,
         )
@@ -187,7 +187,7 @@ def install_platform_cli():
         CMD = [sys.executable, "-m", "poetry"]
 
         subprocess.run(
-            CMD + ["lock"],
+            CMD + ["lock", "--regenerate"],
             cwd=CLI_PATH,
             check=True,  # noqa: S603
         )


### PR DESCRIPTION
This script has not been updated since Poetry V2 was introduced. The `--regenerate` flag needs to be included explicitly. We always want to install the latest versions of packages the environment solves for.
