### PR TITLE
Warn users about orphaned widgets when deleting backends

### DIFF
--- a/desktop/src/routes/backends.tsx
+++ b/desktop/src/routes/backends.tsx
@@ -246,7 +246,7 @@ const DeleteConfirmationModal: React.FC<DeleteConfirmationModalProps> =
 						Are you sure you want to remove this backend?
 					</p>
 					<p className="mb-5 body-md-medium text-theme-primary flex justify-start">
-						This action cannot be undone.
+					Deleting this backend will permanently break any associated widgets. They cannot be reconnected even if you re-add the backend.
 					</p>
 					<div className="flex justify-end gap-2">
 						<Button


### PR DESCRIPTION
# Pull Request Template for OpenBB Developers

0. [Feature] - Warn users about orphaned widgets when deleting backends

    

1. **Why**? (1-3 sentences or a bullet point list):
- When users delete a backend, any widgets associated with it become permanently orphaned
- Users cannot reconnect these widgets even if they re-add the backend (due to new UUID   assignment)
- There was no warning to inform users of this consequence before deletion


2. **What**? (1-3 sentences or a bullet point list):

- Added a warning message to the backend deletion confirmation modal in desktop/src/routes/backends.tsx`
- Warning clearly states: "Deleting this backend will permanently break any associated widgets. They cannot be reconnected even if you re-add the backend."
- Simple, non-intrusive text warning in the existing delete confirmation dialog

3. **Impact** (1-2 sentences or a bullet point list):
- Prevents user frustration and data loss by informing them of consequences before deletion
- No performance impact - static text only
- Improves user experience by setting proper expectations
- Impact score: 3 (low-risk UI text change with positive UX impact)impact. Impact score: 10"

4. **Testing Done**:

- Manual testing: Verified warning appears in the deletion modal
- Confirmed modal displays correctly with updated text
- Tested that deletion still functions as expected after user confirms

5. **Reviewer Notes** (optional):

- Please verify the warning message is clear and adequately communicates the permanence of the action

6. **Any other information** (optional)

I think the current warning is sufficient, no brainer if you delete the widget locally the front end widget will stop working. In any case the clearer the better. I'm new to this repo and look forward to contributing new features. 
