### PR TITLE
fix(yfinance): update yfinance version to fix curl_cffi compatibility

### DIFF
--- a/openbb_platform/providers/yfinance/pyproject.toml
+++ b/openbb_platform/providers/yfinance/pyproject.toml
@@ -9,7 +9,7 @@ packages = [{ include = "openbb_yfinance" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<3.14"
-yfinance = "0.2.58"
+yfinance = "^0.2.66"
 openbb-core = "^1.5.1"
 curl-adapter = ">=1.1.0"
 


### PR DESCRIPTION
## Summary
Update yfinance from pinned version `0.2.58` to `^0.2.66` to resolve the curl_cffi compatibility issue.

## Problem
Any attempt to request data from the yfinance integration returns the error:
```
Error getting data for AAPL: CurlStreamResponse._decode() got an unexpected keyword argument 'max_length'
```

## Root Cause
The error is caused by a version mismatch between yfinance and curl_cffi. The older yfinance version (0.2.58) uses curl_cffi methods with arguments that newer curl_cffi versions no longer accept.

## Solution
Update yfinance to `^0.2.66` which has proper curl_cffi compatibility.

## Testing
- [ ] CI tests pass
- [ ] Manual verification with `obb.equity.price.quote(symbol="AAPL", provider="yfinance")`

Fixes #7277