### PR TITLE
[BugFix] `openbb-econdb`: Fix Implicit None type for Parameter, 'frequency'

### DIFF
--- a/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
+++ b/openbb_platform/providers/econdb/openbb_econdb/models/economic_indicators.py
@@ -56,7 +56,7 @@ class EconDbEconomicIndicatorsQueryParams(EconomicIndicatorsQueryParams):
         + " and the original units and scale differ between entities."
         + "\n    `tusd` should only be used where values are currencies.",
     )
-    frequency: str = Field(
+    frequency: str | None = Field(
         default="quarter",
         description="The frequency of the data, default is 'quarter'."
         + " Only valid when 'symbol' is 'main'.",


### PR DESCRIPTION
This PR converts an implicit type to an explicit type. In `EconDbEconomicIndicatorsQueryParams`, the `frequency` parameter is typically not used - only valid when 'symbol' is 'main' - but the parameter did not accept `None`.

This aligns the type for the conditions in the integration test.

There is no user impact, just housekeeping.