### PR TITLE
Modify ENTRYPOINT in platformAPI Dockerfile

### DIFF
--- a/build/docker/platformAPI.Dockerfile
+++ b/build/docker/platformAPI.Dockerfile
@@ -7,4 +7,4 @@ RUN pip install openbb-platform-api
 
 EXPOSE 6900
 
-ENTRYPOINT ["openbb-api", "--host", "0.0.0.0", "--login"]
+ENTRYPOINT ["openbb-api", "--host", "0.0.0.0"]


### PR DESCRIPTION
Removed the --login option from the Docker ENTRYPOINT. This flag is no longer needed and caused the container to crash on startup.

1. Build image
2. Run container
3. uvicorn.run(... login=...) crash

Removing --login fixes startup

# Pull Request OpenBB

Please go to the `Preview` tab and select the appropriate PR sub-template:

* [OpenBB Platform](?expand=1&template=platform_pull_request_template.md)
* [OpenBB Platform CLI](?expand=1&template=terminal_pull_request_template.md)
* [OpenBB Developers](?expand=1&template=obb_developer_pull_request_template.md)
