### PR TITLE
[BugFix] Support PEP 649 & PEP 749 (Enable Python 3.14)

### DIFF
--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -619,8 +619,8 @@ class ProviderInterface(metaclass=SingletonMeta):
             standard = dataclasses["standard"]
             extra = dataclasses["extra"]
 
-            fields = getattr(type(standard), "model_fields", {}).copy()
-            extra_fields = getattr(type(extra), "model_fields", {}).copy()
+            fields = getattr(standard, "model_fields", {}).copy()
+            extra_fields = getattr(extra, "model_fields", {}).copy()
             fields.update(extra_fields)
 
             fields_dict: dict[str, tuple[Any, Any]] = {}

--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -552,6 +552,24 @@ class ProviderInterface(metaclass=SingletonMeta):
 
         return result
 
+    @staticmethod
+    def _fields_to_pydantic(
+        fields: list[TupleFieldType],
+    ) -> dict[str, tuple[type | None, Any]]:
+        """Convert dataclass fields to pydantic fields.
+
+        Parameters
+        ----------
+        fields : list[TupleFieldType]
+            List of (name, annotation, default) tuples.
+
+        Returns
+        -------
+        dict[str, tuple[type | None, Any]]
+            Dictionary mapping field names to (annotation, default) tuples.
+        """
+        return {name: (annotation, default) for name, annotation, default in fields}
+
     def _generate_data_dc(
         self, map_: MapType
     ) -> dict[str, dict[str, StandardData | ExtraData]]:
@@ -577,15 +595,15 @@ class ProviderInterface(metaclass=SingletonMeta):
             extra: dict
             standard, extra = self._extract_data(providers)
             result[model_name] = {
-                "standard": make_dataclass(
-                    cls_name=model_name,
-                    fields=list(standard.values()),  # type: ignore[arg-type]
-                    bases=(StandardData,),
+                "standard": create_model(  # type: ignore
+                    model_name,
+                    __base__=StandardData,
+                    **self._fields_to_pydantic(list(standard.values())),  # type: ignore
                 ),
-                "extra": make_dataclass(
-                    cls_name=model_name,
-                    fields=list(extra.values()),  # type: ignore[arg-type]
-                    bases=(ExtraData,),
+                "extra": create_model(
+                    model_name,
+                    __base__=ExtraData,
+                    **self._fields_to_pydantic(list(extra.values())),  # type: ignore
                 ),
             }
 
@@ -601,8 +619,9 @@ class ProviderInterface(metaclass=SingletonMeta):
             standard = dataclasses["standard"]
             extra = dataclasses["extra"]
 
-            fields = standard.model_fields.copy()
-            fields.update(extra.model_fields)
+            fields = getattr(type(standard), "model_fields", {}).copy()
+            extra_fields = getattr(type(extra), "model_fields", {}).copy()
+            fields.update(extra_fields)
 
             fields_dict: dict[str, tuple[Any, Any]] = {}
 

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -12,7 +12,6 @@ import textwrap
 import typing as typing_module
 from collections import OrderedDict
 from collections.abc import Callable
-from functools import partial
 from inspect import Parameter, _empty, isclass, signature
 from json import dumps, load
 from pathlib import Path
@@ -1096,7 +1095,7 @@ class MethodDefinition:
                     for meta in param.annotation.__metadata__
                 )
                 model = param.annotation.__args__[0]
-                is_pydantic_model = hasattr(model, "model_fields") or hasattr(
+                is_pydantic_model = hasattr(type(model), "model_fields") or hasattr(
                     model, "__pydantic_fields__"
                 )
                 is_get_request = not MethodDefinition.is_data_processing_function(path)
@@ -1104,7 +1103,7 @@ class MethodDefinition:
                 if is_pydantic_model and is_get_request and not has_depends:
                     # Unpack the model fields as query parameters
                     fields = getattr(
-                        model,
+                        type(model),
                         "model_fields",
                         getattr(model, "__pydantic_fields__", {}),
                     )
@@ -1747,7 +1746,7 @@ class MethodDefinition:
             elif (
                 isinstance(param.annotation, _AnnotatedAlias)
                 and (
-                    hasattr(param.annotation.__args__[0], "model_fields")
+                    hasattr(type(param.annotation.__args__[0]), "model_fields")
                     or hasattr(param.annotation.__args__[0], "__pydantic_fields__")
                 )
                 and not MethodDefinition.is_data_processing_function(path)
@@ -1759,7 +1758,7 @@ class MethodDefinition:
                 if not has_depends:
                     model = param.annotation.__args__[0]
                     fields = getattr(
-                        model,
+                        type(model),
                         "model_fields",
                         getattr(model, "__pydantic_fields__", {}),
                     )
@@ -2668,15 +2667,18 @@ class DocstringGenerator:
                 param_types.update({k: v.type for k, v in kwarg_params.items()})
                 # Format the annotation to hide the metadata, tags, etc.
                 annotation = func.__annotations__.get("return")
+                model_fields = getattr(annotation, "model_fields", {})
                 results_type = (
                     cls._get_repr(
                         cls._get_generic_types(
-                            annotation.model_fields["results"].annotation,  # type: ignore[union-attr,arg-type]
+                            model_fields["results"].annotation,  # type: ignore[union-attr,arg-type]
                             [],
                         ),
                         model_name,
                     )
-                    if isclass(annotation) and issubclass(annotation, OBBject)  # type: ignore[arg-type]
+                    if isclass(annotation)
+                    and issubclass(annotation, OBBject)  # type: ignore[arg-type]
+                    and "results" in model_fields
                     else model_name
                 )
                 doc = cls.generate_model_docstring(
@@ -2684,7 +2686,7 @@ class DocstringGenerator:
                     summary=func.__doc__ or "",
                     explicit_params=explicit_params,
                     kwarg_params=kwarg_params,
-                    returns=return_schema.model_fields,
+                    returns=getattr(type(return_schema), "model_fields", {}),
                     results_type=results_type,
                     sections=sections,
                 )
@@ -2796,8 +2798,10 @@ class DocstringGenerator:
 
                     if not is_primitive:
                         try:
-                            if hasattr(return_annotation, "model_fields"):
-                                fields = return_annotation.model_fields
+                            if hasattr(type(return_annotation), "model_fields"):
+                                fields = getattr(
+                                    type(return_annotation), "model_fields", {}
+                                )
 
                                 for field_name, field in fields.items():
                                     field_type = cls.get_field_type(
@@ -2900,15 +2904,18 @@ class DocstringGenerator:
         """
         if hasattr(type_, "__args__"):
             origin = get_origin(type_)
-            # pylint: disable=unidiomatic-typecheck
-            if (
-                type(origin) is type
+            if origin is Union or origin is UnionType:
+                for arg in type_.__args__:
+                    cls._get_generic_types(arg, items)
+            elif (
+                isinstance(origin, type)
                 and origin is not Annotated
-                and (name := getattr(type_, "_name", getattr(type_, "__name__", None)))
+                and (name := getattr(type_, "_name", getattr(origin, "__name__", None)))
             ):
                 items.append(name)
-            func = partial(cls._get_generic_types, items=items)
-            set().union(*map(func, type_.__args__), items)  # type: ignore
+                for arg in type_.__args__:
+                    cls._get_generic_types(arg, items)
+
         return items
 
     @staticmethod
@@ -4004,10 +4011,12 @@ class ReferenceGenerator:
                     try:
                         module = sys.modules[route_func.__module__]
                         model_class = getattr(module, extracted_model_name, None)
-                        if model_class and hasattr(model_class, "model_fields"):
+                        if model_class and hasattr(type(model_class), "model_fields"):
                             # Set data to the fields
                             reference[path]["data"]["standard"] = []
-                            for field_name, field in model_class.model_fields.items():
+                            for field_name, field in getattr(
+                                type(model_class), "model_fields", {}
+                            ).items():
                                 field_type = DocstringGenerator.get_field_type(
                                     field.annotation, field.is_required(), "website"
                                 )

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -2686,7 +2686,7 @@ class DocstringGenerator:
                     summary=func.__doc__ or "",
                     explicit_params=explicit_params,
                     kwarg_params=kwarg_params,
-                    returns=getattr(type(return_schema), "model_fields", {}),
+                    returns=getattr(return_schema, "model_fields", {}),
                     results_type=results_type,
                     sections=sections,
                 )

--- a/openbb_platform/obbject_extensions/charting/tests/test_charting.py
+++ b/openbb_platform/obbject_extensions/charting/tests/test_charting.py
@@ -136,18 +136,20 @@ def test_get_chart_function(obbject):
 
 
 @patch("openbb_charting.charting.Charting._get_chart_function")
-@patch("openbb_charting.charting.Chart")
-def test_show(_, mock_get_chart_function, obbject):
+def test_show(mock_get_chart_function, obbject):
     """Test show method."""
     # Arrange
     mock_function = MagicMock()
     mock_get_chart_function.return_value = mock_function
     mock_fig = MagicMock()
+    mock_fig.show = MagicMock(
+        return_value=MagicMock(to_plotly_json=MagicMock(return_value={}))
+    )
     mock_function.return_value = (mock_fig, {"content": "mock_content"})
     obj = Charting(obbject)
 
     # Act
-    obj.show()
+    obj.show(render=False)
 
     # Assert
     mock_get_chart_function.assert_called_once()
@@ -156,19 +158,21 @@ def test_show(_, mock_get_chart_function, obbject):
 
 @patch("openbb_charting.charting.Charting._prepare_data_as_df")
 @patch("openbb_charting.charting.Charting._get_chart_function")
-@patch("openbb_charting.charting.Chart")
-def test_to_chart(_, mock_get_chart_function, mock_prepare_data_as_df, obbject):
+def test_to_chart(mock_get_chart_function, mock_prepare_data_as_df, obbject):
     """Test to_chart method."""
     # Arrange
     mock_prepare_data_as_df.return_value = (mock_dataframe, True)
     mock_function = MagicMock()
     mock_get_chart_function.return_value = mock_function
     mock_fig = MagicMock()
+    mock_fig.show = MagicMock(
+        return_value=MagicMock(to_plotly_json=MagicMock(return_value={}))
+    )
     mock_function.return_value = (mock_fig, {"content": "mock_content"})
     obj = Charting(obbject)
 
     # Act
-    obj.to_chart()
+    obj.to_chart(render=False)
 
     # Assert
     mock_get_chart_function.assert_called_once()


### PR DESCRIPTION
This PR addresses two items required for being compatible with Python 3.14. All changes are expected to be backwards-compatible.

## PEP 649

This handles the deferred evaluation of annotations. The `ProviderInterface` was combining `Dataclass` and `pydantic.BaseModel` in a way which was unable to resolve ForwardRefs in Python 3.14.

## PEP 749

`types.UnionType` and `typic.Union` are now aliases and require different handling.

## Files Touched:

There are 3 files touched, one is a test file.

### `openbb_core.app.provider_interface.py`

In, `_generate_data_dc`, use `create_model` instead. Both `StandardData` and `ExtraData` are subclasses of `BaseModel`

In , `_generate_return_schema`, use `getattr(type(standard/extra)` to access `.model_fields` from the class instead of the model instance (deprecated Pydantic syntax)

### `openbb_core.app.static.package_builder.py`

In, `_get_generic_types`, neither _name nor __name__ exists on the alias itself. The __name__ is on origin (the list class), not on type_ (the list[str] alias).

### `openbb_charting.tests.test_charting`

Updates `test_show` and `test_to_chart` to mock the `Figure.show` method and not mock the `Charting` class.


