### PR TITLE
fix(deribit): replace alru_cache with dict cache to fix cross-event-loop RuntimeError

### DIFF
--- a/openbb_platform/providers/deribit/openbb_deribit/utils/helpers.py
+++ b/openbb_platform/providers/deribit/openbb_deribit/utils/helpers.py
@@ -2,7 +2,6 @@
 
 from typing import Literal
 
-from async_lru import alru_cache
 from openbb_core.app.model.abstract.error import OpenBBError
 
 DERIBIT_OPTIONS_SYMBOLS = ["BTC", "ETH", "SOL", "XRP", "BNB", "PAXG"]
@@ -48,7 +47,9 @@ INTERVAL_MAP = {
 }
 
 
-@alru_cache(maxsize=64)
+_instruments_cache: dict[tuple, list[dict]] = {}
+
+
 async def get_instruments(
     currency: Currencies = "BTC",
     derivative_type: DerivativeTypes | None = None,
@@ -72,6 +73,10 @@ async def get_instruments(
     # pylint: disable=import-outside-toplevel
     from openbb_core.provider.utils.helpers import amake_request
 
+    cache_key = (currency, derivative_type, expired)
+    if cache_key in _instruments_cache:
+        return _instruments_cache[cache_key]
+
     if currency != "all" and currency.upper() not in CURRENCIES:
         raise ValueError(
             f"Currency {currency} not supported. Supported currencies are: {', '.join(CURRENCIES)}"
@@ -91,7 +96,9 @@ async def get_instruments(
 
     try:
         response = await amake_request(url)
-        return response.get("result", [])  # type: ignore
+        result = response.get("result", [])  # type: ignore
+        _instruments_cache[cache_key] = result
+        return result
     except Exception as e:  # pylint: disable=broad-except
         raise OpenBBError(
             f"Failed to get instruments -> {e.__class__.__name__}: {e}"

--- a/openbb_platform/providers/deribit/pyproject.toml
+++ b/openbb_platform/providers/deribit/pyproject.toml
@@ -10,7 +10,6 @@ packages = [{ include = "openbb_deribit" }]
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 openbb-core = "^1.5.8"
-async-lru = "^2.0.4"
 
 [build-system]
 requires = ["poetry-core"]


### PR DESCRIPTION
## Summary

Replace `@alru_cache` on `get_instruments()` with a simple dict cache.

`alru_cache` from `async_lru>=2.0` binds to the event loop on first use and raises `RuntimeError: alru_cache is not safe to use across event loops` when called from a different loop. This happens in tests because `fetcher.test()` / `run_async()` creates a new event loop per test function.

These test failures are blocking #7352 and wanted to scope the unrelated test failures outside.

`currency` has 6 values, `derivative_type` has 5 and `expired` is a bool so that's a total of 6 x 6 x 2 = 72 maximum combos - meaning no memory concern for the dict in production. I see there's a `ttl_cache` in `openbb_core` so I can look to utilize that instead.

## Changes

- **helpers.py**: Replace `@alru_cache(maxsize=64)` with a module-level dict cache that is event-loop agnostic
- **pyproject.toml**: Remove `async-lru` dependency (no longer used)

## Tests fixed

These 4 tests fail on every PR against `develop`:

- `test_deribit_futures_curve_fetcher`
- `test_deribit_futures_historical_fetcher`
- `test_deribit_futures_instruments_fetcher`
- `test_deribit_futures_info_fetcher`