### PR TITLE
Upgrade GitHub Actions to latest versions

### DIFF
--- a/.github/workflows/build-desktop-osx64.yml
+++ b/.github/workflows/build-desktop-osx64.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Import Code Signing Certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/build-desktop-osxARM.yml
+++ b/.github/workflows/build-desktop-osxARM.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Import Code Signing Certificate
-        uses: apple-actions/import-codesign-certs@v3
+        uses: apple-actions/import-codesign-certs@v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}

--- a/.github/workflows/build-desktop-win64.yml
+++ b/.github/workflows/build-desktop-win64.yml
@@ -218,7 +218,7 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path "${{ github.workspace }}/desktop/signed-installer"
 
       - name: Sign Installer
-        uses: sslcom/esigner-codesign@v1.3.1
+        uses: sslcom/esigner-codesign@v1.3.2
         with:
           command: sign
           username: ${{ secrets.ESIGNER_USERNAME }}


### PR DESCRIPTION
## Summary

Upgrade GitHub Actions to their latest versions for improved features, bug fixes, and security updates.

## Changes

| Action | Old Version(s) | New Version | Release | Files |
|--------|---------------|-------------|---------|-------|
| `apple-actions/import-codesign-certs` | [`v3`](https://github.com/apple-actions/import-codesign-certs/releases/tag/v3) | [`v6`](https://github.com/apple-actions/import-codesign-certs/releases/tag/v6) | [Release](https://github.com/apple-actions/import-codesign-certs/releases/tag/v6) | build-desktop-osx64.yml, build-desktop-osxARM.yml |
| `sslcom/esigner-codesign` | [`v1.3.1`](https://github.com/sslcom/esigner-codesign/releases/tag/v1.3.1) | [`v1.3.2`](https://github.com/sslcom/esigner-codesign/releases/tag/v1.3.2) | [Release](https://github.com/sslcom/esigner-codesign/releases/tag/v1.3.2) | build-desktop-win64.yml |

## Why upgrade?

Keeping GitHub Actions up to date ensures:
- **Security**: Latest security patches and fixes
- **Features**: Access to new functionality and improvements
- **Compatibility**: Better support for current GitHub features
- **Performance**: Optimizations and efficiency improvements

### ⚠️ Breaking Changes

- **apple-actions/import-codesign-certs** (v3 → v6): Major version upgrade — review the [release notes](https://github.com/apple-actions/import-codesign-certs/releases) for breaking changes

### Security Note

Actions that were previously pinned to commit SHAs remain pinned to SHAs (updated to the latest release SHA) to maintain the security benefits of immutable references.

### Testing

These changes only affect CI/CD workflow configurations and should not impact application functionality. The workflows should be tested by running them on a branch before merging.
