### PR TITLE
refactor: sanitize dynamic column name in SEC form4 utility

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/form4.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/form4.py
@@ -143,6 +143,9 @@ def setup_database(conn):
 
 def add_missing_column(conn, column_name):
     """Add a missing column to the form4_data table."""
+    # Sanitize the column name to prevent SQL injection
+    column_name_clean = column_name.replace('"', '""')
+
     missing_type = (
         "MONEY"
         if "price" in column_name or "value" in column_name
@@ -157,7 +160,9 @@ def add_missing_column(conn, column_name):
         )
     )
     cursor = conn.cursor()
-    cursor.execute(f"ALTER TABLE form4_data ADD COLUMN {column_name} {missing_type}")
+    cursor.execute(
+        f'ALTER TABLE form4_data ADD COLUMN "{column_name_clean}" {missing_type}'
+    )
     conn.commit()
 
 


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

- [x] I've updated the `add_missing_column` function to handle column names as literal identifiers.
- [x] This ensures that dynamically added columns (derived from SEC data or error messages) don't cause SQL syntax errors or injection risks if they contain special characters.

## How has this been tested?

- I ran a standalone test script to verify that the logic correctly handles identifiers with double quotes and prevents any SQL escaping. The table structure remained intact even when I passed malicious identifiers.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `hotfix/sanitize-sec-column-names`.
- [x] I ensure that I am following the [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBB/blob/main/CONTRIBUTING.md).