### PR TITLE
fix: add module-level __getattr__ to provider_interface for dynamic OBBject_ imports

### DIFF
--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -718,3 +718,18 @@ class ProviderInterface(metaclass=SingletonMeta):
                 __doc__=f"OBBject with results of type {name}",
             )
         return annotations
+
+
+_cached_annotations = None
+
+
+def __getattr__(name: str):
+    if name.startswith("OBBject_"):
+        global _cached_annotations
+        if _cached_annotations is None:
+            pi = ProviderInterface()
+            _cached_annotations = pi.return_annotations
+        model_name = name[len("OBBject_"):]
+        if model_name in _cached_annotations:
+            return _cached_annotations[model_name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Closes #7379

This PR adds a module-level `__getattr__` function to `provider_interface.py` that enables dynamic `OBBject_*` imports via Python's module attribute lookup protocol (PEP 562).

## Problem

When users try to import `OBBject_` models directly from `openbb_core.app.provider_interface`, they get an `ImportError` because these models are generated dynamically at runtime by `ProviderInterface.return_annotations` and are not statically defined at module level.

Example:
```python
from openbb_core.app.provider_interface import OBBject_EquityHistorical  # ImportError
```

## Fix

PEP 562 allows a module to define `__getattr__` to intercept attribute lookups. This fix:

1. Intercepts any attribute access starting with `OBBject_`
2. Lazily initializes `ProviderInterface` on first call and caches the result
3. Returns the dynamically-generated model if found
4. Falls through to `AttributeError` for unknown names

```python
from openbb_core.app.provider_interface import OBBject_EquityHistorical  # now works ✓
```

## Notes

- Annotations are cached in `_cached_annotations` to avoid re-initializing `ProviderInterface` on every access
- Non-matching attribute names raise `AttributeError` as expected