### PR TITLE
fix(provider_interface): add __getattr__ to resolve OBBject_* dynamic types

### DIFF
--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -699,3 +699,22 @@ class ProviderInterface(metaclass=SingletonMeta):
                 __doc__=f"OBBject with results of type {name}",
             )
         return annotations
+
+
+# Fix for issue OpenBB-finance/OpenBB#7379
+# OBBject_* types are created dynamically in return_annotations but never
+# registered as module-level attributes, causing ImportError on:
+#   from openbb_core.app.provider_interface import OBBject_EquityInfo
+_provider_interface_annotations: dict = {}
+
+
+def __getattr__(name: str):
+    """Lazily resolve dynamically created OBBject_* types."""
+    if name.startswith("OBBject_"):
+        global _provider_interface_annotations
+        if not _provider_interface_annotations:
+            _provider_interface_annotations = ProviderInterface().return_annotations
+        model_name = name[len("OBBject_"):]
+        if model_name in _provider_interface_annotations:
+            return _provider_interface_annotations[model_name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
## Summary

Fixes #7379.

Package builder generates imports like:

```python
from openbb_core.app.provider_interface import OBBject_EquityInfo
```

But `OBBject_*` types are created dynamically inside `ProviderInterface.return_annotations` and never registered as module-level attributes on `openbb_core.app.provider_interface`. This causes `ImportError` on fresh installs.

## Fix

Add a module-level `__getattr__` hook that lazily resolves `OBBject_*` names by calling `ProviderInterface().return_annotations` on first access. This matches the import pattern the package builder already generates, with no changes to the builder itself.

```python
_provider_interface_annotations: dict = {}

def __getattr__(name: str):
    if name.startswith("OBBject_"):
        global _provider_interface_annotations
        if not _provider_interface_annotations:
            _provider_interface_annotations = ProviderInterface().return_annotations
        model_name = name[len("OBBject_"):]
        if model_name in _provider_interface_annotations:
            return _provider_interface_annotations[model_name]
    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")
```

## Testing

Verified locally on macOS arm64, Python 3.12, openbb 4.6.0 + openbb-core 1.6.0:

```python
from openbb import obb
obb.equity.price.quote("AAPL", provider="yfinance")  # ✅ no ImportError
```