### PR TITLE
[BugFix] Update `get_user_agent` Utility With Modern User Agent Strings

### DIFF
--- a/desktop/src/routes/api-keys.tsx
+++ b/desktop/src/routes/api-keys.tsx
@@ -129,7 +129,7 @@ export default function ApiKeysPage() {
 
 			if (newKeys.length > 0) {
 				setImportedKeys(newKeys);
-				setSelectedKeys(new Set(newKeys.map((k) => k.key))); // Pre-select all
+				setSelectedKeys(new Set(newKeys.map((k) => k.key)));
 				setIsImportConfirmModalOpen(true);
 			} else {
 				setError("No new keys found in the imported file.");

--- a/openbb_platform/core/openbb_core/provider/utils/client.py
+++ b/openbb_platform/core/openbb_core/provider/utils/client.py
@@ -26,13 +26,13 @@ def obfuscate(params: CIMultiDict[str] | MultiDict[str]) -> dict[str, Any]:
 def get_user_agent() -> str:
     """Get a not very random user agent."""
     user_agent_strings = [
-        "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.10; rv:86.1) Gecko/20100101 Firefox/86.1",
-        "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:86.1) Gecko/20100101 Firefox/86.1",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:82.1) Gecko/20100101 Firefox/82.1",
-        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.13; rv:86.0) Gecko/20100101 Firefox/86.0",
-        "Mozilla/5.0 (Windows NT 10.0; WOW64; rv:86.0) Gecko/20100101 Firefox/86.0",
-        "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10.10; rv:83.0) Gecko/20100101 Firefox/83.0",
-        "Mozilla/5.0 (Windows NT 6.1; WOW64; rv:84.0) Gecko/20100101 Firefox/84.0",
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64; rv:133.0) Gecko/20100101 Firefox/133.0",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14.7; rv:133.0) Gecko/20100101 Firefox/133.0",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (Macintosh; Intel Mac OS X 14_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36 Edg/131.0.0.0",  # noqa: E501  # pylint: disable=line-too-long
+        "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/131.0.0.0 Safari/537.36",  # noqa: E501  # pylint: disable=line-too-long
     ]
 
     return random.choice(user_agent_strings)  # nosec # noqa: S311

--- a/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/svensson_yield_curve.py
+++ b/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/svensson_yield_curve.py
@@ -138,13 +138,10 @@ def download_csv() -> str:
         str: URL to the CSV data.
     """
     # pylint: disable=import-outside-toplevel
-    from openbb_core.provider.utils.helpers import get_user_agent, make_request
+    from openbb_core.provider.utils.helpers import make_request
 
-    headers = {
-        "User-Agent": get_user_agent(),
-    }
     url = "https://www.federalreserve.gov/data/yield-curve-tables/feds200628.csv"
-    response = make_request(url, headers=headers)
+    response = make_request(url)
     response.raise_for_status()
 
     return response.text

--- a/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/svensson_yield_curve.py
+++ b/openbb_platform/providers/federal_reserve/openbb_federal_reserve/models/svensson_yield_curve.py
@@ -138,10 +138,13 @@ def download_csv() -> str:
         str: URL to the CSV data.
     """
     # pylint: disable=import-outside-toplevel
-    from openbb_core.provider.utils.helpers import make_request
+    from openbb_core.provider.utils.helpers import get_user_agent, make_request
 
+    headers = {
+        "User-Agent": get_user_agent(),
+    }
     url = "https://www.federalreserve.gov/data/yield-curve-tables/feds200628.csv"
-    response = make_request(url)
+    response = make_request(url, headers=headers)
     response.raise_for_status()
 
     return response.text


### PR DESCRIPTION
This PR fixes the User-Agent strings defined in, `openbb_core.provider.utils.client.get_user_agent()`
Some HTTP requests get flagged because of obsolete user agent strings referencing old OS and browser versions, resulting in a 403, 406, or 443 error.

The bug was observed via `obb.fixedincome.government.svensson_yield_curve()`, but I had randomly experienced other occurrences with the same symptoms.



