### PR TITLE
[Security] Bump DeepDiff and Regenerate Lock Files for Impacted Extensions

### DIFF
--- a/cli/poetry.lock
+++ b/cli/poetry.lock
@@ -944,14 +944,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -5516,14 +5516,14 @@ files = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.2"
+version = "3.3.3"
 description = "SSE plugin for Starlette"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862"},
-    {file = "sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd"},
+    {file = "sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d"},
+    {file = "sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049"},
 ]
 
 [package.dependencies]

--- a/openbb_platform/extensions/platform_api/poetry.lock
+++ b/openbb_platform/extensions/platform_api/poetry.lock
@@ -421,14 +421,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -2029,4 +2029,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "d064fcde776975f6e6685b2b6d43d06931a78f0f926a7cda7fe26b8777521862"
+content-hash = "6fabeb1280a44ef0bd14285c9383d7a2a3cb0c76f3f47b4db2ee29dbb80da422"

--- a/openbb_platform/extensions/platform_api/pyproject.toml
+++ b/openbb_platform/extensions/platform_api/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-platform-api"
-version = "1.3.4"
+version = "1.3.5"
 description = "OpenBB Platform API: Launch script and widgets builder for the Open Data Platform REST API and Workspace Backend Connector."
 authors = ["OpenBB <hello@openbb.co>"]
 license = "AGPL-3.0-only"
@@ -15,8 +15,8 @@ openbb-api = "openbb_platform_api.main:main"
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
-openbb-core = "^1.6.3"
-deepdiff = ">=8.6.1"
+openbb-core = "^1.6.4"
+deepdiff = ">=8.6.2"
 
 [build-system]
 requires = ["poetry-core>=1.0.0"]

--- a/openbb_platform/poetry.lock
+++ b/openbb_platform/poetry.lock
@@ -953,14 +953,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -3341,19 +3341,19 @@ openbb-core = ">=1.6.1,<2.0.0"
 
 [[package]]
 name = "openbb-platform-api"
-version = "1.3.4"
+version = "1.3.5"
 description = "OpenBB Platform API: Launch script and widgets builder for the Open Data Platform REST API and Workspace Backend Connector."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openbb_platform_api-1.3.4-py3-none-any.whl", hash = "sha256:95bc102a5cf8a31f635d331e689b5d756051acca63c3629b57caeaff337854a0"},
-    {file = "openbb_platform_api-1.3.4.tar.gz", hash = "sha256:2ba04266c221c31363d4dc22789d7148d2cef3aee71a89570edc7f2f719eb8b2"},
+    {file = "openbb_platform_api-1.3.5-py3-none-any.whl", hash = "sha256:dfa0175006aede9e09906b81832105075747d836b135e945e73af51060731066"},
+    {file = "openbb_platform_api-1.3.5.tar.gz", hash = "sha256:40816bb6ffe18481d7e023a5c36304761e5334d18098c72af7bd6d44f4235932"},
 ]
 
 [package.dependencies]
-deepdiff = ">=8.6.1"
-openbb-core = ">=1.6.3,<2.0.0"
+deepdiff = ">=8.6.2"
+openbb-core = ">=1.6.4,<2.0.0"
 
 [[package]]
 name = "openbb-quantitative"
@@ -5379,15 +5379,15 @@ files = [
 
 [[package]]
 name = "sse-starlette"
-version = "3.3.2"
+version = "3.3.3"
 description = "SSE plugin for Starlette"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"mcp-server\" or extra == \"all\""
 files = [
-    {file = "sse_starlette-3.3.2-py3-none-any.whl", hash = "sha256:5c3ea3dad425c601236726af2f27689b74494643f57017cafcb6f8c9acfbb862"},
-    {file = "sse_starlette-3.3.2.tar.gz", hash = "sha256:678fca55a1945c734d8472a6cad186a55ab02840b4f6786f5ee8770970579dcd"},
+    {file = "sse_starlette-3.3.3-py3-none-any.whl", hash = "sha256:c5abb5082a1cc1c6294d89c5290c46b5f67808cfdb612b7ec27e8ba061c22e8d"},
+    {file = "sse_starlette-3.3.3.tar.gz", hash = "sha256:72a95d7575fd5129bd0ae15275ac6432bb35ac542fdebb82889c24bb9f3f4049"},
 ]
 
 [package.dependencies]
@@ -6168,4 +6168,4 @@ wsj = ["openbb-wsj"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "b2886567bc2acdba0022d1df2c323b46144526a6c5cbce47b72d8b86e7ed6e50"
+content-hash = "9ad4eb92ea453fe3fd0b3f8127c080fe3e4b6c2ac42d7e23cfd69b0c0cc452d0"

--- a/openbb_platform/providers/federal_reserve/poetry.lock
+++ b/openbb_platform/providers/federal_reserve/poetry.lock
@@ -444,14 +444,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -1102,19 +1102,19 @@ openbb-core = ">=1.6.1,<2.0.0"
 
 [[package]]
 name = "openbb-platform-api"
-version = "1.3.4"
+version = "1.3.5"
 description = "OpenBB Platform API: Launch script and widgets builder for the Open Data Platform REST API and Workspace Backend Connector."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openbb_platform_api-1.3.4-py3-none-any.whl", hash = "sha256:95bc102a5cf8a31f635d331e689b5d756051acca63c3629b57caeaff337854a0"},
-    {file = "openbb_platform_api-1.3.4.tar.gz", hash = "sha256:2ba04266c221c31363d4dc22789d7148d2cef3aee71a89570edc7f2f719eb8b2"},
+    {file = "openbb_platform_api-1.3.5-py3-none-any.whl", hash = "sha256:dfa0175006aede9e09906b81832105075747d836b135e945e73af51060731066"},
+    {file = "openbb_platform_api-1.3.5.tar.gz", hash = "sha256:40816bb6ffe18481d7e023a5c36304761e5334d18098c72af7bd6d44f4235932"},
 ]
 
 [package.dependencies]
-deepdiff = ">=8.6.1"
-openbb-core = ">=1.6.3,<2.0.0"
+deepdiff = ">=8.6.2"
+openbb-core = ">=1.6.4,<2.0.0"
 
 [[package]]
 name = "openpyxl"
@@ -2137,4 +2137,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "1f13215b043709250ae0634a265e8975cb9e4623ab5181497c42d542f85106db"
+content-hash = "f34a127acd59461dec109ffa5338bbbc9633c578d2a0d20163293f0b70ec0c6c"

--- a/openbb_platform/providers/federal_reserve/pyproject.toml
+++ b/openbb_platform/providers/federal_reserve/pyproject.toml
@@ -10,10 +10,10 @@ packages = [{ include = "openbb_federal_reserve" }]
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 openpyxl = "^3.1.5"
-openbb-core = "^1.6.3"
+openbb-core = "^1.6.4"
 openbb-economy = "^1.6.1"
 openbb-fixedincome = "^1.6.1"
-openbb-platform-api = "^1.3.3"
+openbb-platform-api = "^1.3.5"
 beautifulsoup4 = "^4.13.4"
 
 [build-system]

--- a/openbb_platform/providers/imf/poetry.lock
+++ b/openbb_platform/providers/imf/poetry.lock
@@ -436,14 +436,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -1227,19 +1227,19 @@ openbb-core = ">=1.6.1,<2.0.0"
 
 [[package]]
 name = "openbb-platform-api"
-version = "1.3.4"
+version = "1.3.5"
 description = "OpenBB Platform API: Launch script and widgets builder for the Open Data Platform REST API and Workspace Backend Connector."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openbb_platform_api-1.3.4-py3-none-any.whl", hash = "sha256:95bc102a5cf8a31f635d331e689b5d756051acca63c3629b57caeaff337854a0"},
-    {file = "openbb_platform_api-1.3.4.tar.gz", hash = "sha256:2ba04266c221c31363d4dc22789d7148d2cef3aee71a89570edc7f2f719eb8b2"},
+    {file = "openbb_platform_api-1.3.5-py3-none-any.whl", hash = "sha256:dfa0175006aede9e09906b81832105075747d836b135e945e73af51060731066"},
+    {file = "openbb_platform_api-1.3.5.tar.gz", hash = "sha256:40816bb6ffe18481d7e023a5c36304761e5334d18098c72af7bd6d44f4235932"},
 ]
 
 [package.dependencies]
-deepdiff = ">=8.6.1"
-openbb-core = ">=1.6.3,<2.0.0"
+deepdiff = ">=8.6.2"
+openbb-core = ">=1.6.4,<2.0.0"
 
 [[package]]
 name = "orderly-set"
@@ -2695,4 +2695,4 @@ charting = ["openbb-charting"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "0f34e153de2c0fd2e4c1f9f83389d7c70aecccf8bd1dc05662c30a38f0a201d2"
+content-hash = "c787f8521d9d016dabd280f25d68f947354db5dfcbdc7933a0261b66090de90d"

--- a/openbb_platform/providers/imf/pyproject.toml
+++ b/openbb_platform/providers/imf/pyproject.toml
@@ -9,8 +9,8 @@ packages = [{ include = "openbb_imf" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
-openbb-core = "^1.6.3"
-openbb-platform-api = "^1.3.3"
+openbb-core = "^1.6.4"
+openbb-platform-api = "^1.3.5"
 openbb-economy = "^1.6.1"
 openbb-charting = { version = "^2.5.1", optional = true }
 async-lru = "^2"

--- a/openbb_platform/providers/nasdaq/poetry.lock
+++ b/openbb_platform/providers/nasdaq/poetry.lock
@@ -436,14 +436,14 @@ files = [
 
 [[package]]
 name = "deepdiff"
-version = "8.6.1"
+version = "8.6.2"
 description = "Deep Difference and Search of any Python object/data. Recreate objects by adding adding deltas to each other."
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "deepdiff-8.6.1-py3-none-any.whl", hash = "sha256:ee8708a7f7d37fb273a541fa24ad010ed484192cd0c4ffc0fa0ed5e2d4b9e78b"},
-    {file = "deepdiff-8.6.1.tar.gz", hash = "sha256:ec56d7a769ca80891b5200ec7bd41eec300ced91ebcc7797b41eb2b3f3ff643a"},
+    {file = "deepdiff-8.6.2-py3-none-any.whl", hash = "sha256:4d22034a866c3928303a9332c279362f714192d9305bac17c498720d095fd1b4"},
+    {file = "deepdiff-8.6.2.tar.gz", hash = "sha256:186dcbd181e4d76cef11ab05f802d0056c5d6083c5a6748c1473e9d7481e183e"},
 ]
 
 [package.dependencies]
@@ -1097,19 +1097,19 @@ websockets = ">=15.0"
 
 [[package]]
 name = "openbb-platform-api"
-version = "1.3.4"
+version = "1.3.5"
 description = "OpenBB Platform API: Launch script and widgets builder for the Open Data Platform REST API and Workspace Backend Connector."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openbb_platform_api-1.3.4-py3-none-any.whl", hash = "sha256:95bc102a5cf8a31f635d331e689b5d756051acca63c3629b57caeaff337854a0"},
-    {file = "openbb_platform_api-1.3.4.tar.gz", hash = "sha256:2ba04266c221c31363d4dc22789d7148d2cef3aee71a89570edc7f2f719eb8b2"},
+    {file = "openbb_platform_api-1.3.5-py3-none-any.whl", hash = "sha256:dfa0175006aede9e09906b81832105075747d836b135e945e73af51060731066"},
+    {file = "openbb_platform_api-1.3.5.tar.gz", hash = "sha256:40816bb6ffe18481d7e023a5c36304761e5334d18098c72af7bd6d44f4235932"},
 ]
 
 [package.dependencies]
-deepdiff = ">=8.6.1"
-openbb-core = ">=1.6.3,<2.0.0"
+deepdiff = ">=8.6.2"
+openbb-core = ">=1.6.4,<2.0.0"
 
 [[package]]
 name = "orderly-set"
@@ -2117,4 +2117,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "d126379102225d52c7e52064513748ac6a27bc779e97d1c398fe9ed919e4d660"
+content-hash = "83c7d570c944154df5c9a49f96c5d07dcd77da72b312b677dfcaf89983bc4e4e"

--- a/openbb_platform/providers/nasdaq/pyproject.toml
+++ b/openbb_platform/providers/nasdaq/pyproject.toml
@@ -9,8 +9,8 @@ packages = [{ include = "openbb_nasdaq" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
-openbb-core = "^1.6.3"
-openbb-platform-api = "^1.3.3"
+openbb-core = "^1.6.4"
+openbb-platform-api = "^1.3.5"
 async-lru = "^2.0.5"
 random-user-agent = "^1.0.1"
 nasdaq-data-link = "^1.0.4"

--- a/openbb_platform/pyproject.toml
+++ b/openbb_platform/pyproject.toml
@@ -11,7 +11,7 @@ packages = [{ include = "openbb", from = "core" }]
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
 openbb-core = "^1.6.4"
-openbb-platform-api = "^1.3.4"
+openbb-platform-api = "^1.3.5"
 
 openbb-benzinga = "^1.6.0"
 openbb-bls = "^1.3.0"


### PR DESCRIPTION
This PR resolves GHSA-54jj-px8x-5w5q by bumping the minimum version of DeepDiff in `openbb-platform-api`, and then regenerating the lock files for the packages solving for it.

There are no changes to the code.
