### PR TITLE
[BugFix] `openbb-core`: Fix Package Builder In `no_validate` Path & Handle Lazy Annotations

### DIFF
--- a/openbb_platform/core/openbb/assets/reference.json
+++ b/openbb_platform/core/openbb/assets/reference.json
@@ -1,9 +1,9 @@
 {
-    "openbb": "1.6.4core",
+    "openbb": "1.6.5core",
     "info": {
         "title": "OpenBB Platform (Python)",
         "description": "Investment research for everyone, anywhere.",
-        "core": "1.6.4",
+        "core": "1.6.5",
         "extensions": {
             "openbb_core_extension": [],
             "openbb_provider_extension": [],

--- a/openbb_platform/core/openbb_core/app/static/package_builder.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder.py
@@ -557,8 +557,9 @@ class ImportDefinition:
         code += "\nfrom fastapi import Depends"
 
         module_list = [
-            hint_type.__module__ if hasattr(hint_type, "__module__") else hint_type
+            hint_type.__module__
             for hint_type in hint_type_list
+            if hasattr(hint_type, "__module__")
         ]
         module_list = list(set(module_list))
         module_list.sort()  # type: ignore
@@ -1531,6 +1532,11 @@ class MethodDefinition:
             if isinstance(type_hint, type):
                 return type_hint.__name__
 
+            # Unwrap ForwardRef to its inner string so we don't emit
+            # ForwardRef('int') in generated signatures.
+            if hasattr(type_hint, "__forward_arg__"):
+                return type_hint.__forward_arg__
+
             s = str(type_hint)
             if s.startswith("typing."):
                 s = s[7:]
@@ -1615,7 +1621,7 @@ class MethodDefinition:
         if return_type == _empty:
             func_returns = "Any"
         elif isinstance(return_type, str):
-            func_returns = f"ForwardRef('{return_type}')"
+            func_returns = return_type
         elif isclass(return_type) and issubclass(return_type, OBBject):
             func_returns = "OBBject"
         else:
@@ -2041,6 +2047,10 @@ class DocstringGenerator:
 
         try:
             _type = field_type
+
+            # Unwrap ForwardRef to its inner string
+            if hasattr(_type, "__forward_arg__"):
+                _type = _type.__forward_arg__
 
             if "BeforeValidator" in str(_type):
                 _type = "Optional[int]" if is_optional else "int"  # type: ignore

--- a/openbb_platform/core/poetry.lock
+++ b/openbb_platform/core/poetry.lock
@@ -197,14 +197,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
-    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
+    {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
+    {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
 ]
 
 [package.dependencies]
@@ -213,7 +213,7 @@ idna = ">=2.8"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
+trio = ["trio (>=0.32.0)"]
 
 [[package]]
 name = "async-timeout"
@@ -230,14 +230,14 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"},
-    {file = "attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"},
+    {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
+    {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
 ]
 
 [[package]]
@@ -653,27 +653,27 @@ all = ["flake8 (>=7.1.1)", "mypy (>=1.11.2)", "pytest (>=8.3.2)", "ruff (>=0.6.2
 
 [[package]]
 name = "importlib-metadata"
-version = "8.7.1"
+version = "9.0.0"
 description = "Read metadata from Python packages"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "importlib_metadata-8.7.1-py3-none-any.whl", hash = "sha256:5a1f80bf1daa489495071efbb095d75a634cf28a8bc299581244063b53176151"},
-    {file = "importlib_metadata-8.7.1.tar.gz", hash = "sha256:49fef1ae6440c182052f407c8d34a68f72efc36db9ca90dc0113398f2fdde8bb"},
+    {file = "importlib_metadata-9.0.0-py3-none-any.whl", hash = "sha256:2d21d1cc5a017bd0559e36150c21c830ab1dc304dedd1b7ea85d20f45ef3edd7"},
+    {file = "importlib_metadata-9.0.0.tar.gz", hash = "sha256:a4f57ab599e6a2e3016d7595cfd72eb4661a5106e787a95bcc90c7105b831efc"},
 ]
 
 [package.dependencies]
 zipp = ">=3.20"
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 enabler = ["pytest-enabler (>=3.4)"]
 perf = ["ipython"]
-test = ["flufl.flake8", "jaraco.test (>=5.4)", "packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
-type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
+test = ["packaging", "pyfakefs", "pytest (>=6,!=8.1.*)", "pytest-perf (>=0.9.2)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "multidict"

--- a/openbb_platform/core/pyproject.toml
+++ b/openbb_platform/core/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-core"
-version = "1.6.4"
+version = "1.6.5"
 description = "OpenBB package with core functionality."
 authors = ["OpenBB Team <hello@openbb.co>"]
 license = "AGPL-3.0-only"

--- a/openbb_platform/core/tests/app/static/test_package_builder.py
+++ b/openbb_platform/core/tests/app/static/test_package_builder.py
@@ -896,3 +896,95 @@ def test_is_safe_dependency(method_definition):
     assert not method_definition._is_safe_dependency(optional_request_dependency)
     assert not method_definition._is_safe_dependency(none_return_dependency)
     assert method_definition._is_safe_dependency(optional_return_dependency)
+
+
+def test_build_func_params_unwraps_forward_ref(method_definition):
+    """Test that ForwardRef annotations are unwrapped in generated function params.
+
+    Regression test: when extensions use `from __future__ import annotations`
+    with `no_validate=True`, annotations remain as strings at runtime.
+    Annotated["int", ...] auto-wraps "int" into ForwardRef("int").
+    The builder must unwrap these to plain type strings.
+    """
+    # pylint: disable=import-outside-toplevel
+    from collections import OrderedDict
+    from typing import ForwardRef
+
+    from openbb_core.app.model.field import OpenBBField
+
+    param_map = OrderedDict(
+        {
+            "symbol": Parameter(
+                name="symbol",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[
+                    ForwardRef("str"), OpenBBField(description="")
+                ],
+            ),
+            "days": Parameter(
+                name="days",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[
+                    ForwardRef("int"), OpenBBField(description="")
+                ],
+                default=7,
+            ),
+            "asset_type": Parameter(
+                name="asset_type",
+                kind=Parameter.POSITIONAL_OR_KEYWORD,
+                annotation=Annotated[
+                    ForwardRef("Literal['stock', 'etf', 'all'] | None"),
+                    OpenBBField(description=""),
+                ],
+                default=None,
+            ),
+        }
+    )
+
+    output = method_definition.build_func_params(param_map)
+
+    assert "ForwardRef" not in output, (
+        f"ForwardRef should be unwrapped in generated params, got:\n{output}"
+    )
+    assert "str," in output
+    assert "int," in output
+    assert "Literal['stock', 'etf', 'all']" in output
+
+
+def test_build_func_returns_string_annotation(method_definition):
+    """Test that string return types are emitted directly, not wrapped in ForwardRef.
+
+    Regression test: `from __future__ import annotations` causes return annotations
+    to be strings. The builder should emit the string directly (e.g., "OBBject")
+    rather than wrapping it as ForwardRef('OBBject').
+    """
+    output = method_definition.build_func_returns(return_type="OBBject")
+    assert output == "OBBject"
+    assert "ForwardRef" not in output
+
+    output2 = method_definition.build_func_returns(return_type="Any")
+    assert output2 == "Any"
+    assert "ForwardRef" not in output2
+
+
+def test_get_field_type_unwraps_forward_ref(docstring_generator):
+    """Test that ForwardRef is unwrapped in docstring type formatting.
+
+    Regression test: ForwardRef('int') should render as 'int' in docstrings,
+    not as the literal string "ForwardRef('int')".
+    """
+    # pylint: disable=import-outside-toplevel
+    from typing import ForwardRef
+
+    result = docstring_generator.get_field_type(ForwardRef("int"), is_required=True)
+    assert "ForwardRef" not in result, (
+        f"ForwardRef should be unwrapped in docstring types, got: {result}"
+    )
+    assert "int" in result
+
+    result2 = docstring_generator.get_field_type(
+        ForwardRef("Literal['stock', 'etf', 'all'] | None"), is_required=False
+    )
+    assert "ForwardRef" not in result2, (
+        f"ForwardRef should be unwrapped in docstring types, got: {result2}"
+    )

--- a/openbb_platform/poetry.lock
+++ b/openbb_platform/poetry.lock
@@ -243,14 +243,14 @@ files = [
 
 [[package]]
 name = "anyio"
-version = "4.12.1"
+version = "4.13.0"
 description = "High-level concurrency and networking framework on top of asyncio or Trio"
 optional = false
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "anyio-4.12.1-py3-none-any.whl", hash = "sha256:d405828884fc140aa80a3c667b8beed277f1dfedec42ba031bd6ac3db606ab6c"},
-    {file = "anyio-4.12.1.tar.gz", hash = "sha256:41cfcc3a4c85d3f05c932da7c26d0201ac36f72abd4435ba90d0464a3ffed703"},
+    {file = "anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708"},
+    {file = "anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc"},
 ]
 
 [package.dependencies]
@@ -259,7 +259,7 @@ idna = ">=2.8"
 typing_extensions = {version = ">=4.5", markers = "python_version < \"3.13\""}
 
 [package.extras]
-trio = ["trio (>=0.31.0) ; python_version < \"3.10\"", "trio (>=0.32.0) ; python_version >= \"3.10\""]
+trio = ["trio (>=0.32.0)"]
 
 [[package]]
 name = "arch"
@@ -310,14 +310,14 @@ statsmodels = ">=0.12"
 
 [[package]]
 name = "async-lru"
-version = "2.2.0"
+version = "2.3.0"
 description = "Simple LRU cache for asyncio"
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "async_lru-2.2.0-py3-none-any.whl", hash = "sha256:e2c1cf731eba202b59c5feedaef14ffd9d02ad0037fcda64938699f2c380eafe"},
-    {file = "async_lru-2.2.0.tar.gz", hash = "sha256:80abae2a237dbc6c60861d621619af39f0d920aea306de34cb992c879e01370c"},
+    {file = "async_lru-2.3.0-py3-none-any.whl", hash = "sha256:eea27b01841909316f2cc739807acea1c623df2be8c5cfad7583286397bb8315"},
+    {file = "async_lru-2.3.0.tar.gz", hash = "sha256:89bdb258a0140d7313cf8f4031d816a042202faa61d0ab310a0a538baa1c24b6"},
 ]
 
 [package.dependencies]
@@ -338,14 +338,14 @@ files = [
 
 [[package]]
 name = "attrs"
-version = "25.4.0"
+version = "26.1.0"
 description = "Classes Without Boilerplate"
 optional = false
 python-versions = ">=3.9"
 groups = ["main"]
 files = [
-    {file = "attrs-25.4.0-py3-none-any.whl", hash = "sha256:adcf7e2a1fb3b36ac48d97835bb6d8ade15b8dcce26aba8bf1d14847b57a3373"},
-    {file = "attrs-25.4.0.tar.gz", hash = "sha256:16d5969b87f0859ef33a48b35d55ac1be6e42ae49d5e853b597db70c35c57e11"},
+    {file = "attrs-26.1.0-py3-none-any.whl", hash = "sha256:c647aa4a12dfbad9333ca4e71fe62ddc36f4e63b2d260a37a8b83d2f043ac309"},
+    {file = "attrs-26.1.0.tar.gz", hash = "sha256:d03ceb89cb322a8fd706d4fb91940737b6642aa36998fe130a9bc96c985eff32"},
 ]
 
 [[package]]
@@ -873,15 +873,15 @@ test = ["charset_normalizer (>=3.3.2,<4.0)", "cryptography (>=42.0.5,<43.0)", "f
 
 [[package]]
 name = "cyclopts"
-version = "4.10.0"
+version = "4.10.1"
 description = "Intuitive, easy CLIs based on type hints."
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"mcp-server\" or extra == \"all\""
 files = [
-    {file = "cyclopts-4.10.0-py3-none-any.whl", hash = "sha256:50f333382a60df8d40ec14aa2e627316b361c4f478598ada1f4169d959bf9ea7"},
-    {file = "cyclopts-4.10.0.tar.gz", hash = "sha256:0ae04a53274e200ef3477c8b54de63b019bc6cd0162d75c718bf40c9c3fb5268"},
+    {file = "cyclopts-4.10.1-py3-none-any.whl", hash = "sha256:35f37257139380a386d9fe4475e1e7c87ca7795765ef4f31abba579fcfcb6ecd"},
+    {file = "cyclopts-4.10.1.tar.gz", hash = "sha256:ad4e4bb90576412d32276b14a76f55d43353753d16217f2c3cd5bdceba7f15a0"},
 ]
 
 [package.dependencies]
@@ -1711,27 +1711,27 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-cov", "pytest-ena
 
 [[package]]
 name = "jaraco-context"
-version = "6.1.1"
+version = "6.1.2"
 description = "Useful decorators and context managers"
 optional = true
-python-versions = ">=3.9"
+python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"mcp-server\" or extra == \"all\""
 files = [
-    {file = "jaraco_context-6.1.1-py3-none-any.whl", hash = "sha256:0df6a0287258f3e364072c3e40d5411b20cafa30cb28c4839d24319cecf9f808"},
-    {file = "jaraco_context-6.1.1.tar.gz", hash = "sha256:bc046b2dc94f1e5532bd02402684414575cc11f565d929b6563125deb0a6e581"},
+    {file = "jaraco_context-6.1.2-py3-none-any.whl", hash = "sha256:bf8150b79a2d5d91ae48629d8b427a8f7ba0e1097dd6202a9059f29a36379535"},
+    {file = "jaraco_context-6.1.2.tar.gz", hash = "sha256:f1a6c9d391e661cc5b8d39861ff077a7dc24dc23833ccee564b234b81c82dfe3"},
 ]
 
 [package.dependencies]
 "backports.tarfile" = {version = "*", markers = "python_version < \"3.12\""}
 
 [package.extras]
-check = ["pytest-checkdocs (>=2.4)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
+check = ["pytest-checkdocs (>=2.14)", "pytest-ruff (>=0.2.1) ; sys_platform != \"cygwin\""]
 cover = ["pytest-cov"]
 doc = ["furo", "jaraco.packaging (>=9.3)", "jaraco.tidelift (>=1.4)", "rst.linker (>=1.9)", "sphinx (>=3.5)", "sphinx-lint"]
 enabler = ["pytest-enabler (>=3.4)"]
 test = ["jaraco.test (>=5.6.0)", "portend", "pytest (>=6,!=8.1.*)"]
-type = ["mypy (<1.19) ; platform_python_implementation == \"PyPy\"", "pytest-mypy (>=1.0.1)"]
+type = ["pytest-mypy (>=1.0.1) ; platform_python_implementation != \"PyPy\""]
 
 [[package]]
 name = "jaraco-functools"
@@ -2502,15 +2502,15 @@ files = [
 
 [[package]]
 name = "narwhals"
-version = "2.18.0"
+version = "2.18.1"
 description = "Extremely lightweight compatibility layer between dataframe libraries"
 optional = true
 python-versions = ">=3.9"
 groups = ["main"]
 markers = "extra == \"charting\" or extra == \"all\" or extra == \"econometrics\""
 files = [
-    {file = "narwhals-2.18.0-py3-none-any.whl", hash = "sha256:68378155ee706ac9c5b25868ef62ecddd62947b6df7801a0a156bc0a615d2d0d"},
-    {file = "narwhals-2.18.0.tar.gz", hash = "sha256:1de5cee338bc17c338c6278df2c38c0dd4290499fcf70d75e0a51d5f22a6e960"},
+    {file = "narwhals-2.18.1-py3-none-any.whl", hash = "sha256:a0a8bb80205323851338888ba3a12b4f65d352362c8a94be591244faf36504ad"},
+    {file = "narwhals-2.18.1.tar.gz", hash = "sha256:652a1fcc9d432bbf114846688884c215f17eb118aa640b7419295d2f910d2a8b"},
 ]
 
 [package.extras]
@@ -2886,14 +2886,14 @@ openbb-core = ">=1.6.3,<2.0.0"
 
 [[package]]
 name = "openbb-core"
-version = "1.6.4"
+version = "1.6.5"
 description = "OpenBB package with core functionality."
 optional = false
 python-versions = "<4,>=3.10"
 groups = ["main"]
 files = [
-    {file = "openbb_core-1.6.4-py3-none-any.whl", hash = "sha256:387341e5f00c3b2c163f7c024f0a2f45f0e35d2c4e5ac7796fd61f67148f5c9c"},
-    {file = "openbb_core-1.6.4.tar.gz", hash = "sha256:954fcdb914a9705109d3aa64e2067ea55c02599e320edfeb37962613aa3c27b7"},
+    {file = "openbb_core-1.6.5-py3-none-any.whl", hash = "sha256:c585a46f16b63fc6aea5eb9427322a83a2a0dca4e415f09fb46760b6e5f6bdd4"},
+    {file = "openbb_core-1.6.5.tar.gz", hash = "sha256:5e49d98c6a74595b4b7ef2c0b134e11b0f7c1113a7631b0022e252448ade10e3"},
 ]
 
 [package.dependencies]
@@ -4110,20 +4110,20 @@ files = [
 
 [[package]]
 name = "protobuf"
-version = "7.34.0"
+version = "7.34.1"
 description = ""
 optional = false
 python-versions = ">=3.10"
 groups = ["main"]
 files = [
-    {file = "protobuf-7.34.0-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:8e329966799f2c271d5e05e236459fe1cbfdb8755aaa3b0914fa60947ddea408"},
-    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:9d7a5005fb96f3c1e64f397f91500b0eb371b28da81296ae73a6b08a5b76cdd6"},
-    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:4a72a8ec94e7a9f7ef7fe818ed26d073305f347f8b3b5ba31e22f81fd85fca02"},
-    {file = "protobuf-7.34.0-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:964cf977e07f479c0697964e83deda72bcbc75c3badab506fb061b352d991b01"},
-    {file = "protobuf-7.34.0-cp310-abi3-win32.whl", hash = "sha256:f791ec509707a1d91bd02e07df157e75e4fb9fbdad12a81b7396201ec244e2e3"},
-    {file = "protobuf-7.34.0-cp310-abi3-win_amd64.whl", hash = "sha256:9f9079f1dde4e32342ecbd1c118d76367090d4aaa19da78230c38101c5b3dd40"},
-    {file = "protobuf-7.34.0-py3-none-any.whl", hash = "sha256:e3b914dd77fa33fa06ab2baa97937746ab25695f389869afdf03e81f34e45dc7"},
-    {file = "protobuf-7.34.0.tar.gz", hash = "sha256:3871a3df67c710aaf7bb8d214cc997342e63ceebd940c8c7fc65c9b3d697591a"},
+    {file = "protobuf-7.34.1-cp310-abi3-macosx_10_9_universal2.whl", hash = "sha256:d8b2cc79c4d8f62b293ad9b11ec3aebce9af481fa73e64556969f7345ebf9fc7"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_aarch64.whl", hash = "sha256:5185e0e948d07abe94bb76ec9b8416b604cfe5da6f871d67aad30cbf24c3110b"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_s390x.whl", hash = "sha256:403b093a6e28a960372b44e5eb081775c9b056e816a8029c61231743d63f881a"},
+    {file = "protobuf-7.34.1-cp310-abi3-manylinux2014_x86_64.whl", hash = "sha256:8ff40ce8cd688f7265326b38d5a1bed9bfdf5e6723d49961432f83e21d5713e4"},
+    {file = "protobuf-7.34.1-cp310-abi3-win32.whl", hash = "sha256:34b84ce27680df7cca9f231043ada0daa55d0c44a2ddfaa58ec1d0d89d8bf60a"},
+    {file = "protobuf-7.34.1-cp310-abi3-win_amd64.whl", hash = "sha256:e97b55646e6ce5cbb0954a8c28cd39a5869b59090dfaa7df4598a7fba869468c"},
+    {file = "protobuf-7.34.1-py3-none-any.whl", hash = "sha256:bb3812cd53aefea2b028ef42bd780f5b96407247f20c6ef7c679807e9d188f11"},
+    {file = "protobuf-7.34.1.tar.gz", hash = "sha256:9ce42245e704cc5027be797c1db1eb93184d44d1cdd71811fb2d9b25ad541280"},
 ]
 
 [[package]]
@@ -4712,15 +4712,15 @@ files = [
 
 [[package]]
 name = "redis"
-version = "7.3.0"
+version = "7.4.0"
 description = "Python client for Redis database and key-value store"
 optional = true
 python-versions = ">=3.10"
 groups = ["main"]
 markers = "extra == \"mcp-server\" or extra == \"all\""
 files = [
-    {file = "redis-7.3.0-py3-none-any.whl", hash = "sha256:9d4fcb002a12a5e3c3fbe005d59c48a2cc231f87fbb2f6b70c2d89bb64fec364"},
-    {file = "redis-7.3.0.tar.gz", hash = "sha256:4d1b768aafcf41b01022410b3cc4f15a07d9b3d6fe0c66fc967da2c88e551034"},
+    {file = "redis-7.4.0-py3-none-any.whl", hash = "sha256:a9c74a5c893a5ef8455a5adb793a31bb70feb821c86eccb62eebef5a19c429ec"},
+    {file = "redis-7.4.0.tar.gz", hash = "sha256:64a6ea7bf567ad43c964d2c30d82853f8df927c5c9017766c55a1d1ed95d18ad"},
 ]
 
 [package.dependencies]
@@ -6168,4 +6168,4 @@ wsj = ["openbb-wsj"]
 [metadata]
 lock-version = "2.1"
 python-versions = ">=3.10,<4"
-content-hash = "9ad4eb92ea453fe3fd0b3f8127c080fe3e4b6c2ac42d7e23cfd69b0c0cc452d0"
+content-hash = "e1f83c106389931b456f90c87df710edd33a9f396297a0a8168f410b57e11977"

--- a/openbb_platform/pyproject.toml
+++ b/openbb_platform/pyproject.toml
@@ -10,7 +10,7 @@ packages = [{ include = "openbb", from = "core" }]
 
 [tool.poetry.dependencies]
 python = ">=3.10,<4"
-openbb-core = "^1.6.4"
+openbb-core = "^1.6.5"
 openbb-platform-api = "^1.3.5"
 
 openbb-benzinga = "^1.6.0"


### PR DESCRIPTION
This PR resolves a bug where PackageBuilder fails because of unresolved string annotations - `from __future__ import annotations` - in the module and the `no_validate` feature is being used.

When a hint_type is a string annotation (e.g., "Literal['stock', 'etf', 'all'] | None", "int", "str", "str | list[str]"), it doesn't have __module__, so the comprehension falls back to else hint_type — using the raw string as the module name. This produces broken imports like:

```python
import Literal['stock', 'etf', 'all'] | None
import int
import str
import str | list[str]
```

Then, these string annotations get used directly as module names.

The fix is to ensure that the module import comprehension checks for `__module__` before proceeding, and to unwrap ForwardRef to resolve the types.

Tests have been added to `tests/app/static/tset_package_builder` that should fail in the event of a regression.
