### PR TITLE
[BugFix] `openbb-imf`: Resolve Widget Definition Warning in Workspace for `imf_utils.presentation_table`

### DIFF
--- a/openbb_platform/providers/imf/openbb_imf/imf_router.py
+++ b/openbb_platform/providers/imf/openbb_imf/imf_router.py
@@ -548,7 +548,6 @@ async def presentation_table_choices(
 @router.command(
     methods=["GET"],
     widget_config={
-        "title": "IMF Presentation Table",
         "type": "html",
         "params": [
             {


### PR DESCRIPTION
This PR resolves an "Unrecognized parameters" warning from Workspace when the backend is refreshed. The correct field is `name`, and it already existed.

<img width="359" height="189" alt="Screenshot 2026-03-24 at 4 05 32 PM" src="https://github.com/user-attachments/assets/53f65caa-5ac6-420f-ab6e-b1666190383d" />

There is no real change to the code, impact is only on `widgets.json`
