### PR TITLE
fix: pin 19 unpinned action(s),extract 2 unsafe expression(s) to env vars

### DIFF
--- a/.github/workflows/build-desktop-osx64.yml
+++ b/.github/workflows/build-desktop-osx64.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Import Code Signing Certificate
-        uses: apple-actions/import-codesign-certs@v6
+        uses: apple-actions/import-codesign-certs@fe74d46e82474f87e1ba79832ad28a4013d0e33a # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           MACOS_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -64,7 +64,7 @@ jobs:
         run: npm install -g @cyclonedx/cyclonedx-npm
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
         with:
           targets: "x86_64-apple-darwin"
 

--- a/.github/workflows/build-desktop-osxARM.yml
+++ b/.github/workflows/build-desktop-osxARM.yml
@@ -28,7 +28,7 @@ jobs:
         uses: actions/checkout@v6
 
       - name: Import Code Signing Certificate
-        uses: apple-actions/import-codesign-certs@v6
+        uses: apple-actions/import-codesign-certs@fe74d46e82474f87e1ba79832ad28a4013d0e33a # v6
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APPLE_CERTIFICATE: ${{ secrets.MACOS_CERTIFICATE }}
@@ -64,7 +64,7 @@ jobs:
         run: npm install -g @cyclonedx/cyclonedx-npm
 
       - name: install Rust stable
-        uses: dtolnay/rust-toolchain@v1
+        uses: dtolnay/rust-toolchain@e97e2d8cc328f1b50210efc529dca0028893a2d9 # v1
         with:
           toolchain: stable
           targets: "aarch64-apple-darwin"

--- a/.github/workflows/build-desktop-win64.yml
+++ b/.github/workflows/build-desktop-win64.yml
@@ -86,7 +86,7 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path "${{ github.workspace }}/desktop/temp-sign-dlls"
 
       - name: Sign libcrypto DLL
-        uses: sslcom/esigner-codesign@develop
+        uses: sslcom/esigner-codesign@b7f8ff36fc0de8690fbbab8e5b4421d29802f747 # develop
         with:
           command: sign
           username: ${{ secrets.ESIGNER_USERNAME }}
@@ -98,7 +98,7 @@ jobs:
           malware_block: false
 
       - name: Sign libssl DLL
-        uses: sslcom/esigner-codesign@develop
+        uses: sslcom/esigner-codesign@b7f8ff36fc0de8690fbbab8e5b4421d29802f747 # develop
         with:
           command: sign
           username: ${{ secrets.ESIGNER_USERNAME }}
@@ -126,7 +126,7 @@ jobs:
         run: npm install -g @cyclonedx/cyclonedx-npm
 
       - name: Set up Rust
-        uses: dtolnay/rust-toolchain@stable
+        uses: dtolnay/rust-toolchain@631a55b12751854ce901bb631d5902ceb48146f7 # stable
 
       - name: Cache cargo registry
         uses: actions/cache@v5
@@ -183,7 +183,7 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path "${{ github.workspace }}/desktop/temp-sign"
 
       - name: Sign the executable
-        uses: sslcom/esigner-codesign@develop
+        uses: sslcom/esigner-codesign@b7f8ff36fc0de8690fbbab8e5b4421d29802f747 # develop
         with:
           command: sign
           username: ${{ secrets.ESIGNER_USERNAME }}
@@ -218,7 +218,7 @@ jobs:
         run: New-Item -ItemType Directory -Force -Path "${{ github.workspace }}/desktop/signed-installer"
 
       - name: Sign Installer
-        uses: sslcom/esigner-codesign@v1.3.2
+        uses: sslcom/esigner-codesign@cf5f6c1d38ad10f47e3ed9aca873f429b1a8d85b # v1.3.2
         with:
           command: sign
           username: ${{ secrets.ESIGNER_USERNAME }}

--- a/.github/workflows/draft-release.yml
+++ b/.github/workflows/draft-release.yml
@@ -66,7 +66,7 @@ jobs:
           echo "assets_path=./release_assets" >> $GITHUB_OUTPUT
 
       - name: Create VERSIONED release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ${{ steps.extract_version.outputs.versioned_tag }}
           name: ${{ steps.extract_version.outputs.release_name }}

--- a/.github/workflows/general-linting.yml
+++ b/.github/workflows/general-linting.yml
@@ -47,9 +47,11 @@ jobs:
         if: github.event_name == 'pull_request'
         run: |
           # "Checking PR diff"
-          echo "diff_files=$(git diff --diff-filter=d --name-only origin/${{ github.base_ref }}...${{ github.head_ref }} | grep -E '^(openbb_platform|cli)/.*\.py$' | grep -v 'openbb_platform/core/openbb/package' | grep -v 'integration' | grep -v 'tests' | xargs)" >> $GITHUB_ENV
+          echo "diff_files=$(git diff --diff-filter=d --name-only origin/${{ github.base_ref }}...${HEAD_REF} | grep -E '^(openbb_platform|cli)/.*\.py$' | grep -v 'openbb_platform/core/openbb/package' | grep -v 'integration' | grep -v 'tests' | xargs)" >> $GITHUB_ENV
           echo $diff_files
 
+        env:
+          HEAD_REF: ${{ github.head_ref }}
       - uses: actions/cache@v5
         with:
           path: ~/.cache/pip
@@ -94,7 +96,7 @@ jobs:
 
       - name: json-yaml-validate
         id: json-yaml-validate
-        uses: GrantBirki/json-yaml-validate@v4
+        uses: GrantBirki/json-yaml-validate@9bbaa8474e3af4e91f25eda8ac194fdc30564d96 # v4
         with:
           yaml_exclude_regex: "construct.yaml"
           use_gitignore: false

--- a/.github/workflows/gh-branch-name-check.yml
+++ b/.github/workflows/gh-branch-name-check.yml
@@ -23,7 +23,7 @@ jobs:
 
       - name: Get branch names.
         id: branch-names
-        uses: tj-actions/branch-names@v9
+        uses: tj-actions/branch-names@5250492686b253f06fa55861556d1027b067aeb5 # v9
 
       - name: Show Output result for source-branch and target-branch
         run: |

--- a/.github/workflows/gh-pr-labels.yml
+++ b/.github/workflows/gh-pr-labels.yml
@@ -16,13 +16,13 @@ jobs:
       #     mode: minimum
       #     count: 1
       #     labels: "guides, bug, build, docker, docs, feat XS, feat S, feat M, feat L, feat XL, help wanted, refactor, tests, dependencies, release"
-      - uses: mheap/github-action-required-labels@v5
+      - uses: mheap/github-action-required-labels@0ac283b4e65c1fb28ce6079dea5546ceca98ccbe # v5
         with:
           mode: exactly
           count: 0
           labels: "do not merge"
 
       - name: 🏷️ Label OpenBB Platform PRs
-        uses: srvaroa/labeler@master
+        uses: srvaroa/labeler@e8fbb2561481ef6e711a770f0234e9379dc76892 # master
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release-desktop.yml
+++ b/.github/workflows/release-desktop.yml
@@ -25,9 +25,11 @@ jobs:
           if [ "${{ github.event_name }}" == "release" ]; then
             echo "tag=${{ github.event.release.tag_name }}" >> $GITHUB_OUTPUT
           else
-            echo "tag=${{ github.event.inputs.tag_name }}" >> $GITHUB_OUTPUT
+            echo "tag=${INPUT_TAG_NAME}" >> $GITHUB_OUTPUT
           fi
 
+        env:
+          INPUT_TAG_NAME: ${{ github.event.inputs.tag_name }}
       - name: Download release artifacts from published release
         run: |
           mkdir -p artifacts
@@ -146,7 +148,7 @@ jobs:
           cat latest.json
 
       - name: Create ODP release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@153bb8e04406b158c6c84fc1615b65b24149a1fe # v2
         with:
           tag_name: ODP
           name: ODP Desktop (Latest Stable)

--- a/.github/workflows/test-unit-desktop-osx64.yml
+++ b/.github/workflows/test-unit-desktop-osx64.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: lts/*
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/test-unit-desktop-osxARM.yml
+++ b/.github/workflows/test-unit-desktop-osxARM.yml
@@ -28,7 +28,7 @@ jobs:
           node-version: lts/*
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/test-unit-desktop-win64.yml
+++ b/.github/workflows/test-unit-desktop-win64.yml
@@ -60,7 +60,7 @@ jobs:
           node-version: lts/*
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           profile: minimal

--- a/.github/workflows/test-unit-desktop-winARM.yml
+++ b/.github/workflows/test-unit-desktop-winARM.yml
@@ -60,7 +60,7 @@ jobs:
           node-version: lts/*
 
       - name: Set up Rust
-        uses: actions-rs/toolchain@v1
+        uses: actions-rs/toolchain@16499b5e05bf2e26879000db0c1d13f7e13fa3af # v1
         with:
           toolchain: stable
           profile: minimal


### PR DESCRIPTION
## Security: Harden GitHub Actions workflows

Hey, we found some CI/CD security issues in this repo's workflows using [Runner Guard](https://github.com/Vigilant-LLC/runner-guard), our open-source CI/CD security scanner at [Vigilant](https://www.vigilantdefense.com). These are the same vulnerability classes being actively exploited right now in the tj-actions, Trivy, LiteLLM supply chain attack chain. We scanned the top 50K repos on GitHub and over 20,000 have this same problem. We're trying to get fixes out to as many maintainers as possible before more repos get hit.

This PR fixes what we could automatically, and flags anything else that needs a manual look. There's a real person behind this PR, we're actively checking back on comments so if you have any questions just drop them here and we'll respond.

### Fixes applied (in this PR)

| Rule | Severity | File | Description |
|------|----------|------|-------------|
| RGS-007 | high | `.github/workflows/build-desktop-osx64.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build-desktop-osxARM.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/build-desktop-win64.yml` | Pinned 5 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/draft-release.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/general-linting.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/general-linting.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/gh-branch-name-check.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/gh-pr-labels.yml` | Pinned 2 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/release-desktop.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-002 | high | `.github/workflows/release-desktop.yml` | Extracted 1 unsafe expression(s) to env vars |
| RGS-007 | high | `.github/workflows/test-unit-desktop-osx64.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-unit-desktop-osxARM.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-unit-desktop-win64.yml` | Pinned 1 third-party action(s) to commit SHA |
| RGS-007 | high | `.github/workflows/test-unit-desktop-winARM.yml` | Pinned 1 third-party action(s) to commit SHA |


### Advisory: additional findings (manual review recommended)

| Rule | Severity | File | Description |
| RGS-003 | high | `.github/workflows/release-desktop.yml` | Filename Injection via Git Diff or File Listing |
| RGS-003 | high | `.github/workflows/release-desktop.yml` | Filename Injection via Git Diff or File Listing |
| RGS-007 | medium | `.github/workflows/general-linting.yml` | Unpinned Third-Party Action Using Mutable Tag |


### Why this matters

GitHub Actions workflows that use untrusted input in `run:` blocks, expose
secrets inline, or use unpinned third-party actions are vulnerable to
code injection, credential theft, and supply chain attacks. These are the same
vulnerability classes exploited in the [tj-actions/changed-files incident](https://www.vigilantdefense.com/resources/runner-guard)
and subsequent supply chain attacks, which compromised CI secrets across
thousands of repositories.

### How to verify

Review the diff — each change is mechanical and preserves workflow behavior:
- **Expression extraction** (RGS-002/008/014): Moves `${{ }}` expressions from
  `run:` blocks into `env:` mappings, preventing shell injection
- **SHA pinning** (RGS-007): Pins third-party actions to immutable commit SHAs
  (original version tag preserved as comment)


Run `brew install Vigilant-LLC/tap/runner-guard && runner-guard scan .` or install from the
[repo](https://github.com/Vigilant-LLC/runner-guard) to verify.

---

Found by [Runner Guard](https://github.com/Vigilant-LLC/runner-guard) | Built by [Vigilant Cyber Security](https://www.vigilantdefense.com) | [Learn more](https://www.vigilantdefense.com/resources/runner-guard)

If this PR is not welcome, just close it -- we won't send another.