### PR TITLE
ci: pin srvaroa/labeler action to immutable SHA

### DIFF
--- a/.github/workflows/gh-pr-labels.yml
+++ b/.github/workflows/gh-pr-labels.yml
@@ -23,6 +23,6 @@ jobs:
           labels: "do not merge"
 
       - name: 🏷️ Label OpenBB Platform PRs
-        uses: srvaroa/labeler@master
+        uses: srvaroa/labeler@e8fbb2561481ef6e711a770f0234e9379dc76892
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Pins `srvaroa/labeler@master` to a commit SHA to reduce GitHub Actions supply-chain risk from mutable refs.