### PR TITLE
fix(core): dynamically resolve OBBject_* models in provider_interface

### DIFF
--- a/openbb_platform/core/openbb_core/app/provider_interface.py
+++ b/openbb_platform/core/openbb_core/app/provider_interface.py
@@ -739,3 +739,17 @@ class ProviderInterface(metaclass=SingletonMeta):
                 __doc__=f"OBBject with results of type {name}",
             )
         return annotations
+
+_cached_annotations = None
+
+def __getattr__(name: str):
+    """Dynamic resolution for OBBject_* models."""
+    if name.startswith("OBBject_"):
+        global _cached_annotations
+        if _cached_annotations is None:
+            pi = ProviderInterface()
+            _cached_annotations = pi.return_annotations
+        model_name = name[len("OBBject_"):]
+        if model_name in _cached_annotations:
+            return _cached_annotations[model_name]
+    raise AttributeError(f"module {__name__!r} has no attribute {name!r}")


### PR DESCRIPTION
Resolves #7379 and fixes the `ImportError` users hit when importing generated `openbb` Python packages.

### Description
The `openbb-build` process generates imports like `from openbb_core.app.provider_interface import OBBject_EquityInfo`. However, the `ProviderInterface` class creates these `OBBject_*` models dynamically in `return_annotations` and they are never exported as module-level attributes on `openbb_core.app.provider_interface`.

This PR introduces a late-binding `__getattr__` hook at the bottom of `openbb_core/app/provider_interface.py` to lazily resolve these models during import.