### PR TITLE
fix: merge custom widgets in editable mode

### DIFF
--- a/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
+++ b/openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py
@@ -107,6 +107,26 @@ def get_user_settings(current_user_settings: str) -> dict:
     return user_settings
 
 
+def _merge_path_widgets(
+    widgets_json: dict, widget_exclude_filter: list, overwrite: bool = True
+) -> dict:
+    """Merge widgets loaded from additional widgets.json routes."""
+    if not PATH_WIDGETS:
+        return widgets_json
+
+    for k in PATH_WIDGETS:
+        if k in widget_exclude_filter or k + "*" in widget_exclude_filter:
+            continue
+
+        for widget_id, widget in PATH_WIDGETS[k].items():
+            if widget_id in widget_exclude_filter:
+                continue
+            if overwrite or widget_id not in widgets_json:
+                widgets_json[widget_id] = widget
+
+    return widgets_json
+
+
 def get_widgets_json(
     _build: bool,
     _openapi,
@@ -122,6 +142,8 @@ def get_widgets_json(
     from .widgets import build_json
 
     global PATH_WIDGETS  # noqa  pylint: disable=W0603
+
+    path_widget_exclude_filter = list(widget_exclude_filter)
 
     if (
         FIRST_RUN is True
@@ -195,17 +217,13 @@ def get_widgets_json(
                         if existing_widgets_json
                         else build_json(_openapi, widget_exclude_filter)
                     )
+
+        _widgets_json = _merge_path_widgets(
+            _widgets_json, path_widget_exclude_filter, overwrite=False
+        )
     else:
         _widgets_json = build_json(_openapi, widget_exclude_filter)
-
-        if PATH_WIDGETS:
-            for k in PATH_WIDGETS:
-                if k in widget_exclude_filter or k + "*" in widget_exclude_filter:
-                    continue
-
-                for widget_id, widget in PATH_WIDGETS[k].items():
-                    if widget_id not in widget_exclude_filter:
-                        _widgets_json[widget_id] = widget
+        _widgets_json = _merge_path_widgets(_widgets_json, path_widget_exclude_filter)
 
     return _widgets_json
 

--- a/openbb_platform/extensions/platform_api/tests/test_api.py
+++ b/openbb_platform/extensions/platform_api/tests/test_api.py
@@ -8,6 +8,7 @@ from unittest.mock import AsyncMock, MagicMock, mock_open, patch
 
 import openbb_platform_api.utils.api as api_utils
 import pytest
+from fastapi import FastAPI
 from openbb_platform_api.utils.api import (
     check_port,
     get_user_settings,
@@ -168,6 +169,65 @@ def test_get_widgets_json_no_build():
             _build=False, _openapi={}, widget_exclude_filter=[]
         )
         assert widgets_json == {}
+
+
+def test_get_widgets_json_editable_merges_additional_widget_routes(
+    tmp_path, monkeypatch
+):
+    app = FastAPI()
+
+    @app.get("/widgets.json")
+    async def root_widgets():
+        return {"root": {"widgetId": "root", "endpoint": "/root"}}
+
+    @app.get("/custom/widgets.json")
+    async def custom_widgets():
+        return {
+            "custom": {
+                "widgetId": "custom",
+                "endpoint": "/data",
+                "gridData": {"w": 6, "h": 4},
+            }
+        }
+
+    widgets_path = tmp_path / "widgets.json"
+    widgets_path.write_text(
+        json.dumps({"root": {"widgetId": "root", "endpoint": "/root"}}),
+        encoding="utf-8",
+    )
+    monkeypatch.setattr(api_utils, "FIRST_RUN", True)
+    monkeypatch.setattr(api_utils, "PATH_WIDGETS", {})
+    provider_helpers_module = types.ModuleType("openbb_core.provider.utils.helpers")
+
+    def _run_async_stub(callable_or_coroutine, *args, **kwargs):
+        import asyncio
+
+        result = (
+            callable_or_coroutine(*args, **kwargs)
+            if callable(callable_or_coroutine)
+            else callable_or_coroutine
+        )
+        if hasattr(result, "__await__"):
+            return asyncio.run(result)
+        return result
+
+    provider_helpers_module.run_async = _run_async_stub  # type: ignore
+
+    with patch.dict(
+        sys.modules,
+        {"openbb_core.provider.utils.helpers": provider_helpers_module},
+    ):
+        widgets_json = get_widgets_json(
+            _build=False,
+            _openapi={},
+            widget_exclude_filter=[],
+            editable=True,
+            widgets_path=str(widgets_path),
+            app=app,
+        )
+
+    assert widgets_json["custom"]["endpoint"] == "/custom/data"
+    assert widgets_json["custom"]["gridData"] == {"w": 6, "h": 4}
 
 
 def test_parse_args():


### PR DESCRIPTION
## Summary
- merge router-provided widget JSON into editable widgets.json responses without overwriting existing edited widget IDs
- keep path-widget exclude handling based on the caller-provided filter
- add regression coverage for custom widget routes loaded alongside an editable widgets file

Fixes OpenBB-finance/OpenBB#7479

## Verification
- py -3 -m pytest openbb_platform/extensions/platform_api/tests/test_api.py::test_get_widgets_json_editable_merges_additional_widget_routes -q
- py -3 -m pytest openbb_platform/extensions/platform_api/tests/test_merge_widgets.py -q
- py -3 -m py_compile openbb_platform/extensions/platform_api/openbb_platform_api/utils/api.py openbb_platform/extensions/platform_api/tests/test_api.py
- git diff --check