### PR TITLE
[BugFix] Remove Bad Validator & Make Fields Optional in `FuturesHistoricalData`

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -1,8 +1,10 @@
 """Futures Historical Price Standard Model."""
 
-from datetime import date, datetime
+from datetime import (
+    date as dateType,
+    datetime,
+)
 
-from dateutil import parser
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
 from openbb_core.provider.utils.descriptions import (
@@ -16,11 +18,11 @@ class FuturesHistoricalQueryParams(QueryParams):
     """Futures Historical Price Query."""
 
     symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
-    start_date: date | None = Field(
+    start_date: dateType | None = Field(
         default=None,
         description=QUERY_DESCRIPTIONS.get("start_date", ""),
     )
-    end_date: date | None = Field(
+    end_date: dateType | None = Field(
         default=None,
         description=QUERY_DESCRIPTIONS.get("end_date", ""),
     )
@@ -39,9 +41,9 @@ class FuturesHistoricalQueryParams(QueryParams):
 class FuturesHistoricalData(Data):
     """Futures Historical Price Data."""
 
-    date: datetime = Field(description=DATA_DESCRIPTIONS.get("date", ""))
-    open: float = Field(description=DATA_DESCRIPTIONS.get("open", ""))
-    high: float = Field(description=DATA_DESCRIPTIONS.get("high", ""))
-    low: float = Field(description=DATA_DESCRIPTIONS.get("low", ""))
+    date: datetime | dateType = Field(description=DATA_DESCRIPTIONS.get("date", ""))
+    open: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("open", ""))
+    high: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("high", ""))
+    low: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("low", ""))
     close: float = Field(description=DATA_DESCRIPTIONS.get("close", ""))
-    volume: float = Field(description=DATA_DESCRIPTIONS.get("volume", ""))
+    volume: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("volume", ""))

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -45,9 +45,3 @@ class FuturesHistoricalData(Data):
     low: float = Field(description=DATA_DESCRIPTIONS.get("low", ""))
     close: float = Field(description=DATA_DESCRIPTIONS.get("close", ""))
     volume: float = Field(description=DATA_DESCRIPTIONS.get("volume", ""))
-
-    @field_validator("symbol", mode="before", check_fields=False)
-    @classmethod
-    def date_validate(cls, v):
-        """Return formatted datetime."""
-        return parser.isoparse(str(v))

--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_historical.py
@@ -42,8 +42,16 @@ class FuturesHistoricalData(Data):
     """Futures Historical Price Data."""
 
     date: datetime | dateType = Field(description=DATA_DESCRIPTIONS.get("date", ""))
-    open: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("open", ""))
-    high: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("high", ""))
-    low: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("low", ""))
+    open: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("open", "")
+    )
+    high: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("high", "")
+    )
+    low: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("low", "")
+    )
     close: float = Field(description=DATA_DESCRIPTIONS.get("close", ""))
-    volume: float | None = Field(default=None, description=DATA_DESCRIPTIONS.get("volume", ""))
+    volume: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("volume", "")
+    )


### PR DESCRIPTION
This PR fixes a bug in a standard model definition where a date validator was assigned to the symbol field, but had no effect regardless. Changes are:

- remove validator
- make open, high, low, volume optional fields./

No downstream changes required.