### PR TITLE
[BugFix] `openbb-nasdaq`: Fix 'FastAPI' object has no attribute 'add_event_handler'

### DIFF
--- a/openbb_platform/providers/nasdaq/openbb_nasdaq/app.py
+++ b/openbb_platform/providers/nasdaq/openbb_nasdaq/app.py
@@ -20,6 +20,7 @@ Open the server's URL in your browser for more information on connecting to the 
 def main():
     """Return a FastAPI app instance."""
     # pylint: disable=import-outside-toplevel
+    from contextlib import asynccontextmanager
     from datetime import datetime
     from typing import Annotated, Any, Literal
 
@@ -45,19 +46,9 @@ def main():
         reverse=True,
     )
 
-    app = FastAPI()
-
-    async def get_listings() -> DataFrame:
-        """Get the Nasdaq listings."""
-        return listings
-
-    Nasdaqlistings = Annotated[
-        DataFrame,
-        Depends(get_listings),
-    ]
-
-    async def startup_event():
-        """Startup event for the FastAPI app."""
+    @asynccontextmanager
+    async def lifespan(_: FastAPI):
+        """Lifespan event handler for the FastAPI app."""
         nonlocal listings
         fetcher = NasdaqEquitySearchFetcher()
 
@@ -71,8 +62,18 @@ def main():
             " and not name.str.contains('Warrant')"
             " and not name.str.contains('Preferred')"
         )
+        yield
 
-    app.add_event_handler("startup", startup_event)
+    app = FastAPI(lifespan=lifespan)
+
+    async def get_listings() -> DataFrame:
+        """Get the Nasdaq listings."""
+        return listings
+
+    Nasdaqlistings = Annotated[
+        DataFrame,
+        Depends(get_listings),
+    ]
 
     @app.get("/get_symbol_choices", include_in_schema=False)
     async def get_symbol_choices(

--- a/openbb_platform/providers/nasdaq/pyproject.toml
+++ b/openbb_platform/providers/nasdaq/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "openbb-nasdaq"
-version = "1.6.2"
+version = "1.6.3"
 description = "Nasdaq extension for OpenBB"
 authors = ["OpenBB Team <hello@openbb.co>"]
 license = "AGPL-3.0-only"

--- a/openbb_platform/pyproject.toml
+++ b/openbb_platform/pyproject.toml
@@ -53,7 +53,7 @@ openbb-famafrench = { version = "^1.2.1", optional = true }
 openbb-finra = { version = "^1.6.1", optional = true }
 openbb-finviz = { version = "^1.5.1", optional = true }
 openbb-multpl = { version = "^1.3.1", optional = true }
-openbb-nasdaq = { version = "^1.6.2", optional = true }
+openbb-nasdaq = { version = "^1.6.3", optional = true }
 openbb-seeking-alpha = { version = "^1.6.1", optional = true }
 openbb-stockgrid = { version = "^1.6.1", optional = true }
 openbb-tmx = { version = "^1.5.2", optional = true }


### PR DESCRIPTION
This PR fixes changes in newer versions of FastAPI, which removes the event handler methods from the app instance.

The fix is to replace it with a lifespan.

This can be observed vs. the failing tests in #7531 