### PR TITLE
fix(yfinance): normalize class-share symbols before Yahoo requests

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/balance_sheet.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/balance_sheet.py
@@ -87,10 +87,11 @@ class YFinanceBalanceSheetFetcher(
         from openbb_core.provider.utils.helpers import (
             to_snake_case,
         )
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         period = "yearly" if query.period == "annual" else "quarterly"  # type: ignore
-        data = Ticker(query.symbol).get_balance_sheet(
+        data = Ticker(normalize_yfinance_symbol(query.symbol)).get_balance_sheet(
             as_dict=False, pretty=False, freq=period
         )
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/cash_flow.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/cash_flow.py
@@ -84,10 +84,11 @@ class YFinanceCashFlowStatementFetcher(
         from openbb_core.provider.utils.helpers import (
             to_snake_case,
         )
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         period = "yearly" if query.period == "annual" else "quarterly"  # type: ignore
-        data = Ticker(query.symbol).get_cash_flow(
+        data = Ticker(normalize_yfinance_symbol(query.symbol)).get_cash_flow(
             as_dict=False, pretty=False, freq=period
         )
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/company_news.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/company_news.py
@@ -60,6 +60,7 @@ class YFinanceCompanyNewsFetcher(
         from warnings import warn
 
         from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]
@@ -122,10 +123,11 @@ class YFinanceCompanyNewsFetcher(
 
         def _fetch_news(sym: str) -> list[dict]:
             """Fetch the data in a worker thread."""
-            raw = Ticker(sym).get_news() or []
+            provider_symbol = normalize_yfinance_symbol(sym)
+            raw = Ticker(provider_symbol).get_news() or []
             out: list[dict] = []
             for item in raw:
-                norm = _normalize_news_item(item, sym)
+                norm = _normalize_news_item(item, sym.upper())
                 if norm:
                     out.append(norm)
             return out

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_profile.py
@@ -121,10 +121,11 @@ class YFinanceEquityProfileFetcher(
         import asyncio  # noqa
         from openbb_core.app.model.abstract.error import OpenBBError
         from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from warnings import warn
         from yfinance import Ticker
 
-        symbols = query.symbol.split(",")
+        symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]
         results = []
         fields = [
             "symbol",
@@ -158,10 +159,14 @@ class YFinanceEquityProfileFetcher(
 
         async def get_one(symbol):
             """Get the data for one ticker symbol."""
+            requested_symbol = symbol.upper()
+            provider_symbol = normalize_yfinance_symbol(symbol)
             result: dict = {}
             ticker: dict = {}
             try:
-                ticker = await asyncio.to_thread(lambda: Ticker(symbol).get_info())
+                ticker = await asyncio.to_thread(
+                    lambda: Ticker(provider_symbol).get_info()
+                )
             except Exception as e:
                 messages.append(
                     f"Error getting data for {symbol} -> {e.__class__.__name__}: {e}"
@@ -175,6 +180,7 @@ class YFinanceEquityProfileFetcher(
                             )
                         ] = ticker.get(field, None)
                 if result:
+                    result["symbol"] = requested_symbol
                     results.append(result)
 
         tasks = [get_one(symbol) for symbol in symbols]

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_quote.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/equity_quote.py
@@ -78,6 +78,7 @@ class YFinanceEquityQuoteFetcher(
         """Extract the raw data from YFinance."""
         # pylint: disable=import-outside-toplevel
         import asyncio  # noqa
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]
@@ -108,14 +109,18 @@ class YFinanceEquityQuoteFetcher(
         ]
 
         async def get_one(symbol: str) -> None:
+            provider_symbol = normalize_yfinance_symbol(symbol)
             try:
-                ticker = await asyncio.to_thread(lambda: Ticker(symbol).get_info())
+                ticker = await asyncio.to_thread(
+                    lambda: Ticker(provider_symbol).get_info()
+                )
             except Exception as e:
                 warn(f"Error getting data for {symbol}: {e}")
                 return
 
             result = {f: ticker.get(f) for f in fields if f in ticker}
             if result:
+                result["symbol"] = symbol.upper()
                 results.append(result)
 
         await asyncio.gather(*(get_one(symbol) for symbol in symbols))

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/historical_dividends.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/historical_dividends.py
@@ -46,10 +46,11 @@ class YFinanceHistoricalDividendsFetcher(
     ) -> list[dict]:
         """Extract the raw data from YFinance."""
         # pylint: disable=import-outside-toplevel
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         try:
-            ticker = Ticker(query.symbol).get_dividends()
+            ticker = Ticker(normalize_yfinance_symbol(query.symbol)).get_dividends()
             if isinstance(ticker, list) and not ticker or ticker.empty:  # type: ignore
                 raise OpenBBError(f"No dividend data found for {query.symbol}")
         except Exception as e:

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/income_statement.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/income_statement.py
@@ -87,10 +87,11 @@ class YFinanceIncomeStatementFetcher(
         from openbb_core.provider.utils.helpers import (
             to_snake_case,
         )
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         period = "yearly" if query.period == "annual" else "quarterly"
-        data = Ticker(query.symbol).get_income_stmt(
+        data = Ticker(normalize_yfinance_symbol(query.symbol)).get_income_stmt(
             as_dict=False, pretty=False, freq=period
         )
 

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/key_executives.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/key_executives.py
@@ -59,10 +59,11 @@ class YFinanceKeyExecutivesFetcher(
         """Extract the raw data from YFinance."""
         # pylint: disable=import-outside-toplevel
         from openbb_core.app.model.abstract.error import OpenBBError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
         try:
-            ticker = Ticker(query.symbol).get_info()
+            ticker = Ticker(normalize_yfinance_symbol(query.symbol)).get_info()
         except Exception as e:
             raise OpenBBError(
                 f"Error getting data for {query.symbol} -> {e.__class__.__name__}: {e}"

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/key_metrics.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/key_metrics.py
@@ -245,10 +245,11 @@ class YFinanceKeyMetricsFetcher(
         import asyncio  # noqa
         from openbb_core.app.model.abstract.error import OpenBBError
         from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from warnings import warn
         from yfinance import Ticker
 
-        symbols = query.symbol.split(",")
+        symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]
         results = []
         fields = [
             "symbol",
@@ -292,10 +293,14 @@ class YFinanceKeyMetricsFetcher(
 
         async def get_one(symbol):
             """Get the data for one ticker symbol."""
+            requested_symbol = symbol.upper()
+            provider_symbol = normalize_yfinance_symbol(symbol)
             result: dict = {}
             ticker: dict = {}
             try:
-                ticker = await asyncio.to_thread(lambda: Ticker(symbol).get_info())
+                ticker = await asyncio.to_thread(
+                    lambda: Ticker(provider_symbol).get_info()
+                )
             except Exception as e:
                 messages.append(
                     f"Error getting data for {symbol} -> {e.__class__.__name__}: {e}"
@@ -307,6 +312,7 @@ class YFinanceKeyMetricsFetcher(
                     if field in ticker:
                         result[field] = ticker.get(field, None)
                 if result and result.get("52WeekChange") is not None:
+                    result["symbol"] = requested_symbol
                     results.append(result)
 
         tasks = [get_one(symbol) for symbol in symbols]

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/options_chains.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/options_chains.py
@@ -63,16 +63,18 @@ class YFinanceOptionsChainsFetcher(
         """Extract the raw data from YFinance."""
         # pylint: disable=import-outside-toplevel
         import asyncio  # noqa
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from pandas import concat
         from yfinance import Ticker
         from pytz import timezone
 
         symbol = query.symbol.upper()
         symbol = "^" + symbol if symbol in ["VIX", "RUT", "SPX", "NDX"] else symbol
+        provider_symbol = normalize_yfinance_symbol(symbol)
 
-        def _get_all_data(symbol: str):
+        def _get_all_data(provider_symbol: str):
             """Get all options data in a single thread-safe operation."""
-            t = Ticker(symbol)
+            t = Ticker(provider_symbol)
             expirations = list(t.options)
 
             if not expirations or len(expirations) == 0:
@@ -117,7 +119,7 @@ class YFinanceOptionsChainsFetcher(
             return underlying, chains_output, expirations
 
         underlying, chains_output, expirations = await asyncio.to_thread(
-            _get_all_data, symbol
+            _get_all_data, provider_symbol
         )
 
         if not expirations or len(expirations) == 0:

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/price_target_consensus.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/price_target_consensus.py
@@ -86,10 +86,11 @@ class YFinancePriceTargetConsensusFetcher(
         # pylint: disable=import-outside-toplevel
         import asyncio  # noqa
         from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from warnings import warn
         from yfinance import Ticker
 
-        symbols = query.symbol.split(",")  # type: ignore
+        symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]  # type: ignore
         results = []
         fields = [
             "symbol",
@@ -107,10 +108,14 @@ class YFinancePriceTargetConsensusFetcher(
 
         async def get_one(symbol):
             """Get the data for one ticker symbol."""
+            requested_symbol = symbol.upper()
+            provider_symbol = normalize_yfinance_symbol(symbol)
             result: dict = {}
             ticker: dict = {}
             try:
-                ticker = await asyncio.to_thread(lambda: Ticker(symbol).get_info())
+                ticker = await asyncio.to_thread(
+                    lambda: Ticker(provider_symbol).get_info()
+                )
             except Exception as e:
                 messages.append(
                     f"Error getting data for {symbol}: {e.__class__.__name__}: {e}"
@@ -120,6 +125,7 @@ class YFinancePriceTargetConsensusFetcher(
                     if field in ticker:
                         result[field] = ticker.get(field, None)
                 if result and result.get("numberOfAnalystOpinions") is not None:
+                    result["symbol"] = requested_symbol
                     results.append(result)
 
         tasks = [get_one(symbol) for symbol in symbols]

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/share_statistics.py
@@ -119,9 +119,10 @@ class YFinanceShareStatisticsFetcher(
         import asyncio  # noqa
         from openbb_core.app.model.abstract.error import OpenBBError
         from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_yfinance.utils.helpers import normalize_yfinance_symbol
         from yfinance import Ticker
 
-        symbols = query.symbol.split(",")
+        symbols = [s.strip() for s in query.symbol.split(",") if s.strip()]
         results = []
         fields = [
             "symbol",
@@ -143,11 +144,13 @@ class YFinanceShareStatisticsFetcher(
 
         async def get_one(symbol):
             """Get the data for one ticker symbol."""
+            requested_symbol = symbol.upper()
+            provider_symbol = normalize_yfinance_symbol(symbol)
             result: dict = {}
             ticker: dict = {}
             try:
-                _ticker = await asyncio.to_thread(lambda: Ticker(symbol))
-                ticker = await asyncio.to_thread(lambda: _ticker.get_info())
+                _ticker = await asyncio.to_thread(lambda: Ticker(provider_symbol))
+                ticker = await asyncio.to_thread(_ticker.get_info)
                 major_holders = await asyncio.to_thread(
                     lambda: _ticker.get_major_holders(as_dict=True).get("Value")
                 )
@@ -162,6 +165,7 @@ class YFinanceShareStatisticsFetcher(
                     if field in ticker:
                         result[field] = ticker.get(field, None)
                 if result and result.get("sharesOutstanding") is not None:
+                    result["symbol"] = requested_symbol
                     results.append(result)
 
         tasks = [get_one(symbol) for symbol in symbols]

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -2,6 +2,7 @@
 
 # pylint: disable=unused-argument,too-many-arguments,too-many-branches,too-many-locals,too-many-statements
 
+import re
 from typing import TYPE_CHECKING, Any, Literal, Union
 
 from openbb_core.provider.utils.errors import EmptyDataError
@@ -73,6 +74,29 @@ SCREENER_FIELDS = [
     "exchangeTimezoneName",
     "earnings_date",
 ]
+
+# Keep this conservative; Yahoo also uses one-letter exchange suffixes like ".L".
+CLASS_SHARE_SYMBOL_REGEX = re.compile(r"^[A-Z]{1,5}\.[ABC]$")
+
+
+def normalize_yfinance_symbol(symbol: str) -> str:
+    """Convert US class-share symbols to Yahoo's dash convention."""
+    clean_symbol = symbol.strip()
+    upper_symbol = clean_symbol.upper()
+
+    if CLASS_SHARE_SYMBOL_REGEX.fullmatch(upper_symbol):
+        return upper_symbol.replace(".", "-")
+
+    return clean_symbol
+
+
+def normalize_yfinance_symbols(symbols: str) -> str:
+    """Normalize a comma-separated symbol list for yfinance requests."""
+    return ",".join(
+        normalize_yfinance_symbol(symbol)
+        for symbol in symbols.split(",")
+        if symbol.strip()
+    )
 
 
 async def get_custom_screener(
@@ -220,8 +244,8 @@ async def get_defined_screener(
 
 def get_expiration_month(symbol: str) -> str:
     """Get the expiration month for a given symbol."""
-    month = symbol.split(".")[0][-3]
-    year = "20" + symbol.split(".")[0][-2:]
+    month = symbol.split(".", maxsplit=1)[0][-3]
+    year = "20" + symbol.split(".", maxsplit=1)[0][-2:]
     return f"{year}-{MONTH_MAP[month]}"
 
 
@@ -500,7 +524,13 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     from pandas import DataFrame, concat, to_datetime
     import yfinance as yf
 
-    symbol = symbol.upper()
+    requested_tickers = [
+        ticker.strip().upper() for ticker in symbol.split(",") if ticker.strip()
+    ]
+    provider_tickers = [
+        normalize_yfinance_symbol(ticker) for ticker in requested_tickers
+    ]
+    provider_symbols = ",".join(provider_tickers)
     _start_date = start_date
     intraday = False
     if interval in ["60m", "1h"]:
@@ -529,7 +559,7 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
 
     try:
         data = yf.download(
-            tickers=symbol,
+            tickers=provider_symbols,
             start=_start_date,
             end=None,
             interval=interval,
@@ -550,22 +580,24 @@ def yf_download(  # pylint: disable=too-many-positional-arguments
     except ValueError as exc:
         raise EmptyDataError() from exc
 
-    tickers = symbol.split(",")
-    if len(tickers) == 1:
+    if len(provider_tickers) == 1:
+        provider_symbol = provider_tickers[0]
         if hasattr(data.columns, "levels"):
             try:
-                if symbol in data.columns.get_level_values(0):
-                    data = data[symbol]  # type: ignore
-                elif symbol in data.columns.get_level_values(1):
-                    data = data.xs(symbol, level=1, axis=1)  # type: ignore
+                if provider_symbol in data.columns.get_level_values(0):
+                    data = data[provider_symbol]  # type: ignore
+                elif provider_symbol in data.columns.get_level_values(1):
+                    data = data.xs(provider_symbol, level=1, axis=1)  # type: ignore
             except (KeyError, IndexError):
                 pass
-    elif len(tickers) > 1:
+    elif len(provider_tickers) > 1:
         _data = DataFrame()
-        for ticker in tickers:
-            temp = data[ticker].copy().dropna(how="all")  # type: ignore
+        for requested_ticker, provider_ticker in zip(
+            requested_tickers, provider_tickers
+        ):
+            temp = data[provider_ticker].copy().dropna(how="all")  # type: ignore
             if len(temp) > 0:
-                temp["symbol"] = ticker
+                temp["symbol"] = requested_ticker
                 temp = temp.reset_index().rename(
                     columns={"Date": "date", "Datetime": "date", "index": "date"}
                 )

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
@@ -1,14 +1,21 @@
 """Test yfinance helpers."""
 
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
 import pytest
-from unittest.mock import patch, MagicMock
+from openbb_yfinance.models.equity_quote import (
+    YFinanceEquityQuoteFetcher,
+    YFinanceEquityQuoteQueryParams,
+)
 from openbb_yfinance.utils.helpers import (
     df_transform_numbers,
-    get_futures_data,
     get_custom_screener,
     get_defined_screener,
+    get_futures_data,
     get_futures_symbols,
+    normalize_yfinance_symbol,
+    normalize_yfinance_symbols,
     yf_download,
 )
 
@@ -38,6 +45,35 @@ def test_df_transform_numbers():
     transformed = df_transform_numbers(data, ["Value", "% Change"])
     assert transformed["Value"].equals(pd.Series([1e6, 2.5e9, 3e12]))
     assert transformed["% Change"].equals(pd.Series([1 / 100, -2 / 100, 3.5 / 100]))
+
+
+@pytest.mark.parametrize(
+    ("symbol", "expected"),
+    [
+        ("BRK.A", "BRK-A"),
+        ("BF.B", "BF-B"),
+        ("ABC.C", "ABC-C"),
+        ("7203.T", "7203.T"),
+        ("RY.TO", "RY.TO"),
+        ("VOD.L", "VOD.L"),
+        ("BTC-USD", "BTC-USD"),
+        ("^GSPC", "^GSPC"),
+        ("ES=F", "ES=F"),
+    ],
+)
+def test_normalize_yfinance_symbol(symbol, expected):
+    """Test class-share symbol normalization for yfinance requests."""
+    assert normalize_yfinance_symbol(symbol) == expected
+
+
+def test_normalize_yfinance_symbols():
+    """Test comma-separated class-share symbol normalization."""
+    symbols = "BRK.A,BF.B,7203.T,RY.TO,BTC-USD,^GSPC,ES=F"
+
+    assert (
+        normalize_yfinance_symbols(symbols)
+        == "BRK-A,BF-B,7203.T,RY.TO,BTC-USD,^GSPC,ES=F"
+    )
 
 
 @pytest.mark.asyncio
@@ -152,3 +188,66 @@ def test_yf_download_no_session():
             assert (
                 "session" not in call_kwargs
             ), "yf.download should not be called with session parameter"
+
+
+def test_yf_download_normalizes_class_share_symbol():
+    """Test that yf_download sends Yahoo's dash-form class-share symbol."""
+    with patch("yfinance.download") as mock_download:
+        columns = pd.MultiIndex.from_tuples(
+            [
+                ("BRK-A", "Open"),
+                ("BRK-A", "High"),
+                ("BRK-A", "Low"),
+                ("BRK-A", "Close"),
+                ("BRK-A", "Adj Close"),
+            ]
+        )
+        idx = pd.to_datetime(["2023-01-03"])
+        idx.name = "Date"
+        mock_data = pd.DataFrame([[100, 110, 90, 105, 105]], columns=columns, index=idx)
+        mock_download.return_value = mock_data
+
+        yf_download("BRK.A", start_date="2023-01-01", end_date="2023-01-10")
+
+        assert mock_download.call_args.kwargs["tickers"] == "BRK-A"
+
+
+def test_yf_download_preserves_requested_symbol_output_for_multi_symbol():
+    """Test that multi-symbol output keeps OpenBB's requested symbol format."""
+    with patch("yfinance.download") as mock_download:
+        fields = ["Open", "High", "Low", "Close", "Adj Close"]
+        columns = pd.MultiIndex.from_product([["BRK-A", "AAPL"], fields])
+        idx = pd.to_datetime(["2023-01-03"])
+        idx.name = "Date"
+        mock_data = pd.DataFrame(
+            [[100, 110, 90, 105, 105, 200, 210, 190, 205, 205]],
+            columns=columns,
+            index=idx,
+        )
+        mock_download.return_value = mock_data
+
+        data = yf_download("BRK.A,AAPL")
+
+        assert mock_download.call_args.kwargs["tickers"] == "BRK-A,AAPL"
+        assert set(data["symbol"]) == {"BRK.A", "AAPL"}
+        assert "BRK-A" not in set(data["symbol"])
+
+
+@pytest.mark.asyncio
+async def test_equity_quote_fetcher_normalizes_class_share_ticker():
+    """Test that quote requests use Yahoo's dash-form class-share symbol."""
+    with patch("yfinance.Ticker") as mock_ticker:
+        mock_ticker.return_value.get_info.return_value = {
+            "symbol": "BRK-A",
+            "longName": "Berkshire Hathaway Inc.",
+            "quoteType": "EQUITY",
+            "currentPrice": 100,
+        }
+
+        data = await YFinanceEquityQuoteFetcher.aextract_data(
+            YFinanceEquityQuoteQueryParams(symbol="BRK.A"),
+            credentials={},
+        )
+
+        mock_ticker.assert_called_once_with("BRK-A")
+        assert data[0]["symbol"] == "BRK.A"


### PR DESCRIPTION
## Summary
- Add yfinance-only class-share symbol normalization for common US class-share symbols such as `BRK.A` and `BF.B`, converting them to Yahoo's dash-form symbols at the request boundary.
- Apply the helper to `yf_download(...)` and yfinance `Ticker(...)`-based equity/fundamental request paths while preserving the requested dot-form symbol in OpenBB `symbol` output fields.
- Add mocked coverage for helper boundaries, `yf.download` ticker arguments, multi-symbol historical output, and a quote fetcher `Ticker("BRK-A")` path.

## Why
Users can use OpenBB's dot convention from #6702 while Yahoo still receives the dash-form symbols it expects. This keeps the mapping vendor-specific and avoids changing global symbol semantics.

## Scope
- Only `openbb-yfinance` is changed.
- No standard model changes.
- No global symbol policy changes.
- No non-yfinance provider changes.
- The conversion is deliberately conservative for this first step, covering common class suffixes `A`, `B`, and `C` so one-letter Yahoo exchange suffixes such as `VOD.L` remain unchanged.

## Validation
From `openbb_platform/providers/yfinance`:
- `python -m pytest tests/test_yfinance_helpers.py -q` - 19 passed
- `python -m ruff check openbb_yfinance tests/test_yfinance_helpers.py` - passed

Refs #6702