### PR TITLE
[V5] [BugFix] Fix for Breaking Changes in FastAPI 0.137+

### DIFF
--- a/cli/uv.lock
+++ b/cli/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.10, <4"
 resolution-markers = [
     "python_full_version >= '3.15' and sys_platform == 'win32'",
@@ -811,7 +811,7 @@ wheels = [
 
 [[package]]
 name = "fastapi"
-version = "0.128.8"
+version = "0.137.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "annotated-doc" },
@@ -820,9 +820,9 @@ dependencies = [
     { name = "typing-extensions" },
     { name = "typing-inspection" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/01/72/0df5c58c954742f31a7054e2dd1143bae0b408b7f36b59b85f928f9b456c/fastapi-0.128.8.tar.gz", hash = "sha256:3171f9f328c4a218f0a8d2ba8310ac3a55d1ee12c28c949650288aee25966007", size = 375523, upload-time = "2026-02-11T15:19:36.69Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/d5/b1/e5b92c59d2c37817e77c1a8c2fc1f79cdcc04c68253e5406b43e3204cba7/fastapi-0.137.1.tar.gz", hash = "sha256:822360704230d9533d8d9475399613525968aa2f0b5bd2a3ccc9f18c88fd541c", size = 408293, upload-time = "2026-06-15T11:28:20.79Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9f/37/37b07e276f8923c69a5df266bfcb5bac4ba8b55dfe4a126720f8c48681d1/fastapi-0.128.8-py3-none-any.whl", hash = "sha256:5618f492d0fe973a778f8fec97723f598aa9deee495040a8d51aaf3cf123ecf1", size = 103630, upload-time = "2026-02-11T15:19:35.209Z" },
+    { url = "https://files.pythonhosted.org/packages/da/35/380b9a5922f4340e51c309cde09e5bd32e62f02302971bee30dc15aa0624/fastapi-0.137.1-py3-none-any.whl", hash = "sha256:64f6983c59e45c4b9fdc44e57cb8035c2451ee91ea8e8ec042aca37de7cf6b69", size = 121877, upload-time = "2026-06-15T11:28:19.523Z" },
 ]
 
 [[package]]
@@ -1794,6 +1794,7 @@ dependencies = [
     { name = "python-multipart" },
     { name = "requests" },
     { name = "ruff" },
+    { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "uuid7" },
     { name = "uvicorn" },
     { name = "websockets" },
@@ -1808,29 +1809,31 @@ pandas = [
 [package.metadata]
 requires-dist = [
     { name = "aiohttp", specifier = ">=3.13.3" },
-    { name = "fastapi", specifier = ">=0.128.0,<0.129.0" },
+    { name = "fastapi", specifier = ">=0.136.3" },
     { name = "importlib-metadata", specifier = ">=6.8.0" },
     { name = "pandas", marker = "extra == 'pandas'", specifier = ">=1.5.3" },
     { name = "pydantic", specifier = ">=2.12.3,<3.0.0" },
-    { name = "pyjwt", specifier = ">=2.12.0,<3.0.0" },
-    { name = "python-dotenv", specifier = ">=1.0.0,<2.0.0" },
-    { name = "python-multipart", specifier = ">=0.0.26,<0.0.27" },
-    { name = "requests", specifier = ">=2.33.0,<3.0.0" },
+    { name = "pyjwt", specifier = ">=2.13.0" },
+    { name = "python-dotenv", specifier = ">=1.0.0" },
+    { name = "python-multipart", specifier = ">=0.0.29" },
+    { name = "requests", specifier = ">=2.34.2" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
-    { name = "uuid7", specifier = ">=0.1.0,<0.2.0" },
-    { name = "uvicorn", specifier = ">=0.40.0,<0.41.0" },
+    { name = "tomli", marker = "python_full_version < '3.11'", specifier = ">=2.0.0" },
+    { name = "uuid7", specifier = ">=0.1.0" },
+    { name = "uvicorn", specifier = ">=0.48.0" },
     { name = "websockets", specifier = ">=15.0" },
 ]
 provides-extras = ["pandas"]
 
 [package.metadata.requires-dev]
-dev = [{ name = "openbb-devtools" }]
+dev = [{ name = "openbb-devtools", editable = "../openbb_platform/extensions/devtools" }]
 
 [[package]]
 name = "openbb-devtools"
 version = "2.0.0"
 source = { editable = "../openbb_platform/extensions/devtools" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "codespell" },
     { name = "ipykernel" },
     { name = "pre-commit" },
@@ -1846,11 +1849,13 @@ dependencies = [
     { name = "tox" },
     { name = "ty" },
     { name = "types-python-dateutil" },
+    { name = "types-requests" },
     { name = "types-toml" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = "<3.14" },
     { name = "codespell", specifier = ">=2.2.5,<3.0.0" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "pre-commit", specifier = ">=3.5.0,<4.0.0" },
@@ -1864,8 +1869,9 @@ requires-dist = [
     { name = "pytest-subtests", specifier = ">=0.11.0,<1.0.0" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
     { name = "tox", specifier = ">=4.11.3,<5.0.0" },
-    { name = "ty", specifier = ">=0.0.1a14" },
+    { name = "ty", specifier = ">=0.0.40" },
     { name = "types-python-dateutil", specifier = ">=2.8.19.14,<3.0.0" },
+    { name = "types-requests", specifier = ">=2.32,<3.0.0" },
     { name = "types-toml", specifier = ">=0.10.8.7,<1.0.0" },
 ]
 
@@ -2583,14 +2589,14 @@ wheels = [
 
 [[package]]
 name = "pyjwt"
-version = "2.12.1"
+version = "2.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c2/27/a3b6e5bf6ff856d2509292e95c8f57f0df7017cf5394921fc4e4ef40308a/pyjwt-2.12.1.tar.gz", hash = "sha256:c74a7a2adf861c04d002db713dd85f84beb242228e671280bf709d765b03672b", size = 102564, upload-time = "2026-03-13T19:27:37.25Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3b/81/58d0ac84e1ef3a3843791d6954d94c0b33d526c75eeb1efbce9d0a4c4077/pyjwt-2.13.0.tar.gz", hash = "sha256:41571c89ca91598c79e8ef18a2d07367d4810fbbd6f637794879baf1b7703423", size = 107515, upload-time = "2026-05-21T19:54:36.618Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/7a/8dd906bd22e79e47397a61742927f6747fe93242ef86645ee9092e610244/pyjwt-2.12.1-py3-none-any.whl", hash = "sha256:28ca37c070cad8ba8cd9790cd940535d40274d22f80ab87f3ac6a713e6e8454c", size = 29726, upload-time = "2026-03-13T19:27:35.677Z" },
+    { url = "https://files.pythonhosted.org/packages/a3/5e/ecf12fdb62546d64385c158514e9b2b671f7832108ef2ecd2020ce0af2d1/pyjwt-2.13.0-py3-none-any.whl", hash = "sha256:66adcc2aff09b3f1bbd95fc1e1577df8ac8723c978552fd43304c8a290ac5728", size = 31274, upload-time = "2026-05-21T19:54:35.362Z" },
 ]
 
 [[package]]
@@ -2792,11 +2798,11 @@ wheels = [
 
 [[package]]
 name = "python-multipart"
-version = "0.0.26"
+version = "0.0.32"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/88/71/b145a380824a960ebd60e1014256dbb7d2253f2316ff2d73dfd8928ec2c3/python_multipart-0.0.26.tar.gz", hash = "sha256:08fadc45918cd615e26846437f50c5d6d23304da32c341f289a617127b081f17", size = 43501, upload-time = "2026-04-10T14:09:59.473Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5b/42/55c32bb9b12693c092ad250a0e82edb5b31ddeda6eb772de5f308b3804ad/python_multipart-0.0.32.tar.gz", hash = "sha256:be54b7f3fa167bb83e4fcd936b887b708f4e57fe75911c02aebf53efaf8d938e", size = 46881, upload-time = "2026-06-04T16:18:58.647Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9a/22/f1925cdda983ab66fc8ec6ec8014b959262747e58bdca26a4e3d1da29d56/python_multipart-0.0.26-py3-none-any.whl", hash = "sha256:c0b169f8c4484c13b0dcf2ef0ec3a4adb255c4b7d18d8e420477d2b1dd03f185", size = 28847, upload-time = "2026-04-10T14:09:58.131Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/04/e8135ebd1ad02c56ec633277529b2602ff99ff634be76cdba5744cf554fd/python_multipart-0.0.32-py3-none-any.whl", hash = "sha256:ff6d3f776f16878c894e52e107296ffc890e913c611b1a4ec6c44e2821fe2e23", size = 30042, upload-time = "2026-06-04T16:18:57.319Z" },
 ]
 
 [[package]]
@@ -3048,7 +3054,7 @@ wheels = [
 
 [[package]]
 name = "requests"
-version = "2.33.1"
+version = "2.34.2"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "certifi" },
@@ -3056,9 +3062,9 @@ dependencies = [
     { name = "idna" },
     { name = "urllib3" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/a4/98b9c7c6428a668bf7e42ebb7c79d576a1c3c1e3ae2d47e674b468388871/requests-2.33.1.tar.gz", hash = "sha256:18817f8c57c6263968bc123d237e3b8b08ac046f5456bd1e307ee8f4250d3517", size = 134120, upload-time = "2026-03-30T16:09:15.531Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/ac/c3/e2a2b89f2d3e2179abd6d00ebd70bff6273f37fb3e0cc209f48b39d00cbf/requests-2.34.2.tar.gz", hash = "sha256:f288924cae4e29463698d6d60bc6a4da69c89185ad1e0bcc4104f584e960b9ed", size = 142856, upload-time = "2026-05-14T19:25:27.735Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d7/8e/7540e8a2036f79a125c1d2ebadf69ed7901608859186c856fa0388ef4197/requests-2.33.1-py3-none-any.whl", hash = "sha256:4e6d1ef462f3626a1f0a0a9c42dd93c63bad33f9f1c1937509b8c5c8718ab56a", size = 64947, upload-time = "2026-03-30T16:09:13.83Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/f4/c67b0b3f1b9245e8d266f0f112c500d50e5b4e83cb6f3b71b6528104182a/requests-2.34.2-py3-none-any.whl", hash = "sha256:2a0d60c172f83ac6ab31e4554906c0f3b3588d37b5cb939b1c061f4907e278e0", size = 73075, upload-time = "2026-05-14T19:25:26.443Z" },
 ]
 
 [[package]]
@@ -3631,26 +3637,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.33"
+version = "0.0.49"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/8d/37cb91808069509d43a2a11743e12f1e854fd808dbef2203309d256718cd/ty-0.0.49.tar.gz", hash = "sha256:0a027bd0c9c75d035641a365d087ad883446057f9be0b9826251c2aecafbf145", size = 5884753, upload-time = "2026-06-12T03:08:20.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
-    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/9237c6a96356612dd0393db1e94cf21f903616adf3a3701bf3da6e4adc92/ty-0.0.49-py3-none-linux_armv6l.whl", hash = "sha256:12c0c4310b936d762a8586c210b53d4fa4bb361a04429afa89bf84b922e5e065", size = 11834671, upload-time = "2026-06-12T03:07:53.062Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/15/daf5a14a5e07012277d450c75325c94614e2acfec4c620c881486118c410/ty-0.0.49-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:737bfdc2caf9712a8580944dcdc80a450a37a4f2bc83c8fa9b7433b374f9e471", size = 11589570, upload-time = "2026-06-12T03:08:25.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/58/30bdf98436488aca25f0763bf7f92a061528d42461b686453029e845e4c5/ty-0.0.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab90c1baf3b1701d282fce4b02fa552a962d109f8972c46ef6b22429503bfea4", size = 10985236, upload-time = "2026-06-12T03:08:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/22/45/ece503e4a1396e13a1a9a0cde51afe476a6506a1d557eeadf8ad45c83bc0/ty-0.0.49-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ce8ecf6ba6fc79bd137cc0557a754f7e5f2dfe9436412551d480d680e248ad", size = 11504302, upload-time = "2026-06-12T03:08:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dc/5d09333d289dfbca1804eaade125c9e8a1a992a2a592a8b80c5e9b589ca9/ty-0.0.49-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10d85c6865c984e78661e0bd20b180514b4a289739224e84816e342bdf381e04", size = 11626629, upload-time = "2026-06-12T03:08:06.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/155f41c9dd7237c4b609211f29f77755a139ee6218605dadc7fe21d5e3c8/ty-0.0.49-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d96a67a206619e01fa92f35a22267ec634bba62be24b1d0e947020cc179995b", size = 12074481, upload-time = "2026-06-12T03:08:09.643Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4c/998ee13cd5045f1f8b36982de7343163832ac53f27debe01b0de0e8bd968/ty-0.0.49-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de9f648564e0a66344ef397770387cb0d093735f8679d2c5a08a4741e79814d", size = 12678042, upload-time = "2026-06-12T03:08:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/9a505aba85c41ce54cbcaa14f8d79aa084b86151d2d70df11c4655b92898/ty-0.0.49-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5779179ab397d15f8c9dbb8f506ec1b1745f54eac639982f76ef3ce538943b50", size = 12316194, upload-time = "2026-06-12T03:08:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/ded37fb93503294abbc83c36470bb1413bea05048b745881d4470b518a06/ty-0.0.49-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792d4974e93cc09bd32f934586080bbbe21b8e777099cb521cb2de18b68a49f0", size = 12145507, upload-time = "2026-06-12T03:07:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/392e80d78f02445f695b815bb9eb0fffacda68b03faee38c900f7b990815/ty-0.0.49-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:727bda86deb136073e525c2e78d60e38aedcce5d80579170844a52bbf7c1440d", size = 12365967, upload-time = "2026-06-12T03:08:12.553Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/31b0c2a7fbedd3373e389cb1d81b8d2128f6f868fafb46557736a6f9aca8/ty-0.0.49-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4f2fc2bc4a8d2ff1cca59fd94772cabdfec4062d47a0b3a0784be46d94d0540b", size = 11475283, upload-time = "2026-06-12T03:08:28.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5b/329e101638920b468a3bb63059c9f66ef99b44aac501222c44832a507321/ty-0.0.49-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3724bd9badef333321578b6a941fbc571ebf49141ec2356a8590fbe4c9aa588d", size = 11645343, upload-time = "2026-06-12T03:08:15.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/c897e615e32f80ca81c8c1bc49b9a1f72ff9e3cfea0f8345ba505fe28472/ty-0.0.49-py3-none-musllinux_1_2_i686.whl", hash = "sha256:166c6eb52ee4af3c5a9bb267d165d93000daa55c6758cd8ff3199741fb75917d", size = 11725585, upload-time = "2026-06-12T03:08:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/fdb42ee239f618800842681af5bb8598117e74512c10974a8b7b9086a898/ty-0.0.49-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:91e81d832c287b05782ee32eb1b801f62c1fa08df37d589d2b88c3f1d51c9731", size = 12237261, upload-time = "2026-06-12T03:08:31.105Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0f/a2d6a5fc9d0786cbeb3c200786da4e18c203589be3984bb5def83ca92320/ty-0.0.49-py3-none-win32.whl", hash = "sha256:7186af5ca9829d1f5d8916bcf767b8e819bfbf61b1b8ec843bb3fc699cb502e1", size = 11100789, upload-time = "2026-06-12T03:07:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9d/473ac8bc57b5a2d121da893bf9dd74a118efb19a01d711df1a6e397f05cc/ty-0.0.49-py3-none-win_amd64.whl", hash = "sha256:ae2142fc126a01effcca0c222908b0e6654b5ba1266d4e4d406e4866aef8e1d1", size = 12204644, upload-time = "2026-06-12T03:08:04.327Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a2/8959249da951ba3977fee20e688d28678b8a1d30a9ed4464228a85d45853/ty-0.0.49-py3-none-win_arm64.whl", hash = "sha256:75d5e2e7649765f31f4bed6c8adb149a75b18edd3fa6336dac4d0efc1a66466f", size = 11558965, upload-time = "2026-06-12T03:08:23.012Z" },
 ]
 
 [[package]]
@@ -3660,6 +3667,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/f3/2427775f80cd5e19a0a71ba8e5ab7645a01a852f43a5fd0ffc24f66338e0/types_python_dateutil-2.9.0.20260408.tar.gz", hash = "sha256:8b056ec01568674235f64ecbcef928972a5fac412f5aab09c516dfa2acfbb582", size = 16981, upload-time = "2026-04-08T04:28:10.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/c6/eeba37bfee282a6a97f889faef9352d6172c6a5088eb9a4daf570d9d748d/types_python_dateutil-2.9.0.20260408-py3-none-any.whl", hash = "sha256:473139d514a71c9d1fbd8bb328974bedcb1cc3dba57aad04ffa4157f483c216f", size = 18437, upload-time = "2026-04-08T04:28:10.095Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]
@@ -3721,16 +3740,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.40.0"
+version = "0.49.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c3/d1/8f3c683c9561a4e6689dd3b1d345c815f10f86acd044ee1fb9a4dcd0b8c5/uvicorn-0.40.0.tar.gz", hash = "sha256:839676675e87e73694518b5574fd0f24c9d97b46bea16df7b8c05ea1a51071ea", size = 81761, upload-time = "2025-12-21T14:16:22.45Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/c4/1f/fa18009dea8469069cca78a4e877a008ab78f08b064bfc9ab891579077ff/uvicorn-0.49.0.tar.gz", hash = "sha256:ebf4271aa580d9de97f93192d4595176df6e91f9aae919ca73e4fc07df1e66a3", size = 91284, upload-time = "2026-06-03T22:01:30.448Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/3d/d8/2083a1daa7439a66f3a48589a57d576aa117726762618f6bb09fe3798796/uvicorn-0.40.0-py3-none-any.whl", hash = "sha256:c6c8f55bc8bf13eb6fa9ff87ad62308bbbc33d0b67f84293151efe87e0d5f2ee", size = 68502, upload-time = "2025-12-21T14:16:21.041Z" },
+    { url = "https://files.pythonhosted.org/packages/88/fa/e1388bbcf24ef3274f45c0c1c7b501fd14971037c1b6ee23610553307497/uvicorn-0.49.0-py3-none-any.whl", hash = "sha256:ba3d14c3ee7e41c6c654c46c9eb489d33213cdd30aa1696eab1374337c13f68f", size = 71376, upload-time = "2026-06-03T22:01:29.037Z" },
 ]
 
 [[package]]

--- a/openbb_platform/core/openbb_core/api/app_loader.py
+++ b/openbb_platform/core/openbb_core/api/app_loader.py
@@ -6,6 +6,7 @@ from pydantic import ValidationError
 
 from openbb_core.api.exception_handlers import ExceptionHandlers
 from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_core.app.route_iter import iter_included_routers
 from openbb_core.app.router import RouterLoader
 from openbb_core.provider.utils.errors import EmptyDataError, UnauthorizedError
 
@@ -19,6 +20,7 @@ class AppLoader:
         for router in routers:
             if router:
                 app.include_router(router=router, prefix=prefix)
+        AppLoader.deduplicate_router_event_handlers(app)
 
     @staticmethod
     def add_openapi_tags(app: FastAPI):
@@ -36,9 +38,20 @@ class AppLoader:
     @staticmethod
     def add_exception_handlers(app: FastAPI):
         """Add exception handlers."""
-        app.exception_handlers[Exception] = ExceptionHandlers.exception
-        app.exception_handlers[ValidationError] = ExceptionHandlers.validation
-        app.exception_handlers[ResponseValidationError] = ExceptionHandlers.validation
-        app.exception_handlers[OpenBBError] = ExceptionHandlers.openbb
-        app.exception_handlers[EmptyDataError] = ExceptionHandlers.empty_data
-        app.exception_handlers[UnauthorizedError] = ExceptionHandlers.unauthorized
+        app.add_exception_handler(Exception, ExceptionHandlers.exception)
+        app.add_exception_handler(ValidationError, ExceptionHandlers.validation)  # ty: ignore[invalid-argument-type]
+        app.add_exception_handler(ResponseValidationError, ExceptionHandlers.validation)  # ty: ignore[invalid-argument-type]
+        app.add_exception_handler(OpenBBError, ExceptionHandlers.openbb)  # ty: ignore[invalid-argument-type]
+        app.add_exception_handler(EmptyDataError, ExceptionHandlers.empty_data)  # ty: ignore[invalid-argument-type]
+        app.add_exception_handler(UnauthorizedError, ExceptionHandlers.unauthorized)  # ty: ignore[invalid-argument-type]
+
+    @staticmethod
+    def deduplicate_router_event_handlers(app: FastAPI) -> None:
+        """Clear startup/shutdown handlers on included routers after assembly."""
+        for included in iter_included_routers(app.router):
+            on_startup = getattr(included, "on_startup", None)
+            on_shutdown = getattr(included, "on_shutdown", None)
+            if isinstance(on_startup, list):
+                on_startup.clear()
+            if isinstance(on_shutdown, list):
+                on_shutdown.clear()

--- a/openbb_platform/core/openbb_core/api/rest_api.py
+++ b/openbb_platform/core/openbb_core/api/rest_api.py
@@ -65,6 +65,7 @@ app = FastAPI(
         for s in system.api_settings.servers
     ],
     lifespan=lifespan,
+    strict_content_type=False,
 )
 app.add_middleware(
     CORSMiddleware,

--- a/openbb_platform/core/openbb_core/api/router/commands.py
+++ b/openbb_platform/core/openbb_core/api/router/commands.py
@@ -19,6 +19,7 @@ from openbb_core.app.model.abstract.error import OpenBBError
 from openbb_core.app.model.command_context import CommandContext
 from openbb_core.app.model.obbject import OBBject
 from openbb_core.app.model.user_settings import UserSettings
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_core.app.router import RouterLoader
 from openbb_core.app.service.auth_service import AuthService
 from openbb_core.app.service.system_service import SystemService
@@ -353,9 +354,16 @@ def build_api_wrapper(
 def add_command_map(command_runner: CommandRunner, api_router: APIRouter) -> None:
     """Add command map to the API router."""
     plugins_router = RouterLoader.from_extensions()
-
-    for route in plugins_router.api_router.routes:
-        route.endpoint = build_api_wrapper(command_runner=command_runner, route=route)  # type: ignore # noqa
+    for effective in iter_api_routes(plugins_router.api_router):
+        leaf = getattr(effective, "original_route", effective)
+        if not isinstance(leaf, APIRoute):
+            continue
+        original_leaf_path = leaf.path
+        leaf.path = effective.path
+        try:
+            leaf.endpoint = build_api_wrapper(command_runner=command_runner, route=leaf)
+        finally:
+            leaf.path = original_leaf_path
     api_router.include_router(router=plugins_router.api_router)
 
 

--- a/openbb_platform/core/openbb_core/app/route_iter.py
+++ b/openbb_platform/core/openbb_core/app/route_iter.py
@@ -1,0 +1,35 @@
+"""Route iteration helpers."""
+
+from collections.abc import Iterator
+from typing import Any
+
+from fastapi.routing import APIRoute
+
+_IncludedRouter: type | None = None
+try:  # noqa: SIM105
+    from fastapi.routing import (
+        _IncludedRouter,  # type: ignore[attr-defined,no-redef]
+    )
+except ImportError:  # pragma: no cover
+    pass
+
+
+def iter_api_routes(router: Any) -> Iterator:
+    """Yield prefix-resolved route descriptors from a router or app."""
+    if not hasattr(router, "routes"):
+        return
+    for route in router.routes:
+        if _IncludedRouter is not None and isinstance(route, _IncludedRouter):
+            yield from route.effective_route_contexts()
+        elif isinstance(route, APIRoute):
+            yield route
+
+
+def iter_included_routers(router: Any) -> Iterator:
+    """Yield every original ``APIRouter`` reachable through ``include_router``."""
+    if not hasattr(router, "routes") or _IncludedRouter is None:
+        return
+    for route in router.routes:
+        if isinstance(route, _IncludedRouter):
+            yield route.original_router
+            yield from iter_included_routers(route.original_router)

--- a/openbb_platform/core/openbb_core/app/router.py
+++ b/openbb_platform/core/openbb_core/app/router.py
@@ -29,6 +29,7 @@ from openbb_core.app.provider_interface import (
     ProviderInterface,
     StandardParams,
 )
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_core.env import Env
 
 P = ParamSpec("P")
@@ -430,7 +431,9 @@ class CommandMap:
     ) -> dict[str, Callable]:
         """Get command map."""
         api_router = router.api_router
-        command_map = {route.path: route.endpoint for route in api_router.routes}  # type: ignore
+        command_map = {
+            route.path: route.endpoint for route in iter_api_routes(api_router)
+        }
         return command_map
 
     @staticmethod
@@ -443,7 +446,7 @@ class CommandMap:
         mapping = ProviderInterface().map
 
         coverage_map: dict[Any, Any] = {}
-        for route in api_router.routes:
+        for route in iter_api_routes(api_router):
             openapi_extra = getattr(route, "openapi_extra", None)
             if openapi_extra:
                 model = openapi_extra.get("model", None)
@@ -458,7 +461,7 @@ class CommandMap:
                             rp = (
                                 route.path
                                 if sep is None
-                                else route.path.replace("/", sep)  # type: ignore
+                                else route.path.replace("/", sep)
                             )
                             coverage_map[provider].append(rp)
 
@@ -474,7 +477,7 @@ class CommandMap:
         mapping = ProviderInterface().map
 
         coverage_map: dict[Any, Any] = {}
-        for route in api_router.routes:
+        for route in iter_api_routes(api_router):
             openapi_extra = getattr(route, "openapi_extra")
             if openapi_extra:
                 model = openapi_extra.get("model", None)
@@ -484,7 +487,7 @@ class CommandMap:
                         providers.remove("openbb")
 
                     if hasattr(route, "path"):
-                        rp = route.path if sep is None else route.path.replace("/", sep)  # type: ignore
+                        rp = route.path if sep is None else route.path.replace("/", sep)
                         if route.path not in coverage_map:
                             coverage_map[rp] = []
                         coverage_map[rp] = providers
@@ -496,12 +499,12 @@ class CommandMap:
         api_router = router.api_router
 
         coverage_map: dict[Any, Any] = {}
-        for route in api_router.routes:
+        for route in iter_api_routes(api_router):
             openapi_extra = getattr(route, "openapi_extra")
             if openapi_extra:
                 model = openapi_extra.get("model", None)
                 if model and hasattr(route, "path"):
-                    rp = route.path if sep is None else route.path.replace("/", sep)  # type: ignore
+                    rp = route.path if sep is None else route.path.replace("/", sep)
                     if route.path not in coverage_map:
                         coverage_map[rp] = []
                     coverage_map[rp] = model

--- a/openbb_platform/core/openbb_core/app/static/package_builder/path_handler.py
+++ b/openbb_platform/core/openbb_core/app/static/package_builder/path_handler.py
@@ -6,9 +6,9 @@ from typing import (
     TypeVar,
 )
 
-from fastapi.routing import APIRoute
 from starlette.routing import BaseRoute
 
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_core.app.router import RouterLoader
 
 if TYPE_CHECKING:
@@ -83,41 +83,16 @@ class PathHandler:
     def build_route_map() -> dict[str, BaseRoute]:
         """Build the route map."""
         router = RouterLoader.from_extensions()
-        route_map = {
-            route.path: route
-            for route in router.api_router.routes
-            if isinstance(route, APIRoute)
-            and "." not in str(route.path)
-            and getattr(route, "include_in_schema", True)
-        }
-
-        # Also include routes directly registered on _api_router instances
-        # We need to traverse the router tree to find all _api_router instances
-        def collect_api_router_routes(router_obj, collected_routes):
-            """Recursively collect routes from _api_router instances."""
-            if hasattr(router_obj, "_api_router"):
-                for inner_route in router_obj._api_router.routes:
-                    if (
-                        isinstance(inner_route, APIRoute)
-                        and getattr(inner_route, "include_in_schema", True)
-                        and (inner_route.path not in collected_routes)
-                    ):
-                        collected_routes[inner_route.path] = inner_route
-
-            # Check if this router has sub-routers
-            if hasattr(router_obj, "api_router") and hasattr(
-                router_obj.api_router, "routes"
-            ):
-                for route in router_obj.api_router.routes:
-                    if not isinstance(route, APIRoute):
-                        continue
-                    endpoint = getattr(route, "endpoint", None)
-                    if endpoint and hasattr(endpoint, "__self__"):
-                        collect_api_router_routes(endpoint.__self__, collected_routes)
-
-        collect_api_router_routes(router, route_map)
-
-        return route_map  # type: ignore
+        route_map: dict[str, BaseRoute] = {}
+        for route in iter_api_routes(router.api_router):
+            path = getattr(route, "path", None)
+            if path is None:
+                continue
+            if not getattr(route, "include_in_schema", True):
+                continue
+            if path not in route_map:
+                route_map[path] = route  # type: ignore[assignment]
+        return route_map
 
     @staticmethod
     def build_path_list(route_map: dict[str, BaseRoute]) -> list[str]:

--- a/openbb_platform/core/tests/api/test_rest_api.py
+++ b/openbb_platform/core/tests/api/test_rest_api.py
@@ -19,6 +19,7 @@ from fastapi.testclient import TestClient
 
 from openbb_core.api import rest_api
 from openbb_core.api.rest_api import app, system
+from openbb_core.app.route_iter import iter_api_routes
 
 
 def test_openapi_schema_metadata_matches_system_settings():
@@ -71,7 +72,7 @@ def test_router_inclusion_invariant_commands_imply_coverage():
     The invariant we test: if there exists any command route, coverage
     routes must exist. This catches accidental removal of the conditional.
     """
-    paths = {getattr(r, "path", None) for r in app.routes}
+    paths = {getattr(r, "path", None) for r in iter_api_routes(app)}
     prefix = system.api_settings.prefix
 
     coverage_paths = {

--- a/openbb_platform/core/tests/api/test_router/test_commands_helpers.py
+++ b/openbb_platform/core/tests/api/test_router/test_commands_helpers.py
@@ -432,5 +432,10 @@ def test_add_command_map_wraps_and_includes_plugin_routes(monkeypatch):
     api_router = APIRouter()
     add_command_map(MagicMock(spec=CommandRunner), api_router)
 
+    from openbb_core.app.route_iter import iter_api_routes
+
     assert plugins_api_router.routes[0].endpoint is wrapped
-    assert any(getattr(route, "path", None) == "/plugin" for route in api_router.routes)
+    assert any(
+        getattr(route, "path", None) == "/plugin"
+        for route in iter_api_routes(api_router)
+    )

--- a/openbb_platform/core/tests/app/static/package_builder/test_method_definition_helpers.py
+++ b/openbb_platform/core/tests/app/static/package_builder/test_method_definition_helpers.py
@@ -1457,8 +1457,13 @@ def test_build_command_method_getsource_typeerror(monkeypatch):
     monkeypatch.setattr(
         MethodDefinition, "is_deprecated_function", staticmethod(lambda p: False)
     )
-    monkeypatch.setattr(
-        md.inspect, "getsource", lambda _f: (_ for _ in ()).throw(TypeError("x"))
-    )
+    real_getsource = md.inspect.getsource
+
+    def _patched_getsource(obj):
+        if obj is endpoint:
+            raise TypeError("x")
+        return real_getsource(obj)
+
+    monkeypatch.setattr(md.inspect, "getsource", _patched_getsource)
     code = MethodDefinition.build_command_method("/x/y", endpoint)
     assert "def y" in code

--- a/openbb_platform/core/tests/app/static/test_package_builder_dependencies.py
+++ b/openbb_platform/core/tests/app/static/test_package_builder_dependencies.py
@@ -154,7 +154,9 @@ def router_with_router_level_dep(monkeypatch, fake_router):
 
 def _resolve_test_path(router: Router) -> str:
     """Return the single registered sub-route path under ``/test``."""
-    routes = router.routers["test"].api_router.routes
+    from openbb_core.app.route_iter import iter_api_routes
+
+    routes = list(iter_api_routes(router.routers["test"].api_router))
     assert routes, "fake_router has no sub-routes"
     return f"/test{routes[0].path}"
 

--- a/openbb_platform/core/tests/app/test_command_output_extensions_e2e.py
+++ b/openbb_platform/core/tests/app/test_command_output_extensions_e2e.py
@@ -292,12 +292,9 @@ async def test_command_runner_results_only_extension_sets_flag(
 
 
 def _build_app_with_real_command_router(fake_router: Router) -> FastAPI:
-    """Build a FastAPI app whose routes are wrapped by the real ``build_api_wrapper``.
-
-    Mirrors ``openbb_core.api.router.commands.add_command_map`` but driven from
-    the in-memory ``fake_router`` (so we don't depend on real installed extensions).
-    """
+    """Build a FastAPI app whose routes are wrapped by ``build_api_wrapper``."""
     from openbb_core.api.router.commands import build_api_wrapper
+    from openbb_core.app.route_iter import iter_api_routes
 
     runner = CommandRunner(
         command_map=CommandMap(router=fake_router),
@@ -306,10 +303,16 @@ def _build_app_with_real_command_router(fake_router: Router) -> FastAPI:
     )
 
     api_router = APIRouter()
-    for route in fake_router.api_router.routes:
-        route.endpoint = build_api_wrapper(  # type: ignore[attr-defined]
-            command_runner=runner, route=route
-        )
+    for effective in iter_api_routes(fake_router.api_router):
+        leaf = getattr(effective, "original_route", effective)
+        original_leaf_path = leaf.path
+        leaf.path = effective.path
+        try:
+            leaf.endpoint = build_api_wrapper(  # type: ignore[attr-defined]
+                command_runner=runner, route=leaf
+            )
+        finally:
+            leaf.path = original_leaf_path
     api_router.include_router(router=fake_router.api_router)
 
     app = FastAPI()

--- a/openbb_platform/core/uv.lock
+++ b/openbb_platform/core/uv.lock
@@ -1700,6 +1700,7 @@ name = "openbb-devtools"
 version = "2.0.0"
 source = { editable = "../extensions/devtools" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "codespell" },
     { name = "ipykernel" },
     { name = "pre-commit" },
@@ -1715,11 +1716,13 @@ dependencies = [
     { name = "tox" },
     { name = "ty" },
     { name = "types-python-dateutil" },
+    { name = "types-requests" },
     { name = "types-toml" },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "aiohttp", specifier = "<3.14" },
     { name = "codespell", specifier = ">=2.2.5,<3.0.0" },
     { name = "ipykernel", specifier = ">=6.30.1" },
     { name = "pre-commit", specifier = ">=3.5.0,<4.0.0" },
@@ -1733,8 +1736,9 @@ requires-dist = [
     { name = "pytest-subtests", specifier = ">=0.11.0,<1.0.0" },
     { name = "ruff", specifier = ">=0.15,<0.16" },
     { name = "tox", specifier = ">=4.11.3,<5.0.0" },
-    { name = "ty", specifier = ">=0.0.1a14" },
+    { name = "ty", specifier = ">=0.0.40" },
     { name = "types-python-dateutil", specifier = ">=2.8.19.14,<3.0.0" },
+    { name = "types-requests", specifier = ">=2.32,<3.0.0" },
     { name = "types-toml", specifier = ">=0.10.8.7,<1.0.0" },
 ]
 
@@ -2965,26 +2969,27 @@ wheels = [
 
 [[package]]
 name = "ty"
-version = "0.0.33"
+version = "0.0.49"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/84/44/9478c50c266826c1bf30d1692e589755bffa8f1c0a3eb7af8a346c255991/ty-0.0.33.tar.gz", hash = "sha256:46d63bda07403322cb6c28ccfdd5536be916e13df725c29f7ccd0a21f06bd9e8", size = 5559373, upload-time = "2026-04-28T10:45:13.18Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/1d/8d/37cb91808069509d43a2a11743e12f1e854fd808dbef2203309d256718cd/ty-0.0.49.tar.gz", hash = "sha256:0a027bd0c9c75d035641a365d087ad883446057f9be0b9826251c2aecafbf145", size = 5884753, upload-time = "2026-06-12T03:08:20.221Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e9/24/e287388c63a19191be26b32ff4dbd06029834068150ebe2532939bc4c851/ty-0.0.33-py3-none-linux_armv6l.whl", hash = "sha256:94d0a9d2234261a8911396d59e506b5923fe0971dbda43b9dcea287936887fcc", size = 11021308, upload-time = "2026-04-28T10:45:43.34Z" },
-    { url = "https://files.pythonhosted.org/packages/00/ca/ba1eed819895bd239fba8ee35dfcd5fcb266c203b0914a17a59579096bb5/ty-0.0.33-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:e4a2b5ba078f90de342f56b5f7979bb77c9b9b1d8625a041352ffc6ee93c4073", size = 10777272, upload-time = "2026-04-28T10:45:32.905Z" },
-    { url = "https://files.pythonhosted.org/packages/25/a8/c3131d37b44b3fea1d6654a1c929a0cd0873822f77a90482b8ec28f6fbbd/ty-0.0.33-py3-none-macosx_11_0_arm64.whl", hash = "sha256:84ff5707825e9af9668d2bcf66975f93e520a63b524ab494e3a8265735be2563", size = 10201078, upload-time = "2026-04-28T10:45:23.374Z" },
-    { url = "https://files.pythonhosted.org/packages/7b/db/d8e37ff0045810cc65e1ff36aa0da0a2253c05659787ac987df8a16c7897/ty-0.0.33-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e375285736f57886868e7af0b11c7b0ec5b6543fa15e7ad2a714fed9f077d4e0", size = 10732347, upload-time = "2026-04-28T10:45:21.444Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/1a/20e83a412506a918e4684fc67b567cf7cc13b105470b3428cb23c3d5aa13/ty-0.0.33-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:5680f6350c3b4e46b8bff6d7bb132366ea239463d6cad4892725d06046e65464", size = 10808238, upload-time = "2026-04-28T10:45:38.565Z" },
-    { url = "https://files.pythonhosted.org/packages/5d/4b/d0a39f4464dc6cb4cc2c159473ce216bd1846bfb684c0323a3cb36dce5c6/ty-0.0.33-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:c5535538bad8d0f7e62bcdff02197cdb30e41451d80b35d27e17d128f2e1dc5d", size = 11288348, upload-time = "2026-04-28T10:45:08.419Z" },
-    { url = "https://files.pythonhosted.org/packages/35/7e/f1745e0f9583363d7a83d9a4990fc244f76ecc30840ddad83dc16a33c52d/ty-0.0.33-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:da196c42bbbc069e1e21e3e52107c061aa9660352dae57a41930690b56e2c02d", size = 11789907, upload-time = "2026-04-28T10:45:19.064Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/71/25f39f46a12d662859d45bc648555d0661044eb43db6b5648c9947487da9/ty-0.0.33-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9281672921ef6d4460e03146b5e6c18cb1a3e3a3b8a1a88f6f33226d05a469b7", size = 11500774, upload-time = "2026-04-28T10:45:48.012Z" },
-    { url = "https://files.pythonhosted.org/packages/94/ec/136959ecbb7c71cb90537f5aea441c73f4ab24612868a6ecdc9d7444d32d/ty-0.0.33-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:82c1b8f303f82da64e878108e764be3ecbcd7c9903ac0a7f7031614ed00b97ab", size = 11360314, upload-time = "2026-04-28T10:45:05.402Z" },
-    { url = "https://files.pythonhosted.org/packages/cf/95/32809575c222f00beed498cb728e9290a0f5009f930025381bb7253b2206/ty-0.0.33-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:efe3af412c9ff67bce5fa37d0a2b0d8555c24072b145a5bac6c79637f1c83abe", size = 10707785, upload-time = "2026-04-28T10:45:10.836Z" },
-    { url = "https://files.pythonhosted.org/packages/13/89/c8e9531f7aa4a093359e15fa32c8e1277fbbe90d16894d7c6032d29f4b34/ty-0.0.33-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:aeec29c91ea768601747da546c3efc20b72c2fb1bd52bcc786a5c6eeff51d27b", size = 10834987, upload-time = "2026-04-28T10:45:40.738Z" },
-    { url = "https://files.pythonhosted.org/packages/31/16/9835fbcf5338af1a1917bd28fdb8a7193c210b83f243aa286fa9f79cb3ad/ty-0.0.33-py3-none-musllinux_1_2_i686.whl", hash = "sha256:a535977c52bbb5f7e96b8b70a6ad375ad077f4a9ff2492508ea3816a2b403819", size = 10968968, upload-time = "2026-04-28T10:45:30.26Z" },
-    { url = "https://files.pythonhosted.org/packages/36/69/64c76aabc1bc70c7f24b686cd93c3407f8ea430905e395f59bf9603ef571/ty-0.0.33-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1d732facf39fcb221ba279d469c5040d37883e964f123b1563888efd34818180", size = 11458077, upload-time = "2026-04-28T10:45:45.971Z" },
-    { url = "https://files.pythonhosted.org/packages/91/84/fae27b0c4718776a298690d31ca4cc1995f2e3e1c63a7b59e84c41498e9a/ty-0.0.33-py3-none-win32.whl", hash = "sha256:d90960b574428dc252f85e8598ec5fcb7f619794196b2fc95a90da075ed4681c", size = 10345364, upload-time = "2026-04-28T10:45:16.836Z" },
-    { url = "https://files.pythonhosted.org/packages/3c/a0/a2938b23ae3e1a09a2d7c189e2ac5f7113676bae4e0e23948b568e18e5f8/ty-0.0.33-py3-none-win_amd64.whl", hash = "sha256:c1c3aec62c44de610c6e95f0a4e97ac3dbc07934bfdbf1fd90d758c9ff72f48e", size = 11342470, upload-time = "2026-04-28T10:45:26.455Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/62/7fb948aace38d2f6329261bb33c035a8484549c74f1db28649c7a4c6fed9/ty-0.0.33-py3-none-win_arm64.whl", hash = "sha256:0d44f99ba1b441e55e2aa301b2ac0a21112784931b46a5f66f4ea9efe5620d97", size = 10742673, upload-time = "2026-04-28T10:45:35.555Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/de/9237c6a96356612dd0393db1e94cf21f903616adf3a3701bf3da6e4adc92/ty-0.0.49-py3-none-linux_armv6l.whl", hash = "sha256:12c0c4310b936d762a8586c210b53d4fa4bb361a04429afa89bf84b922e5e065", size = 11834671, upload-time = "2026-06-12T03:07:53.062Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/15/daf5a14a5e07012277d450c75325c94614e2acfec4c620c881486118c410/ty-0.0.49-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:737bfdc2caf9712a8580944dcdc80a450a37a4f2bc83c8fa9b7433b374f9e471", size = 11589570, upload-time = "2026-06-12T03:08:25.779Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/58/30bdf98436488aca25f0763bf7f92a061528d42461b686453029e845e4c5/ty-0.0.49-py3-none-macosx_11_0_arm64.whl", hash = "sha256:ab90c1baf3b1701d282fce4b02fa552a962d109f8972c46ef6b22429503bfea4", size = 10985236, upload-time = "2026-06-12T03:08:36.664Z" },
+    { url = "https://files.pythonhosted.org/packages/22/45/ece503e4a1396e13a1a9a0cde51afe476a6506a1d557eeadf8ad45c83bc0/ty-0.0.49-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:b4ce8ecf6ba6fc79bd137cc0557a754f7e5f2dfe9436412551d480d680e248ad", size = 11504302, upload-time = "2026-06-12T03:08:01.664Z" },
+    { url = "https://files.pythonhosted.org/packages/17/dc/5d09333d289dfbca1804eaade125c9e8a1a992a2a592a8b80c5e9b589ca9/ty-0.0.49-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:10d85c6865c984e78661e0bd20b180514b4a289739224e84816e342bdf381e04", size = 11626629, upload-time = "2026-06-12T03:08:06.844Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/36/155f41c9dd7237c4b609211f29f77755a139ee6218605dadc7fe21d5e3c8/ty-0.0.49-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:1d96a67a206619e01fa92f35a22267ec634bba62be24b1d0e947020cc179995b", size = 12074481, upload-time = "2026-06-12T03:08:09.643Z" },
+    { url = "https://files.pythonhosted.org/packages/96/4c/998ee13cd5045f1f8b36982de7343163832ac53f27debe01b0de0e8bd968/ty-0.0.49-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:3de9f648564e0a66344ef397770387cb0d093735f8679d2c5a08a4741e79814d", size = 12678042, upload-time = "2026-06-12T03:08:39.319Z" },
+    { url = "https://files.pythonhosted.org/packages/85/c9/9a505aba85c41ce54cbcaa14f8d79aa084b86151d2d70df11c4655b92898/ty-0.0.49-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:5779179ab397d15f8c9dbb8f506ec1b1745f54eac639982f76ef3ce538943b50", size = 12316194, upload-time = "2026-06-12T03:08:18.023Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/b8/ded37fb93503294abbc83c36470bb1413bea05048b745881d4470b518a06/ty-0.0.49-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:792d4974e93cc09bd32f934586080bbbe21b8e777099cb521cb2de18b68a49f0", size = 12145507, upload-time = "2026-06-12T03:07:56.505Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/07/392e80d78f02445f695b815bb9eb0fffacda68b03faee38c900f7b990815/ty-0.0.49-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:727bda86deb136073e525c2e78d60e38aedcce5d80579170844a52bbf7c1440d", size = 12365967, upload-time = "2026-06-12T03:08:12.553Z" },
+    { url = "https://files.pythonhosted.org/packages/50/d3/31b0c2a7fbedd3373e389cb1d81b8d2128f6f868fafb46557736a6f9aca8/ty-0.0.49-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:4f2fc2bc4a8d2ff1cca59fd94772cabdfec4062d47a0b3a0784be46d94d0540b", size = 11475283, upload-time = "2026-06-12T03:08:28.334Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/5b/329e101638920b468a3bb63059c9f66ef99b44aac501222c44832a507321/ty-0.0.49-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:3724bd9badef333321578b6a941fbc571ebf49141ec2356a8590fbe4c9aa588d", size = 11645343, upload-time = "2026-06-12T03:08:15.246Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/76/c897e615e32f80ca81c8c1bc49b9a1f72ff9e3cfea0f8345ba505fe28472/ty-0.0.49-py3-none-musllinux_1_2_i686.whl", hash = "sha256:166c6eb52ee4af3c5a9bb267d165d93000daa55c6758cd8ff3199741fb75917d", size = 11725585, upload-time = "2026-06-12T03:08:33.915Z" },
+    { url = "https://files.pythonhosted.org/packages/59/e1/fdb42ee239f618800842681af5bb8598117e74512c10974a8b7b9086a898/ty-0.0.49-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:91e81d832c287b05782ee32eb1b801f62c1fa08df37d589d2b88c3f1d51c9731", size = 12237261, upload-time = "2026-06-12T03:08:31.105Z" },
+    { url = "https://files.pythonhosted.org/packages/98/0f/a2d6a5fc9d0786cbeb3c200786da4e18c203589be3984bb5def83ca92320/ty-0.0.49-py3-none-win32.whl", hash = "sha256:7186af5ca9829d1f5d8916bcf767b8e819bfbf61b1b8ec843bb3fc699cb502e1", size = 11100789, upload-time = "2026-06-12T03:07:59.092Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/9d/473ac8bc57b5a2d121da893bf9dd74a118efb19a01d711df1a6e397f05cc/ty-0.0.49-py3-none-win_amd64.whl", hash = "sha256:ae2142fc126a01effcca0c222908b0e6654b5ba1266d4e4d406e4866aef8e1d1", size = 12204644, upload-time = "2026-06-12T03:08:04.327Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/a2/8959249da951ba3977fee20e688d28678b8a1d30a9ed4464228a85d45853/ty-0.0.49-py3-none-win_arm64.whl", hash = "sha256:75d5e2e7649765f31f4bed6c8adb149a75b18edd3fa6336dac4d0efc1a66466f", size = 11558965, upload-time = "2026-06-12T03:08:23.012Z" },
 ]
 
 [[package]]
@@ -2994,6 +2999,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/88/f3/2427775f80cd5e19a0a71ba8e5ab7645a01a852f43a5fd0ffc24f66338e0/types_python_dateutil-2.9.0.20260408.tar.gz", hash = "sha256:8b056ec01568674235f64ecbcef928972a5fac412f5aab09c516dfa2acfbb582", size = 16981, upload-time = "2026-04-08T04:28:10.995Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/fd/c6/eeba37bfee282a6a97f889faef9352d6172c6a5088eb9a4daf570d9d748d/types_python_dateutil-2.9.0.20260408-py3-none-any.whl", hash = "sha256:473139d514a71c9d1fbd8bb328974bedcb1cc3dba57aad04ffa4157f483c216f", size = 18437, upload-time = "2026-04-08T04:28:10.095Z" },
+]
+
+[[package]]
+name = "types-requests"
+version = "2.33.0.20260518"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "urllib3" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/e0/01/c5a19253fe1ac159159ddf9a3a07cec8bb5e486ec4d9002ad2821da0e5d2/types_requests-2.33.0.20260518.tar.gz", hash = "sha256:df7bd3bfe0ca8402dfb841e7d9be714bb5578203283d66d7dc4ef69343449a5e", size = 24752, upload-time = "2026-05-18T06:07:37.966Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/1c/bc/b139710a3b6018f7fb2b9508b35c8af564e61bf2bf4fa619d088f3e16f85/types_requests-2.33.0.20260518-py3-none-any.whl", hash = "sha256:626d697d1adaaff76e2044dc8c5c051d8f21abc157bdfe204a75558076fe0bf0", size = 21391, upload-time = "2026-05-18T06:07:37.044Z" },
 ]
 
 [[package]]

--- a/openbb_platform/extensions/news/tests/test_router.py
+++ b/openbb_platform/extensions/news/tests/test_router.py
@@ -1,5 +1,6 @@
 """Router tests."""
 
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_core.app.router import Router
 
 from openbb_news.router import router
@@ -7,7 +8,7 @@ from openbb_news.router import router
 
 def test_router_aggregates_rss_commands():
     assert isinstance(router, Router)
-    paths = {getattr(route, "path", "") for route in router.api_router.routes}
+    paths = {getattr(route, "path", "") for route in iter_api_routes(router.api_router)}
     assert "/rss" in paths
     assert "/rss_providers" in paths
     assert "/rss_feeds" in paths
@@ -16,7 +17,7 @@ def test_router_aggregates_rss_commands():
 def test_router_aggregates_provider_news_commands():
     from openbb_core.app.provider_interface import ProviderInterface
 
-    paths = {getattr(route, "path", "") for route in router.api_router.routes}
+    paths = {getattr(route, "path", "") for route in iter_api_routes(router.api_router)}
     model_map = ProviderInterface().map
     if "CompanyNews" in model_map:
         assert "/company" in paths

--- a/openbb_platform/extensions/quantitative/tests/test_router.py
+++ b/openbb_platform/extensions/quantitative/tests/test_router.py
@@ -33,7 +33,9 @@ EXPECTED_ROUTES = {
 
 def test_router_aggregates_every_command():
     """The top-level router wires every quantitative command exactly once."""
+    from openbb_core.app.route_iter import iter_api_routes
+
     assert isinstance(router, Router)
-    paths = [r.path for r in router.api_router.routes]
+    paths = [r.path for r in iter_api_routes(router.api_router)]
     assert set(paths) == EXPECTED_ROUTES
     assert len(paths) == len(EXPECTED_ROUTES)

--- a/openbb_platform/extensions/technical/openbb_technical/multi/catalog.py
+++ b/openbb_platform/extensions/technical/openbb_technical/multi/catalog.py
@@ -5,6 +5,7 @@ import inspect
 from typing import Any, Literal, get_args, get_origin, get_type_hints
 
 from openbb_core.app.model.obbject import OBBject
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_core.app.router import Router
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.abstract.query_params import QueryParams
@@ -374,7 +375,7 @@ def _build_catalog() -> list[IndicatorEntry]:
         if family_router is None:
             continue  # pragma: no cover - every family module exposes ``router``
         candidates = _module_query_params(module)
-        for route in family_router.api_router.routes:
+        for route in iter_api_routes(family_router.api_router):
             endpoint = route.endpoint
             endpoint_name = endpoint.__name__
             query_params = _match_query_params_for(endpoint_name, candidates)

--- a/openbb_platform/extensions/technical/tests/test_router.py
+++ b/openbb_platform/extensions/technical/tests/test_router.py
@@ -2,12 +2,13 @@
 
 from __future__ import annotations
 
+from openbb_core.app.route_iter import iter_api_routes
 from openbb_technical.router import router
 
 
 class TestTopLevelRouter:
     def test_aggregator_exposes_indicator_routes(self):
-        paths = {r.path for r in router.api_router.routes}
+        paths = {r.path for r in iter_api_routes(router.api_router)}
         assert "/sma" in paths
         assert "/rsi" in paths
         assert "/macd" in paths
@@ -19,7 +20,7 @@ class TestTopLevelRouter:
         assert "/relative_rotation" in paths
 
     def test_aggregator_exposes_signal_routes(self):
-        paths = {r.path for r in router.api_router.routes}
+        paths = {r.path for r in iter_api_routes(router.api_router)}
         assert "/signals/crossovers" in paths
         assert "/signals/oscillator_signals" in paths
         assert "/signals/divergences" in paths
@@ -28,7 +29,7 @@ class TestTopLevelRouter:
         assert "/signals/regime" in paths
 
     def test_aggregator_exposes_multi_routes(self):
-        paths = {r.path for r in router.api_router.routes}
+        paths = {r.path for r in iter_api_routes(router.api_router)}
         assert "/multi" in paths
         assert "/screen" in paths
         assert "/correlation" in paths
@@ -36,7 +37,7 @@ class TestTopLevelRouter:
         assert "/indicators" in paths
 
     def test_no_duplicate_paths(self):
-        paths = [r.path for r in router.api_router.routes]
+        paths = [r.path for r in iter_api_routes(router.api_router)]
         assert len(paths) == len(set(paths)), (
             f"Duplicate route registered. Counts: "
             f"{ {p: paths.count(p) for p in set(paths) if paths.count(p) > 1} }"

--- a/openbb_platform/providers/imf/tests/test_imf_router.py
+++ b/openbb_platform/providers/imf/tests/test_imf_router.py
@@ -330,39 +330,45 @@ class TestAppsJson:
 class TestRouterRegistration:
     """Tests confirming the new fetcher endpoints are registered on the router."""
 
+    @staticmethod
+    def _router_paths() -> set[str]:
+        from openbb_core.app.route_iter import iter_api_routes
+
+        return {r.path for r in iter_api_routes(router.api_router)}
+
     def test_country_activity_registered(self):
         """``country_activity`` is reachable through the router's api routes."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/country_activity") for p in paths)
 
     def test_monthly_trade_registered(self):
         """``monthly_trade`` is registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/monthly_trade") for p in paths)
 
     def test_container_metrics_registered(self):
         """``container_metrics`` is registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/container_metrics") for p in paths)
 
     def test_disruption_events_registered(self):
         """``disruption_events`` is registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/disruption_events") for p in paths)
 
     def test_disruptions_map_registered(self):
         """``disruptions_map`` is registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/disruptions_map") for p in paths)
 
     def test_disruption_sankey_registered(self):
         """``disruption_sankey`` is registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/disruption_sankey") for p in paths)
 
     def test_choice_endpoints_registered(self):
         """The 4 ``list_*_choices`` endpoints are registered."""
-        paths = {r.path for r in router.api_router.routes}
+        paths = self._router_paths()
         assert any(p.endswith("/list_country_choices") for p in paths)
         assert any(p.endswith("/list_tradenow_region_choices") for p in paths)
         assert any(p.endswith("/list_container_port_choices") for p in paths)

--- a/openbb_platform/providers/oecd/tests/record/http/test_oecd_fetchers/test_oecd_gdp_forecast_fetcher_urllib3_v2.yaml
+++ b/openbb_platform/providers/oecd/tests/record/http/test_oecd_fetchers/test_oecd_gdp_forecast_fetcher_urllib3_v2.yaml
@@ -5,20 +5,22 @@ interactions:
       Accept:
       - application/vnd.sdmx.data+csv; version=2.0.0; labels=both
     method: GET
-    uri: https://sdmx.oecd.org/public/rest/v2/data/dataflow/OECD.ECO.MAD/DSD_EO%40DF_EO/1.4/USA.GDPV_USD.A?c%5BTIME_PERIOD%5D=ge%3A2023-01%2Cle%3A2024-01&detail=full&dimensionAtObservation=TIME_PERIOD
+    uri: https://sdmx.oecd.org/public/rest/v2/data/dataflow/OECD.ECO.MAD/DSD_EO%40DF_EO/1.5/USA.GDPV_USD.A?c%5BTIME_PERIOD%5D=ge%3A2023-01%2Cle%3A2024-01&detail=full&dimensionAtObservation=TIME_PERIOD
   response:
     body:
       string: "STRUCTURE,STRUCTURE_ID,ACTION,REF_AREA: Reference area,MEASURE: Measure,FREQ:
         Frequency of observation,TIME_PERIOD: Time period,OBS_VALUE,OBS_STATUS: Observation
         status,UNIT_MEASURE: Unit of measure,UNIT_MULT: Unit multiplier,CURRENCY:
         Currency,BASE_PER: Base period,METHODOLOGY: Methodology,DECIMALS: Decimals,PRICE_BASE:
-        Price base,ADJUSTMENT: Adjustment\r\nDATAFLOW,OECD.ECO.MAD:DF_EO(1.4),I,USA:
+        Price base,ADJUSTMENT: Adjustment\r\nDATAFLOW,OECD.ECO.MAD:DSD_EO@DF_EO(1.5),I,USA:
         United States,\"GDPV_USD: Gross domestic product, volume in USD, constant
         exchange rates\",A: Annual,2023,25031611545935,,\"USD_EXC: US dollars, exchange
         rate converted\",0: Units,,2021,,2: Two,L: Chain linked volume,\r\n"
     headers:
+      Age:
+      - '1252'
       CF-RAY:
-      - 9dc5fde08968ef12-YVR
+      - a0cd2df83b6c0b9d-YVR
       Cache-Control:
       - public,max-age=7200
       Connection:
@@ -26,9 +28,9 @@ interactions:
       Content-Language:
       - en,en-US
       Content-Type:
-      - application/vnd.sdmx.data+csv; charset=utf-8; labels=both; version=2.0.0
+      - application/vnd.sdmx.data+csv; version=2.0.0; labels=both; charset=utf-8
       Date:
-      - Sat, 14 Mar 2026 20:22:42 GMT
+      - Tue, 16 Jun 2026 22:16:33 GMT
       Server:
       - cloudflare
       Strict-Transport-Security:
@@ -38,20 +40,20 @@ interactions:
       Vary:
       - X-Range, Accept, Accept-Language, Accept-Encoding, Accept-Charset,Accept,Accept-Encoding,Accept-Encoding
       X-Server-Node:
-      - Server 3
+      - Server 1
       alt-svc:
       - h3=":443"; ma=86400
       api-supported-versions:
       - '2'
       cf-cache-status:
-      - MISS
+      - HIT
       last-modified:
-      - Sat, 14 Mar 2026 20:22:42 GMT
+      - Tue, 16 Jun 2026 21:55:41 GMT
       set-cookie:
-      - __cf_bm=G75AQgFiVwLSvlKsvjZiKXtdc0Q58ycOaiQugSC4mEc-1773519759.4410257-1.0.1.1-OB1cC0N8sNRLFVfKvD8AEYP2GoLxuUKsuw9w50XW.BcUXGB_wLOXuDfJ9Lr0mr1vYvJuej4eSLUbKE8NJ3kAB.rn5OKDFQzD8dQmy0EoCUYQ1xEgH4Lz9OK6G6Zbs1S8;
-        HttpOnly; Secure; Path=/; Domain=oecd.org; Expires=Sat, 14 Mar 2026 20:52:42
-        GMT
-      - _cfuvid=yk2Tj_Lkd0RTJzFZI4iNJHZcpPhvi4k4Sn5zfmbVLwY-1773519759.4410257-1.0.1.1-KD8YGE2bBkrzsyJhG9Y6aYAV_aQnk4z9bxtXieRxo.U;
+      - __cf_bm=KHkYizjjOqn4uHmPavcPhH_Qd07ynlDDslxjp5rxmrc-1781648193.3126335-1.0.1.1-fK0VpMjmWywg9CfWTOO4B0niEO6IfcscD7brdrX6O2Inj9DYmfANGX6XtHjwepq.y5CS3Ln.tLYW8xD9bL9BIQ4Vt4kMoorAOPTYYyREb2va1vcezyJJtlf5qjIkLqnj;
+        HttpOnly; SameSite=None; Secure; Path=/; Domain=oecd.org; Expires=Tue, 16
+        Jun 2026 22:46:33 GMT
+      - _cfuvid=5RbRWPtgwaqTMyMdaI164iuhq9aZZeV1SbNwwOyAkb0-1781648193.3126335-1.0.1.1-jJ_ibeQY0W5eN2p1gTLyeS7jQLjNZIciuNFEkxuTAvo;
         HttpOnly; SameSite=None; Secure; Path=/; Domain=oecd.org
     status:
       code: 200


### PR DESCRIPTION
This PR addresses the breaking changes in FastAPI v0.137+, where `include_router` now preserves `APIRouter`/`APIRoute` instances instead of cloning them. This affects how `openbb-core` introspects routes for building static packages and merging router metadata—the routes appearing in app.routes might now be wrappers rather than copies.

The fix ensures backwards compatibility.