### PR TITLE
feat: add options exposure summary command

### DIFF
--- a/openbb_platform/extensions/derivatives/integration/test_derivatives_api.py
+++ b/openbb_platform/extensions/derivatives/integration/test_derivatives_api.py
@@ -10,6 +10,53 @@ from openbb_core.provider.utils.helpers import get_querystring
 
 # pylint: disable=too-many-lines,redefined-outer-name
 
+SYNTHETIC_OPTIONS_CHAIN = [
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "call",
+        "open_interest": 10,
+        "volume": 5,
+        "delta": 0.6,
+        "gamma": 0.02,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "put",
+        "open_interest": 8,
+        "volume": 4,
+        "delta": -0.4,
+        "gamma": 0.03,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 105,
+        "option_type": "call",
+        "open_interest": 20,
+        "volume": 10,
+        "delta": 0.4,
+        "gamma": 0.01,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 95,
+        "option_type": "put",
+        "open_interest": 12,
+        "volume": 7,
+        "delta": -0.25,
+        "gamma": 0.015,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+]
+
 
 @pytest.fixture(scope="session")
 def headers():
@@ -258,3 +305,25 @@ def test_derivatives_options_surface(params, headers):
     )
     assert isinstance(result, requests.Response)
     assert result.status_code == 200
+
+
+@pytest.mark.integration
+def test_derivatives_options_exposure(headers):
+    """Test the options exposure endpoint."""
+    url = "http://0.0.0.0:8000/api/v1/derivatives/options/exposure?by=strike"
+    result = requests.post(
+        url,
+        headers=headers,
+        timeout=10,
+        json={"data": SYNTHETIC_OPTIONS_CHAIN},
+    )
+
+    assert isinstance(result, requests.Response)
+    assert result.status_code == 200
+
+    payload = result.json()
+    strike_100 = next(row for row in payload["results"] if row["strike"] == 100)
+
+    assert strike_100["total_open_interest"] == 18
+    assert strike_100["net_gex"] == -400
+    assert payload["extra"]["summary"]["gamma_wall"] == 105

--- a/openbb_platform/extensions/derivatives/integration/test_derivatives_python.py
+++ b/openbb_platform/extensions/derivatives/integration/test_derivatives_python.py
@@ -6,6 +6,53 @@ from openbb_core.app.model.obbject import OBBject
 # pylint: disable=too-many-lines,redefined-outer-name
 # pylint: disable=import-outside-toplevel,inconsistent-return-statements
 
+SYNTHETIC_OPTIONS_CHAIN = [
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "call",
+        "open_interest": 10,
+        "volume": 5,
+        "delta": 0.6,
+        "gamma": 0.02,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "put",
+        "open_interest": 8,
+        "volume": 4,
+        "delta": -0.4,
+        "gamma": 0.03,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 105,
+        "option_type": "call",
+        "open_interest": 20,
+        "volume": 10,
+        "delta": 0.4,
+        "gamma": 0.01,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 95,
+        "option_type": "put",
+        "open_interest": 12,
+        "volume": 7,
+        "delta": -0.25,
+        "gamma": 0.015,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+]
+
 
 @pytest.fixture(scope="session")
 def obb(pytestconfig):
@@ -226,3 +273,31 @@ def test_derivatives_options_surface(params, obb):
     assert result
     assert isinstance(result, OBBject)
     assert len(result.results) > 0
+
+
+@pytest.mark.integration
+def test_derivatives_options_exposure(obb):
+    """Test options exposure aggregation."""
+    result = obb.derivatives.options.exposure(
+        data=SYNTHETIC_OPTIONS_CHAIN,
+        by="strike",
+    )
+
+    assert result
+    assert isinstance(result, OBBject)
+    assert len(result.results) == 3
+
+    strike_100 = next(row for row in result.results if row["strike"] == 100)
+    assert strike_100["call_open_interest"] == 10
+    assert strike_100["put_open_interest"] == 8
+    assert strike_100["total_open_interest"] == 18
+    assert strike_100["net_gex"] == -400
+    assert strike_100["net_dex"] == 28000
+
+    summary = result.extra["summary"]
+    assert summary["total_open_interest"] == 50
+    assert summary["total_gex"] == 8200
+    assert summary["net_gex"] == -200
+    assert summary["put_call_ratio_open_interest"] == 0.6667
+    assert summary["gamma_wall"] == 105
+    assert summary["put_gamma_wall"] == 100

--- a/openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py
@@ -1,0 +1,278 @@
+"""Helpers for options endpoints."""
+
+from typing import Any, Literal
+
+from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.standard_models.options_chains import OptionsChainsData
+
+
+def options_data_to_df(data: list[Data] | Data, underlying_price: float | None = None):
+    """Normalize options chain inputs into a DataFrame."""
+    # pylint: disable=import-outside-toplevel
+    from pandas import DataFrame
+
+    if isinstance(data, OptionsChainsData):
+        df = DataFrame(data.model_dump(exclude_none=True, exclude_unset=True))
+        if underlying_price is None and data.last_price is not None:
+            underlying_price = data.last_price
+    elif isinstance(data, DataFrame):
+        df = DataFrame(data.copy())
+    elif isinstance(data, dict):
+        df = DataFrame(
+            data if all(isinstance(value, list) for value in data.values()) else [data]
+        )
+    elif isinstance(data, list):
+        if all(isinstance(record, dict) for record in data):
+            df = DataFrame(data)
+        elif all(isinstance(record, Data) for record in data):
+            df = DataFrame(
+                [
+                    record.model_dump(exclude_none=True, exclude_unset=True)
+                    for record in data
+                ]
+            )
+        else:
+            df = DataFrame()
+    elif isinstance(data, Data):
+        df = DataFrame([data.model_dump(exclude_none=True, exclude_unset=True)])
+    else:
+        df = DataFrame()
+
+    if not df.empty and underlying_price is not None:
+        df["underlying_price"] = underlying_price
+
+    return df
+
+
+def prepare_options_exposure_df(df, underlying_price: float | None = None):
+    """Prepare chain data for exposure aggregation."""
+    # pylint: disable=import-outside-toplevel
+    from datetime import datetime
+
+    from pandas import Timestamp, to_datetime, to_numeric
+
+    options = df.copy()
+
+    if "option_type" not in options.columns:
+        raise OpenBBError("Error: No option_type field found.")
+    if "strike" not in options.columns:
+        raise OpenBBError("Error: No strike field found.")
+
+    options["option_type"] = options["option_type"].astype(str).str.lower()
+    options = options[options["option_type"].isin(["call", "put"])]
+
+    if "open_interest" not in options.columns:
+        options["open_interest"] = 0
+    if "volume" not in options.columns:
+        options["volume"] = 0
+    if "contract_size" not in options.columns:
+        options["contract_size"] = 100
+
+    numeric_cols = [
+        "strike",
+        "open_interest",
+        "volume",
+        "contract_size",
+        "delta",
+        "gamma",
+        "dte",
+        "underlying_price",
+    ]
+    for col in [col for col in numeric_cols if col in options.columns]:
+        options[col] = to_numeric(options[col], errors="coerce")
+
+    if underlying_price is not None:
+        options["underlying_price"] = underlying_price
+    elif "underlying_price" in options.columns:
+        last_price = options["underlying_price"].dropna()
+        if not last_price.empty:
+            options["underlying_price"] = last_price.iloc[0]
+
+    if "expiration" in options.columns:
+        options["expiration"] = to_datetime(options["expiration"], errors="coerce")
+    if "eod_date" in options.columns:
+        options["eod_date"] = to_datetime(options["eod_date"], errors="coerce")
+
+    if "expiration" in options.columns and (
+        "dte" not in options.columns or options["dte"].isna().any()
+    ):
+        if "eod_date" in options.columns and options["eod_date"].notna().any():
+            derived_dte = (options["expiration"] - options["eod_date"]).dt.days
+        else:
+            today = Timestamp(datetime.today().date())
+            derived_dte = (options["expiration"] - today).dt.days
+        options["dte"] = (
+            derived_dte
+            if "dte" not in options.columns
+            else options["dte"].fillna(derived_dte)
+        )
+
+    options["open_interest"] = options["open_interest"].fillna(0)
+    options["volume"] = options["volume"].fillna(0)
+    options["contract_size"] = options["contract_size"].fillna(100)
+
+    if _can_calculate_exposure(options, "delta"):
+        options["DEX"] = (
+            options["delta"]
+            * options["contract_size"]
+            * options["open_interest"]
+            * options["underlying_price"]
+        ).fillna(0)
+
+    if _can_calculate_exposure(options, "gamma"):
+        gex = (
+            options["gamma"]
+            * options["contract_size"]
+            * options["open_interest"]
+            * (options["underlying_price"] * options["underlying_price"])
+            * 0.01
+        ).fillna(0)
+        options["GEX"] = gex.where(options["option_type"] == "call", -gex)
+
+    return options.reset_index(drop=True)
+
+
+def has_underlying_price(options) -> bool:
+    """Return whether a prepared options DataFrame has a usable underlying price."""
+    return (
+        "underlying_price" in options.columns
+        and options["underlying_price"].notna().any()
+    )
+
+
+def build_exposure_rows(options, by: Literal["expiration", "strike"]):
+    """Build per-expiration or per-strike exposure rows."""
+    records: list[dict[str, Any]] = []
+    metrics = ["open_interest", "volume"]
+
+    if "DEX" in options.columns:
+        metrics.append("DEX")
+    if "GEX" in options.columns:
+        metrics.append("GEX")
+
+    grouped = options.groupby(by, dropna=False, sort=True)
+
+    for key, group in grouped:
+        row: dict[str, Any] = {by: _as_native(key)}
+
+        for metric in metrics:
+            calls = _sum_metric(group, metric, "call")
+            puts = _sum_metric(group, metric, "put")
+            prefix = metric.lower()
+            row[f"call_{prefix}"] = calls
+            row[f"put_{prefix}"] = puts
+            row[f"total_{prefix}"] = _total_metric(metric, calls, puts)
+            row[f"net_{prefix}"] = (
+                calls - puts if metric in ["open_interest", "volume"] else calls + puts
+            )
+            row[f"put_call_ratio_{prefix}"] = _safe_ratio(abs(puts), abs(calls))
+
+        records.append(row)
+
+    return records
+
+
+def build_exposure_summary(
+    options, rows: list[dict[str, Any]], by: str
+) -> dict[str, Any]:
+    """Build global exposure summary and wall levels."""
+    summary: dict[str, Any] = {
+        "by": by,
+        "records": len(rows),
+        "call_open_interest": _sum_metric(options, "open_interest", "call"),
+        "put_open_interest": _sum_metric(options, "open_interest", "put"),
+        "call_volume": _sum_metric(options, "volume", "call"),
+        "put_volume": _sum_metric(options, "volume", "put"),
+    }
+    summary["total_open_interest"] = (
+        summary["call_open_interest"] + summary["put_open_interest"]
+    )
+    summary["total_volume"] = summary["call_volume"] + summary["put_volume"]
+    summary["put_call_ratio_open_interest"] = _safe_ratio(
+        summary["put_open_interest"], summary["call_open_interest"]
+    )
+    summary["put_call_ratio_volume"] = _safe_ratio(
+        summary["put_volume"], summary["call_volume"]
+    )
+
+    for metric in ["DEX", "GEX"]:
+        if metric not in options.columns:
+            continue
+        metric_key = metric.lower()
+        summary[f"call_{metric_key}"] = _sum_metric(options, metric, "call")
+        summary[f"put_{metric_key}"] = _sum_metric(options, metric, "put")
+        summary[f"total_{metric_key}"] = _total_metric(
+            metric,
+            summary[f"call_{metric_key}"],
+            summary[f"put_{metric_key}"],
+        )
+        summary[f"net_{metric_key}"] = (
+            summary[f"call_{metric_key}"] + summary[f"put_{metric_key}"]
+        )
+
+    if "GEX" in options.columns and "strike" in options.columns:
+        gex_by_strike = options.groupby("strike", dropna=False)["GEX"].sum()
+        call_gex_by_strike = (
+            options[options["option_type"] == "call"].groupby("strike")["GEX"].sum()
+        )
+        put_gex_by_strike = (
+            options[options["option_type"] == "put"].groupby("strike")["GEX"].sum()
+        )
+
+        if not gex_by_strike.empty:
+            gamma_wall = gex_by_strike.abs().idxmax()
+            summary["gamma_wall"] = _as_native(gamma_wall)
+            summary["gamma_wall_gex"] = float(gex_by_strike.loc[gamma_wall])
+        if not call_gex_by_strike.empty:
+            call_wall = call_gex_by_strike.idxmax()
+            summary["call_gamma_wall"] = _as_native(call_wall)
+            summary["call_gamma_wall_gex"] = float(call_gex_by_strike.loc[call_wall])
+        if not put_gex_by_strike.empty:
+            put_wall = put_gex_by_strike.idxmin()
+            summary["put_gamma_wall"] = _as_native(put_wall)
+            summary["put_gamma_wall_gex"] = float(put_gex_by_strike.loc[put_wall])
+
+    return {key: _as_native(value) for key, value in summary.items()}
+
+
+def _can_calculate_exposure(options, greek: Literal["delta", "gamma"]) -> bool:
+    """Return whether the greek and underlying price can produce exposure."""
+    return (
+        greek in options.columns
+        and options[greek].notna().any()
+        and has_underlying_price(options)
+    )
+
+
+def _safe_ratio(numerator: float, denominator: float) -> float | None:
+    """Return a rounded ratio when the denominator is non-zero."""
+    return round(numerator / denominator, 4) if denominator else None
+
+
+def _total_metric(metric: str, calls: float, puts: float) -> float:
+    """Return the metric total using gross totals for signed exposure metrics."""
+    return abs(calls) + abs(puts) if metric in ["DEX", "GEX"] else calls + puts
+
+
+def _as_native(value: Any) -> Any:
+    """Convert Pandas/Numpy values to API-safe Python values."""
+    # pylint: disable=import-outside-toplevel
+    from pandas import isna
+
+    if isna(value):
+        return None
+    if hasattr(value, "item"):
+        return value.item()
+    if hasattr(value, "date"):
+        return value.date().isoformat()
+    return value
+
+
+def _sum_metric(df, metric: str, option_type: Literal["call", "put"] | None = None):
+    """Sum a metric, optionally for one side of the chain."""
+    if metric not in df.columns:
+        return 0
+    if option_type:
+        df = df[df["option_type"] == option_type]
+    return float(df[metric].sum())

--- a/openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py
@@ -16,6 +16,14 @@ from openbb_core.app.router import Router
 from openbb_core.provider.abstract.data import Data
 from openbb_core.provider.standard_models.options_chains import OptionsChainsData
 
+from openbb_derivatives.options.helpers import (
+    build_exposure_rows,
+    build_exposure_summary,
+    has_underlying_price,
+    options_data_to_df,
+    prepare_options_exposure_df,
+)
+
 router = Router(prefix="/options")
 
 # pylint: disable=unused-argument
@@ -245,6 +253,137 @@ async def surface(  # pylint: disable=R0913, R0917
     )
 
     return OBBject(results=df.to_dict(orient="records"))
+
+
+@router.command(
+    methods=["POST"],
+    examples=[
+        PythonEx(
+            description="Summarize gamma, delta, open interest, and volume exposure by strike.",
+            code=[
+                "data = obb.derivatives.options.chains('AAPL', provider='cboe')",
+                "exposure = obb.derivatives.options.exposure(data=data.results, by='strike')",
+                "exposure.to_df(index=None).head()",
+                "exposure.extra['summary']",
+            ],
+        ),
+    ],
+)
+async def exposure(  # pylint: disable=R0913, R0917
+    data: list[Data] | Data,
+    underlying_price: float | None = None,
+    by: Literal["expiration", "strike"] = "strike",
+    option_type: Literal["all", "otm", "itm", "calls", "puts"] = "all",
+    dte_min: int | None = None,
+    dte_max: int | None = None,
+    moneyness: float | None = None,
+    strike_min: float | None = None,
+    strike_max: float | None = None,
+    oi: bool = False,
+    volume: bool = False,
+) -> OBBject:
+    """Summarize options chain exposure by strike or expiration.
+
+    Data posted can be an instance of OptionsChainsData,
+    a pandas DataFrame, a list of dictionaries, or the results from
+    `/derivatives/options/chains`.
+
+    The command aggregates calls and puts for:
+
+    - Open interest
+    - Volume
+    - Delta exposure (DEX), when delta and underlying price are available
+    - Gamma exposure (GEX), when gamma and underlying price are available
+
+    Gamma exposure follows the same convention as the options chain properties:
+    calls are positive and puts are negative. For DEX and GEX, `net_*` fields
+    retain this signed exposure, while `total_*` fields report gross exposure.
+    """
+    df = options_data_to_df(data, underlying_price)
+
+    if df.empty:
+        raise OpenBBError("No data to process!")
+
+    options = prepare_options_exposure_df(df, underlying_price)
+
+    if options.empty:
+        raise OpenBBError("No options records to process!")
+
+    if by not in options.columns:
+        raise OpenBBError(f"Error: No {by} field found.")
+
+    if option_type in ["otm", "itm"] and not has_underlying_price(options):
+        raise OpenBBError(
+            "Last price must be provided for OTM/ITM options filtering, "
+            "and was not found in the data."
+        )
+
+    if oi:
+        options = options[options["open_interest"] > 0]
+
+    if volume:
+        options = options[options["volume"] > 0]
+
+    if dte_min is not None:
+        if "dte" not in options.columns:
+            raise OpenBBError("Error: No dte field found.")
+        options = options[options["dte"] >= dte_min]
+
+    if dte_max is not None:
+        if "dte" not in options.columns:
+            raise OpenBBError("Error: No dte field found.")
+        options = options[options["dte"] <= dte_max]
+
+    if moneyness is not None and moneyness > 0:
+        if not has_underlying_price(options):
+            raise OpenBBError(
+                "Last price must be provided for moneyness filtering, "
+                "and was not found in the data."
+            )
+        high = (1 + (float(moneyness) / 100)) * options["underlying_price"]
+        low = (1 - (float(moneyness) / 100)) * options["underlying_price"]
+        options = options[(options["strike"] >= low) & (options["strike"] <= high)]
+
+    if strike_min is not None:
+        options = options[options["strike"] >= strike_min]
+
+    if strike_max is not None:
+        options = options[options["strike"] <= strike_max]
+
+    if option_type == "calls":
+        options = options[options["option_type"] == "call"]
+    elif option_type == "puts":
+        options = options[options["option_type"] == "put"]
+    elif option_type == "otm":
+        options = options[
+            (
+                (options["option_type"] == "call")
+                & (options["strike"] > options["underlying_price"])
+            )
+            | (
+                (options["option_type"] == "put")
+                & (options["strike"] < options["underlying_price"])
+            )
+        ]
+    elif option_type == "itm":
+        options = options[
+            (
+                (options["option_type"] == "call")
+                & (options["strike"] < options["underlying_price"])
+            )
+            | (
+                (options["option_type"] == "put")
+                & (options["strike"] > options["underlying_price"])
+            )
+        ]
+
+    if options.empty:
+        raise OpenBBError("No options records matched the filters.")
+
+    rows = build_exposure_rows(options, by)
+    summary = build_exposure_summary(options, rows, by)
+
+    return OBBject(results=rows, extra={"summary": summary})
 
 
 @router.command(

--- a/openbb_platform/extensions/derivatives/tests/test_options_exposure.py
+++ b/openbb_platform/extensions/derivatives/tests/test_options_exposure.py
@@ -1,0 +1,201 @@
+"""Tests for options exposure helpers and command."""
+
+from asyncio import run
+from datetime import date
+
+import pytest
+from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_core.app.model.obbject import OBBject
+from openbb_core.provider.standard_models.options_chains import OptionsChainsData
+from openbb_derivatives.options.options_router import exposure
+
+SYNTHETIC_OPTIONS_CHAIN = [
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "call",
+        "open_interest": 10,
+        "volume": 5,
+        "delta": 0.6,
+        "gamma": 0.02,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 100,
+        "option_type": "put",
+        "open_interest": 8,
+        "volume": 4,
+        "delta": -0.4,
+        "gamma": 0.03,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 105,
+        "option_type": "call",
+        "open_interest": 20,
+        "volume": 10,
+        "delta": 0.4,
+        "gamma": 0.01,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+    {
+        "expiration": "2030-01-17",
+        "strike": 95,
+        "option_type": "put",
+        "open_interest": 12,
+        "volume": 7,
+        "delta": -0.25,
+        "gamma": 0.015,
+        "underlying_price": 100,
+        "contract_size": 100,
+    },
+]
+
+
+def test_options_exposure_aggregates_by_strike() -> None:
+    """Test options exposure aggregation by strike."""
+    result = run(exposure(data=SYNTHETIC_OPTIONS_CHAIN, by="strike"))
+
+    assert result
+    assert isinstance(result, OBBject)
+    assert len(result.results) == 3
+
+    strike_100 = next(row for row in result.results if row["strike"] == 100)
+    assert strike_100["call_open_interest"] == 10
+    assert strike_100["put_open_interest"] == 8
+    assert strike_100["total_open_interest"] == 18
+    assert strike_100["total_gex"] == 4400
+    assert strike_100["net_gex"] == -400
+    assert strike_100["total_dex"] == 92000
+    assert strike_100["net_dex"] == 28000
+
+    summary = result.extra["summary"]
+    assert summary["total_open_interest"] == 50
+    assert summary["total_gex"] == 8200
+    assert summary["net_gex"] == -200
+    assert summary["put_call_ratio_open_interest"] == 0.6667
+    assert summary["gamma_wall"] == 105
+    assert summary["put_gamma_wall"] == 100
+
+
+def test_options_exposure_serializes_expiration_groups() -> None:
+    """Test expiration grouping serializes date keys to API-safe strings."""
+    result = run(exposure(data=SYNTHETIC_OPTIONS_CHAIN, by="expiration"))
+
+    assert len(result.results) == 1
+    assert result.results[0]["expiration"] == "2030-01-17"
+    assert result.results[0]["total_open_interest"] == 50
+    assert result.extra["summary"]["by"] == "expiration"
+
+
+def test_options_exposure_uses_supplied_underlying_price() -> None:
+    """Test greeks exposure can use a command-level underlying price."""
+    records = [
+        {key: value for key, value in record.items() if key != "underlying_price"}
+        for record in SYNTHETIC_OPTIONS_CHAIN
+    ]
+
+    result = run(exposure(data=records, underlying_price=100, by="strike"))
+
+    strike_100 = next(row for row in result.results if row["strike"] == 100)
+    assert strike_100["net_gex"] == -400
+    assert result.extra["summary"]["gamma_wall"] == 105
+
+
+def test_options_exposure_filters_otm_options() -> None:
+    """Test OTM filtering uses the available underlying price."""
+    result = run(exposure(data=SYNTHETIC_OPTIONS_CHAIN, option_type="otm"))
+
+    assert {row["strike"] for row in result.results} == {95, 105}
+    assert result.extra["summary"]["total_open_interest"] == 32
+
+
+def test_options_exposure_omits_greeks_when_not_available() -> None:
+    """Test exposure output does not report zero greeks when greeks are unavailable."""
+    records = [
+        {
+            key: value
+            for key, value in record.items()
+            if key not in {"delta", "gamma", "underlying_price"}
+        }
+        for record in SYNTHETIC_OPTIONS_CHAIN
+    ]
+
+    result = run(exposure(data=records, by="strike"))
+    strike_100 = next(row for row in result.results if row["strike"] == 100)
+
+    assert "total_dex" not in strike_100
+    assert "total_gex" not in strike_100
+    assert "net_dex" not in result.extra["summary"]
+    assert "net_gex" not in result.extra["summary"]
+
+
+def test_options_exposure_omits_greeks_when_underlying_price_is_null() -> None:
+    """Test null underlying prices do not become zero exposure metrics."""
+    records = [
+        {**record, "underlying_price": None} for record in SYNTHETIC_OPTIONS_CHAIN
+    ]
+
+    result = run(exposure(data=records, by="strike"))
+    strike_100 = next(row for row in result.results if row["strike"] == 100)
+
+    assert "total_dex" not in strike_100
+    assert "total_gex" not in strike_100
+    assert "gamma_wall" not in result.extra["summary"]
+
+
+def test_options_exposure_uses_options_chains_last_price() -> None:
+    """Test OptionsChainsData.last_price is honored by the exposure command."""
+    data = OptionsChainsData(
+        contract_symbol=[
+            "FAKE300117C00100000",
+            "FAKE300117P00100000",
+        ],
+        expiration=[date(2030, 1, 17), date(2030, 1, 17)],
+        strike=[100, 100],
+        option_type=["call", "put"],
+        open_interest=[10, 8],
+        volume=[5, 4],
+        delta=[0.6, -0.4],
+        gamma=[0.02, 0.03],
+        contract_size=[100, 100],
+    )
+    data.last_price = 100
+
+    result = run(exposure(data=data, by="strike"))
+
+    assert result.results[0]["net_gex"] == -400
+    assert result.extra["summary"]["put_gamma_wall"] == 100
+
+
+def test_options_exposure_uses_eod_date_for_derived_dte() -> None:
+    """Test missing DTE is derived from eod_date when historical rows provide it."""
+    records = [
+        {
+            **record,
+            "dte": None,
+            "eod_date": "2030-01-10",
+        }
+        for record in SYNTHETIC_OPTIONS_CHAIN
+    ]
+
+    result = run(exposure(data=records, dte_min=7, dte_max=7, by="strike"))
+
+    assert len(result.results) == 3
+    assert result.extra["summary"]["total_open_interest"] == 50
+
+
+def test_options_exposure_requires_underlying_price_for_moneyness_filters() -> None:
+    """Test moneyness filters fail early without an underlying price."""
+    records = [
+        {key: value for key, value in record.items() if key != "underlying_price"}
+        for record in SYNTHETIC_OPTIONS_CHAIN
+    ]
+
+    with pytest.raises(OpenBBError, match="Last price must be provided"):
+        run(exposure(data=records, option_type="otm"))


### PR DESCRIPTION
## Summary
- add POST command `obb.derivatives.options.exposure` for option-chain exposure summaries
- aggregate open interest, volume, DEX, and GEX by strike or expiration
- report signed `net_dex`/`net_gex` separately from gross `total_dex`/`total_gex`
- return gamma/call/put wall and put-call ratio summary metadata
- keep exposure math in an options helper module so the router remains focused on endpoint orchestration

## Quality Hardening
- avoid reporting misleading zero DEX/GEX when greeks or underlying price are unavailable
- honor `OptionsChainsData.last_price` when users set the underlying price after fetching chains
- derive missing DTE from `eod_date` for historical option-chain rows before falling back to today
- add deterministic non-integration unit coverage for strike/expiration aggregation, OTM filtering, missing greeks, null underlying price, `last_price`, and historical DTE handling

## Tests
- `uvx --from black black --check openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py openbb_platform/extensions/derivatives/tests/test_options_exposure.py openbb_platform/extensions/derivatives/integration/test_derivatives_python.py openbb_platform/extensions/derivatives/integration/test_derivatives_api.py`
- `uvx --from ruff ruff check openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py openbb_platform/extensions/derivatives/tests/test_options_exposure.py openbb_platform/extensions/derivatives/integration/test_derivatives_python.py openbb_platform/extensions/derivatives/integration/test_derivatives_api.py`
- `uvx --from openbb-devtools mypy openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py --ignore-missing-imports --scripts-are-modules --check-untyped-defs`
- `uvx --from openbb-devtools pylint openbb_platform/extensions/derivatives/openbb_derivatives/options/options_router.py openbb_platform/extensions/derivatives/openbb_derivatives/options/helpers.py`
- `PYTHONPATH=openbb_platform/core:openbb_platform/extensions/derivatives uvx --from pytest --with pandas --with pydantic --with uuid7 --with fastapi --with python-multipart --with requests --with aiohttp --with websockets --with html5lib --with python-dotenv --with importlib-metadata --with pyjwt pytest openbb_platform/extensions/derivatives/tests/test_options_exposure.py -q`
- `PYTHONPATH=<core plus all extension package dirs> uvx --from pytest --with pandas --with pydantic --with uuid7 --with fastapi --with python-multipart --with requests --with aiohttp --with websockets --with html5lib --with python-dotenv --with importlib-metadata --with pyjwt pytest openbb_platform/extensions/tests/test_routers.py -q`

Refs #6948