### PR TITLE
[Test] Cover platform extension widget filter

### DIFF
--- a/openbb_platform/extensions/platform_api/tests/test_api.py
+++ b/openbb_platform/extensions/platform_api/tests/test_api.py
@@ -51,7 +51,7 @@ def _load_main_with_mocks():
                 cors=types.SimpleNamespace(
                     allow_origins=["*"], allow_methods=["*"], allow_headers=["*"]
                 ),
-                api_settings=types.SimpleNamespace(prefix="/api"),
+                api_settings=types.SimpleNamespace(prefix="/api/v1"),
             )
 
     system_service_module.SystemService = DummySystemService  # type:ignore
@@ -903,6 +903,106 @@ def test_get_widgets_json_merges_with_additional_sources(monkeypatch):
 
     assert widgets["default"] == base_widgets["default"]
     assert widgets["extra"] == additional_widgets["extra"]
+
+
+@pytest.fixture
+def check_for_platform_extensions_fn():
+    main = _load_main_with_mocks()
+    return main.check_for_platform_extensions
+
+
+@pytest.fixture
+def platform_extension_openapi_tags():
+    return [
+        {"name": "technical"},
+        {"name": "econometrics"},
+        {"name": "quantitative"},
+        {"name": "economy"},
+    ]
+
+
+@pytest.fixture
+def platform_extension_modules(monkeypatch):
+    module_names = (
+        "openbb_technical",
+        "openbb_econometrics",
+        "openbb_quantitative",
+    )
+    inserted = {
+        name: types.ModuleType(name) for name in module_names if name not in sys.modules
+    }
+    for name, module in inserted.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    yield inserted
+    for name in inserted:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def _mock_fastapi_app(openapi_tags):
+    app = MagicMock()
+    app.openapi_tags = openapi_tags
+    return app
+
+
+def test_check_for_platform_extensions_excludes_loaded_modules(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+    platform_extension_modules,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    result = check_for_platform_extensions_fn(app, [])
+
+    assert "/api/v1/technical/*" in result
+    assert "/api/v1/econometrics/*" in result
+    assert "/api/v1/quantitative/*" in result
+    assert "/api/v1/economy/*" not in result
+
+
+def test_check_for_platform_extensions_preserves_existing_exclusions(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+    platform_extension_modules,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    existing = ["/api/v1/custom/*"]
+    result = check_for_platform_extensions_fn(app, existing.copy())
+
+    assert "/api/v1/custom/*" in result
+
+
+def test_check_for_platform_extensions_skips_when_modules_not_loaded(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    excluded = (
+        "openbb_technical",
+        "openbb_econometrics",
+        "openbb_quantitative",
+    )
+    saved = {name: sys.modules.pop(name, None) for name in excluded}
+    try:
+        result = check_for_platform_extensions_fn(app, [])
+    finally:
+        for name, module in saved.items():
+            if module is not None:
+                sys.modules[name] = module
+
+    assert result == []
+
+
+def test_check_for_platform_extensions_matches_tag_names_not_dict_identity(
+    check_for_platform_extensions_fn,
+    monkeypatch,
+):
+    app = _mock_fastapi_app([{"name": "technical"}, {"name": "economy"}])
+    monkeypatch.setitem(
+        sys.modules, "openbb_technical", types.ModuleType("openbb_technical")
+    )
+
+    result = check_for_platform_extensions_fn(app, [])
+
+    assert result == ["/api/v1/technical/*"]
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Adds regression coverage for `check_for_platform_extensions()` so platform-only extensions such as technical, quantitative, and econometrics are excluded from generated Workspace widgets when their modules are loaded.

## Context

Related to #7175.

PR #7184 fixed a widget-generation issue where data-processing routers could be incorrectly included in generated Workspace widgets. This PR adds focused regression coverage for that behavior so the filter does not regress.

This does not claim to fully resolve #7175, since the original Workspace 500 may also involve local/remote backend URL configuration or Workspace-side behavior.

## What Changed

- Added tests for `check_for_platform_extensions()`
- Verifies technical, quantitative, and econometrics tags are excluded when their modules are loaded
- Verifies unrelated tags like economy are not excluded
- Verifies existing exclusions are preserved
- Guards against the previous dict-vs-string tag comparison regression

## Test Plan

- `pytest openbb_platform/extensions/platform_api/tests/test_api.py::test_check_for_platform_extensions_* -q`
  - 4 passed
- `pytest openbb_platform/extensions/platform_api/tests/test_api.py -q`
  - 29 passed, 1 failed (`TestPathDetectionHelpers::test_is_absolute_path_detection_unix`; pre-existing Windows-only failure)
- `pytest openbb_platform/extensions/platform_api/tests -q`
  - 74 passed, 1 failed (same pre-existing Windows path test)
- `pre-commit run --files openbb_platform/extensions/platform_api/tests/test_api.py`
  - black, codespell, detect-secrets, merge-conflict checks passed
  - ruff failed on pre-existing module-level D103 docstring warnings in `test_api.py`
  - pylint hook failed locally because `pylint` is not installed in this environment
