### PR TITLE
feat(derivatives): add yfinance futures expirations endpoint

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/futures_expirations.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/futures_expirations.py
@@ -1,0 +1,46 @@
+"""Futures Expirations Standard Model."""
+
+from datetime import date as dateType
+
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.abstract.query_params import QueryParams
+from openbb_core.provider.utils.descriptions import (
+    DATA_DESCRIPTIONS,
+    QUERY_DESCRIPTIONS,
+)
+from pydantic import Field, field_validator
+
+
+class FuturesExpirationsQueryParams(QueryParams):
+    """Futures Expirations Query."""
+
+    symbol: str = Field(description=QUERY_DESCRIPTIONS.get("symbol", ""))
+
+    @field_validator("symbol", mode="before", check_fields=False)
+    @classmethod
+    def to_upper(cls, v):
+        """Convert field to uppercase."""
+        return v.upper()
+
+
+class FuturesExpirationsData(Data):
+    """Futures Expirations Data."""
+
+    symbol: str = Field(description=DATA_DESCRIPTIONS.get("symbol", ""))
+    contract_symbol: str = Field(description="Vendor-specific futures contract symbol.")
+    expiration: dateType | None = Field(
+        default=None,
+        description="Contract expiration date, when available from the provider.",
+    )
+    expiration_month: str | None = Field(
+        default=None,
+        description="Futures expiration month in YYYY-MM format.",
+    )
+    exchange: str | None = Field(
+        default=None,
+        description="Exchange where the contract is listed.",
+    )
+    name: str | None = Field(
+        default=None,
+        description="Human-readable contract name.",
+    )

--- a/openbb_platform/extensions/derivatives/openbb_derivatives/futures/futures_router.py
+++ b/openbb_platform/extensions/derivatives/openbb_derivatives/futures/futures_router.py
@@ -63,6 +63,23 @@ async def curve(
 
 
 @router.command(
+    model="FuturesExpirations",
+    examples=[
+        APIEx(parameters={"symbol": "ES", "provider": "yfinance"}),
+        APIEx(parameters={"symbol": "CL", "provider": "yfinance"}),
+    ],
+)
+async def expirations(
+    cc: CommandContext,
+    provider_choices: ProviderChoices,
+    standard_params: StandardParams,
+    extra_params: ExtraParams,
+) -> OBBject:
+    """Futures contract expiration dates."""
+    return await OBBject.from_query(Query(**locals()))
+
+
+@router.command(
     model="FuturesInstruments",
     examples=[
         APIEx(parameters={"provider": "deribit"}),

--- a/openbb_platform/extensions/platform_api/tests/test_api.py
+++ b/openbb_platform/extensions/platform_api/tests/test_api.py
@@ -51,7 +51,7 @@ def _load_main_with_mocks():
                 cors=types.SimpleNamespace(
                     allow_origins=["*"], allow_methods=["*"], allow_headers=["*"]
                 ),
-                api_settings=types.SimpleNamespace(prefix="/api"),
+                api_settings=types.SimpleNamespace(prefix="/api/v1"),
             )
 
     system_service_module.SystemService = DummySystemService  # type:ignore
@@ -903,6 +903,106 @@ def test_get_widgets_json_merges_with_additional_sources(monkeypatch):
 
     assert widgets["default"] == base_widgets["default"]
     assert widgets["extra"] == additional_widgets["extra"]
+
+
+@pytest.fixture
+def check_for_platform_extensions_fn():
+    main = _load_main_with_mocks()
+    return main.check_for_platform_extensions
+
+
+@pytest.fixture
+def platform_extension_openapi_tags():
+    return [
+        {"name": "technical"},
+        {"name": "econometrics"},
+        {"name": "quantitative"},
+        {"name": "economy"},
+    ]
+
+
+@pytest.fixture
+def platform_extension_modules(monkeypatch):
+    module_names = (
+        "openbb_technical",
+        "openbb_econometrics",
+        "openbb_quantitative",
+    )
+    inserted = {
+        name: types.ModuleType(name) for name in module_names if name not in sys.modules
+    }
+    for name, module in inserted.items():
+        monkeypatch.setitem(sys.modules, name, module)
+    yield inserted
+    for name in inserted:
+        monkeypatch.delitem(sys.modules, name, raising=False)
+
+
+def _mock_fastapi_app(openapi_tags):
+    app = MagicMock()
+    app.openapi_tags = openapi_tags
+    return app
+
+
+def test_check_for_platform_extensions_excludes_loaded_modules(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+    platform_extension_modules,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    result = check_for_platform_extensions_fn(app, [])
+
+    assert "/api/v1/technical/*" in result
+    assert "/api/v1/econometrics/*" in result
+    assert "/api/v1/quantitative/*" in result
+    assert "/api/v1/economy/*" not in result
+
+
+def test_check_for_platform_extensions_preserves_existing_exclusions(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+    platform_extension_modules,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    existing = ["/api/v1/custom/*"]
+    result = check_for_platform_extensions_fn(app, existing.copy())
+
+    assert "/api/v1/custom/*" in result
+
+
+def test_check_for_platform_extensions_skips_when_modules_not_loaded(
+    check_for_platform_extensions_fn,
+    platform_extension_openapi_tags,
+):
+    app = _mock_fastapi_app(platform_extension_openapi_tags)
+    excluded = (
+        "openbb_technical",
+        "openbb_econometrics",
+        "openbb_quantitative",
+    )
+    saved = {name: sys.modules.pop(name, None) for name in excluded}
+    try:
+        result = check_for_platform_extensions_fn(app, [])
+    finally:
+        for name, module in saved.items():
+            if module is not None:
+                sys.modules[name] = module
+
+    assert result == []
+
+
+def test_check_for_platform_extensions_matches_tag_names_not_dict_identity(
+    check_for_platform_extensions_fn,
+    monkeypatch,
+):
+    app = _mock_fastapi_app([{"name": "technical"}, {"name": "economy"}])
+    monkeypatch.setitem(
+        sys.modules, "openbb_technical", types.ModuleType("openbb_technical")
+    )
+
+    result = check_for_platform_extensions_fn(app, [])
+
+    assert result == ["/api/v1/technical/*"]
 
 
 if __name__ == "__main__":

--- a/openbb_platform/providers/yfinance/openbb_yfinance/__init__.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/__init__.py
@@ -15,6 +15,7 @@ from openbb_yfinance.models.equity_quote import YFinanceEquityQuoteFetcher
 from openbb_yfinance.models.equity_screener import YFinanceEquityScreenerFetcher
 from openbb_yfinance.models.etf_info import YFinanceEtfInfoFetcher
 from openbb_yfinance.models.futures_curve import YFinanceFuturesCurveFetcher
+from openbb_yfinance.models.futures_expirations import YFinanceFuturesExpirationsFetcher
 from openbb_yfinance.models.futures_historical import YFinanceFuturesHistoricalFetcher
 from openbb_yfinance.models.gainers import YFGainersFetcher
 from openbb_yfinance.models.growth_tech_equities import YFGrowthTechEquitiesFetcher
@@ -64,6 +65,7 @@ financial markets and assets.""",
         "EtfHistorical": YFinanceEquityHistoricalFetcher,
         "EtfInfo": YFinanceEtfInfoFetcher,
         "FuturesCurve": YFinanceFuturesCurveFetcher,
+        "FuturesExpirations": YFinanceFuturesExpirationsFetcher,
         "FuturesHistorical": YFinanceFuturesHistoricalFetcher,
         "GrowthTechEquities": YFGrowthTechEquitiesFetcher,
         "HistoricalDividends": YFinanceHistoricalDividendsFetcher,

--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/futures_expirations.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/futures_expirations.py
@@ -1,0 +1,66 @@
+"""Yahoo Finance Futures Expirations Model."""
+
+# pylint: disable=unused-argument
+
+import asyncio
+from typing import Any
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.futures_expirations import (
+    FuturesExpirationsData,
+    FuturesExpirationsQueryParams,
+)
+from openbb_core.provider.utils.errors import EmptyDataError
+
+
+class YFinanceFuturesExpirationsQueryParams(FuturesExpirationsQueryParams):
+    """Yahoo Finance Futures Expirations Query.
+
+    Source: https://finance.yahoo.com/
+    """
+
+
+class YFinanceFuturesExpirationsData(FuturesExpirationsData):
+    """Yahoo Finance Futures Expirations Data."""
+
+
+class YFinanceFuturesExpirationsFetcher(
+    Fetcher[
+        YFinanceFuturesExpirationsQueryParams,
+        list[YFinanceFuturesExpirationsData],
+    ]
+):
+    """YFinance Futures Expirations Fetcher."""
+
+    @staticmethod
+    def transform_query(
+        params: dict[str, Any],
+    ) -> YFinanceFuturesExpirationsQueryParams:
+        """Transform the query."""
+        return YFinanceFuturesExpirationsQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: YFinanceFuturesExpirationsQueryParams,
+        credentials: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> list[dict]:
+        """Extract futures expiration data from Yahoo."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_yfinance.utils.helpers import get_futures_expirations
+
+        data = await asyncio.to_thread(get_futures_expirations, query.symbol)
+
+        if not data:
+            raise EmptyDataError()
+
+        return data
+
+    @staticmethod
+    def transform_data(
+        query: YFinanceFuturesExpirationsQueryParams,
+        data: list[dict],
+        **kwargs: Any,
+    ) -> list[YFinanceFuturesExpirationsData]:
+        """Transform the data to the standard format."""
+        return [YFinanceFuturesExpirationsData.model_validate(d) for d in data]

--- a/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/utils/helpers.py
@@ -220,8 +220,8 @@ async def get_defined_screener(
 
 def get_expiration_month(symbol: str) -> str:
     """Get the expiration month for a given symbol."""
-    month = symbol.split(".")[0][-3]
-    year = "20" + symbol.split(".")[0][-2:]
+    month = symbol.split(".", maxsplit=1)[0][-3]
+    year = "20" + symbol.split(".", maxsplit=1)[0][-2:]
     return f"{year}-{MONTH_MAP[month]}"
 
 
@@ -255,6 +255,65 @@ def get_futures_symbols(symbol: str) -> list:
             futures_symbols = futures.get("futures", [])
 
     return futures_symbols
+
+
+def get_futures_expirations(symbol: str) -> list[dict]:
+    """Get futures contract expiration metadata from Yahoo's futuresChain module."""
+    # pylint: disable=import-outside-toplevel
+    from contextlib import suppress
+    from datetime import datetime
+
+    from yfinance.data import YfData
+
+    root = symbol.upper().replace("=F", "")
+    _symbol = root + "%3DF"
+    url = f"https://query2.finance.yahoo.com/v10/finance/quoteSummary/{_symbol}"
+    params = {"modules": "futuresChain"}
+
+    response: dict = YfData().get_raw_json(url=url, params=params)
+    futures_symbols: list = []
+    details: dict = {}
+
+    if "quoteSummary" in response:
+        result = response["quoteSummary"].get("result", [])
+        if result:
+            futures_chain = result[0].get("futuresChain", {})
+            if futures_chain:
+                futures_symbols = futures_chain.get("futures", [])
+                details = futures_chain.get("futuresChainDetails", {}) or {}
+
+    if not futures_symbols:
+        raise EmptyDataError(f"No futures chain found for {symbol}")
+
+    output: list[dict] = []
+    for contract in futures_symbols:
+        contract_symbol = contract.get("symbol", "") if isinstance(contract, dict) else contract
+        if not contract_symbol:
+            continue
+
+        detail = details.get(contract_symbol, {}) if isinstance(details, dict) else {}
+        expiration = None
+        expire_iso = detail.get("expireIsoDate")
+        if expire_iso:
+            with suppress(ValueError, TypeError):
+                expiration = datetime.strptime(str(expire_iso)[:10], "%Y-%m-%d").date()
+
+        expiration_month = None
+        with suppress(IndexError, KeyError):
+            expiration_month = get_expiration_month(contract_symbol)
+
+        output.append(
+            {
+                "symbol": root,
+                "contract_symbol": contract_symbol,
+                "expiration": expiration,
+                "expiration_month": expiration_month,
+                "exchange": detail.get("exchange"),
+                "name": detail.get("shortName"),
+            }
+        )
+
+    return output
 
 
 async def get_futures_quotes(symbols: list) -> "DataFrame":

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_fetchers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_fetchers.py
@@ -1,9 +1,11 @@
 """Tests for YFinance fetchers."""
 
 from datetime import date
+from unittest.mock import patch
 
 import pytest
 from openbb_core.app.service.user_service import UserService
+from openbb_core.provider.utils.errors import EmptyDataError
 from openbb_yfinance.models.active import YFActiveFetcher
 from openbb_yfinance.models.aggressive_small_caps import YFAggressiveSmallCapsFetcher
 from openbb_yfinance.models.available_indices import YFinanceAvailableIndicesFetcher
@@ -18,6 +20,7 @@ from openbb_yfinance.models.equity_quote import YFinanceEquityQuoteFetcher
 from openbb_yfinance.models.equity_screener import YFinanceEquityScreenerFetcher
 from openbb_yfinance.models.etf_info import YFinanceEtfInfoFetcher
 from openbb_yfinance.models.futures_curve import YFinanceFuturesCurveFetcher
+from openbb_yfinance.models.futures_expirations import YFinanceFuturesExpirationsFetcher
 from openbb_yfinance.models.futures_historical import YFinanceFuturesHistoricalFetcher
 from openbb_yfinance.models.gainers import YFGainersFetcher
 from openbb_yfinance.models.growth_tech_equities import YFGrowthTechEquitiesFetcher
@@ -207,6 +210,45 @@ def test_y_finance_options_chains_fetcher(credentials=test_credentials):
     fetcher = YFinanceOptionsChainsFetcher()
     result = fetcher.test(params, credentials)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_y_finance_futures_expirations_fetcher():
+    """Test YFinanceFuturesExpirationsFetcher."""
+    mock_data = [
+        {
+            "symbol": "ES",
+            "contract_symbol": "ESU26.CME",
+            "expiration": date(2026, 9, 18),
+            "expiration_month": "2026-09",
+            "exchange": "CME",
+            "name": "E-Mini S&P 500 Sep 26",
+        }
+    ]
+
+    fetcher = YFinanceFuturesExpirationsFetcher()
+    query = fetcher.transform_query({"symbol": "ES"})
+
+    with patch(
+        "openbb_yfinance.utils.helpers.get_futures_expirations",
+        return_value=mock_data,
+    ):
+        data = await fetcher.aextract_data(query, {})
+        result = fetcher.transform_data(query, data)
+
+    assert len(result) == 1
+    assert result[0].symbol == "ES"
+    assert result[0].contract_symbol == "ESU26.CME"
+    assert result[0].expiration == date(2026, 9, 18)
+    assert result[0].expiration_month == "2026-09"
+    assert result[0].exchange == "CME"
+    assert result[0].name == "E-Mini S&P 500 Sep 26"
+
+    with patch(
+        "openbb_yfinance.utils.helpers.get_futures_expirations",
+        return_value=[],
+    ), pytest.raises(EmptyDataError):
+        await fetcher.aextract_data(query, {})
 
 
 @pytest.mark.skip("Unreliable amount of data while recording test.")

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_helpers.py
@@ -1,13 +1,16 @@
 """Test yfinance helpers."""
 
+from unittest.mock import MagicMock, patch
+
 import pandas as pd
 import pytest
-from unittest.mock import patch, MagicMock
+from openbb_core.provider.utils.errors import EmptyDataError
 from openbb_yfinance.utils.helpers import (
     df_transform_numbers,
-    get_futures_data,
     get_custom_screener,
     get_defined_screener,
+    get_futures_data,
+    get_futures_expirations,
     get_futures_symbols,
     yf_download,
 )
@@ -123,6 +126,127 @@ def test_get_futures_symbols_no_session():
         assert (
             "session" not in call_kwargs
         ), "YfData should not be called with session parameter"
+
+
+def test_get_futures_expirations_maps_details():
+    """Test get_futures_expirations maps Yahoo futuresChainDetails."""
+    with patch("yfinance.data.YfData") as mock_yfdata:
+        mock_instance = MagicMock()
+        mock_instance.get_raw_json.return_value = {
+            "quoteSummary": {
+                "result": [
+                    {
+                        "futuresChain": {
+                            "futures": ["ESU26.CME", "ESZ26.CME", "CLN26.NYM"],
+                            "futuresChainDetails": {
+                                "ESU26.CME": {
+                                    "expireIsoDate": "2026-09-18T00:00:00Z",
+                                    "exchange": "CME",
+                                    "shortName": "E-Mini S&P 500 Sep 26",
+                                },
+                                "ESZ26.CME": {
+                                    "expireIsoDate": "2026-12-18T00:00:00Z",
+                                    "exchange": "CME",
+                                    "shortName": "E-Mini S&P 500 Dec 26",
+                                },
+                            },
+                        }
+                    }
+                ]
+            }
+        }
+        mock_yfdata.return_value = mock_instance
+
+        result = get_futures_expirations("ES")
+
+        assert len(result) == 3
+        assert result[0]["symbol"] == "ES"
+        assert result[0]["contract_symbol"] == "ESU26.CME"
+        assert str(result[0]["expiration"]) == "2026-09-18"
+        assert result[0]["expiration_month"] == "2026-09"
+        assert result[0]["exchange"] == "CME"
+        assert result[0]["name"] == "E-Mini S&P 500 Sep 26"
+        assert result[2]["contract_symbol"] == "CLN26.NYM"
+        assert result[2]["expiration"] is None
+        assert result[2]["expiration_month"] == "2026-07"
+        assert result[2]["exchange"] is None
+        assert result[2]["name"] is None
+
+
+def test_get_futures_expirations_empty_chain():
+    """Test get_futures_expirations raises EmptyDataError for empty chains."""
+    with patch("yfinance.data.YfData") as mock_yfdata:
+        mock_instance = MagicMock()
+        mock_instance.get_raw_json.return_value = {
+            "quoteSummary": {"result": [{"futuresChain": {"futures": []}}]}
+        }
+        mock_yfdata.return_value = mock_instance
+
+        with pytest.raises(EmptyDataError, match="No futures chain found for NQ"):
+            get_futures_expirations("NQ")
+
+
+def test_get_futures_expirations_unexpected_contract_symbol():
+    """Test get_futures_expirations tolerates unexpected contract symbol formats."""
+    with patch("yfinance.data.YfData") as mock_yfdata:
+        mock_instance = MagicMock()
+        mock_instance.get_raw_json.return_value = {
+            "quoteSummary": {
+                "result": [
+                    {
+                        "futuresChain": {
+                            "futures": ["ESU26.CME", "INVALID"],
+                            "futuresChainDetails": {},
+                        }
+                    }
+                ]
+            }
+        }
+        mock_yfdata.return_value = mock_instance
+
+        result = get_futures_expirations("ES")
+
+        assert len(result) == 2
+        assert result[0]["expiration_month"] == "2026-09"
+        assert result[1]["contract_symbol"] == "INVALID"
+        assert result[1]["expiration_month"] is None
+
+
+def test_get_futures_expirations_malformed_expire_iso_date():
+    """Test get_futures_expirations tolerates malformed expireIsoDate values."""
+    with patch("yfinance.data.YfData") as mock_yfdata:
+        mock_instance = MagicMock()
+        mock_instance.get_raw_json.return_value = {
+            "quoteSummary": {
+                "result": [
+                    {
+                        "futuresChain": {
+                            "futures": ["ESU26.CME", "ESZ26.CME"],
+                            "futuresChainDetails": {
+                                "ESU26.CME": {
+                                    "expireIsoDate": "2026-09-18T00:00:00Z",
+                                    "exchange": "CME",
+                                },
+                                "ESZ26.CME": {
+                                    "expireIsoDate": "not-a-valid-date",
+                                    "exchange": "CME",
+                                },
+                            },
+                        }
+                    }
+                ]
+            }
+        }
+        mock_yfdata.return_value = mock_instance
+
+        result = get_futures_expirations("ES")
+
+        assert len(result) == 2
+        assert str(result[0]["expiration"]) == "2026-09-18"
+        assert result[0]["expiration_month"] == "2026-09"
+        assert result[1]["expiration"] is None
+        assert result[1]["expiration_month"] == "2026-12"
+        assert result[1]["exchange"] == "CME"
 
 
 def test_yf_download_no_session():


### PR DESCRIPTION
## Summary
Adds a yfinance-backed futures expirations endpoint under `derivatives.futures`.

- Adds `FuturesExpirations` standard model
- Adds `obb.derivatives.futures.expirations(...)`
- Registers `YFinanceFuturesExpirationsFetcher`
- Uses Yahoo `futuresChainDetails.expireIsoDate` when available
- Falls back to `expiration_month` parsed from contract symbols
- Preserves rows when contract detail metadata is missing or partially malformed

## Scope
- Futures only
- yfinance only
- No options expirations
- No `economy.calendar` changes
- No BarChart dependency

## Tests
- `git diff --cached --check`
- `ruff check` on changed files
- Focused yfinance helper/fetcher tests

Result: 5 passed.
