### PR TITLE
Add FXMacroData provider listing

### DIFF
--- a/assets/extensions/provider.json
+++ b/assets/extensions/provider.json
@@ -167,6 +167,17 @@
         "instructions": "Go to: https://fred.stlouisfed.org\n\n![FRED](https://user-images.githubusercontent.com/46355364/207827137-d143ba4c-72cb-467d-a7f4-5cc27c597aec.png)\n\nClick on, \"My Account\", create a new account or sign in with Google:\n\n![FRED](https://user-images.githubusercontent.com/46355364/207827011-65cdd501-27e3-436f-bd9d-b0d8381d46a7.png)\n\nAfter completing the sign-up, go to \"My Account\", and select \"API Keys\". Then, click on, \"Request API Key\".\n\n![FRED](https://user-images.githubusercontent.com/46355364/207827577-c869f989-4ef4-4949-ab57-6f3931f2ae9d.png)\n\nFill in the box for information about the use-case for FRED, and by clicking, \"Request API key\", at the bottom of the page, the API key will be issued.\n\n![FRED](https://user-images.githubusercontent.com/46355364/207828032-0a32d3b8-1378-4db2-9064-aa1eb2111632.png)"
     },
     {
+        "packageName": "fxmacrodata",
+        "optional": true,
+        "reprName": "FXMacroData",
+        "description": "FXMacroData provides official-source macroeconomic indicators, release calendars, FX spot rates, CFTC Commitment of Traders positioning, and commodity prices for FX research workflows.",
+        "credentials": [
+            "fxmacrodata_api_key"
+        ],
+        "website": "https://fxmacrodata.com",
+        "instructions": "Public USD macro catalogue, macro history, and release calendar data can be used without an API key. Add an FXMacroData API key as `fxmacrodata_api_key` for non-USD currencies, FX spot history, COT positioning, commodities, and subscriber datasets. Subscribe at https://fxmacrodata.com/subscribe."
+    },
+    {
         "packageName": "openbb-government-us",
         "optional": true,
         "reprName": "Data.gov | United States Government",

--- a/openbb_platform/README.md
+++ b/openbb_platform/README.md
@@ -61,6 +61,7 @@ These packages are not installed when `pip install openbb` is run.  They are ava
 | openbb-federal-reserve | [Federal Reserve](https://www.federalreserve.gov/) data connector | pip install openbb-federal-reserve | None |
 | openbb-finra | [FINRA](https://www.finra.org/finra-data) data connector | pip install openbb-finra | None / Free |
 | openbb-finviz | [Finviz](https://finviz.com) data connector | pip install openbb-finviz | None |
+| fxmacrodata | [FXMacroData](https://fxmacrodata.com) macro indicators, release calendars, FX spot, COT positioning, and commodities for FX research | pip install fxmacrodata | Free / Paid |
 | openbb-government-us | [US Government](https://data.gov) data connector | pip install openbb-us-government | None |
 | openbb-nasdaq | [Nasdaq Data Link](https://data.nasdaq.com/) connector | pip install openbb-nasdaq | None / Free |
 | openbb-seeking-alpha | [Seeking Alpha](https://seekingalpha.com/) data connector | pip install openbb-seeking-alpha | None |


### PR DESCRIPTION
## Summary

Adds FXMacroData to the OpenBB provider extension catalogue and OpenBB Platform README extension table.

FXMacroData provides official-source macroeconomic indicators, release calendars, FX spot rates, CFTC Commitment of Traders positioning, and commodity prices for FX research workflows.

## Package

- Package: `fxmacrodata`
- Provider name: `fxmacrodata`
- Credential key: `fxmacrodata_api_key`
- Website: https://fxmacrodata.com
- Public data without an API key: USD macro catalogue, USD macro history, USD release calendar
- Authenticated data: non-USD macro data, FX spot history, COT positioning, commodities, and subscriber datasets

## Status

Ready for maintainer review.

The supporting FXMacroData SDK validation PR is https://github.com/fxmacrodata/fxmacrodata/pull/3. Its Python 3.11 and Python 3.12 validation checks are passing.

No credentials or API keys are included in this PR.

## Validation

- `python -m json.tool assets/extensions/provider.json`
- Local secret-pattern scan of changed files
- FXMacroData SDK validation checks passed on Python 3.11 and Python 3.12: https://github.com/fxmacrodata/fxmacrodata/pull/3