### PR TITLE
[BugFix] ODP Desktop: Fix Cargo Clippy Error From Introduced Rules In Latest Version

### DIFF
--- a/desktop/src-tauri/src/tauri_handlers/startup.rs
+++ b/desktop/src-tauri/src/tauri_handlers/startup.rs
@@ -797,13 +797,7 @@ pub async fn install_conda(directory: String, window: Window) -> Result<bool, St
         log::debug!(
             "Executing installer via start /B: {} with args: {:?}",
             installer_path.to_string_lossy(),
-            &[
-                "/InstallationType=JustMe",
-                "/RegisterPython=0",
-                "/AddToPath=0",
-                "/S",
-                &format!("/D={}", conda_dir.to_string_lossy())
-            ]
+            args
         );
 
         // Run the installer via cmd start


### PR DESCRIPTION
This PR fixes a linting error surfaced by the CI tests. The latest version of Cargo Clippy introduces stricter rules, and trips the lint job.

The fix removes redundant code.

``
error: redundant reference in `debug!` argument
   --> src-tauri\src\tauri_handlers\startup.rs:800:13
    |
800 | /             &[
801 | |                 "/InstallationType=JustMe",
802 | |                 "/RegisterPython=0",
803 | |                 "/AddToPath=0",
804 | |                 "/S",
805 | |                 &format!("/D={}", conda_dir.to_string_lossy())
806 | |             ]
    | |_____________^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/rust-1.97.0/index.html#useless_borrows_in_formatting
    = note: `-D clippy::useless-borrows-in-formatting` implied by `-D warnings`
    = help: to override `-D warnings` add `#[allow(clippy::useless_borrows_in_formatting)]`
help: remove the redundant `&`
    |
800 ~             [
801 +                 "/InstallationType=JustMe",
802 +                 "/RegisterPython=0",
803 +                 "/AddToPath=0",
804 +                 "/S",
805 +                 &format!("/D={}", conda_dir.to_string_lossy())
806 +             ]
    |
```