### PR TITLE
feat: add openbb-nse provider with index constituents

### DIFF
--- a/openbb_platform/dev_install.py
+++ b/openbb_platform/dev_install.py
@@ -64,6 +64,7 @@ openbb-finra = { path = "./providers/finra", optional = true, develop = true }
 openbb-finviz = { path = "./providers/finviz", optional = true, develop = true }
 openbb-multpl = { path = "./providers/multpl", optional = true, develop = true }
 openbb-nasdaq = { path = "./providers/nasdaq", optional = true, develop = true }
+openbb-nse = { path = "./providers/nse", optional = true, develop = true }
 openbb-seeking-alpha = { path = "./providers/seeking_alpha", optional = true, develop = true }
 openbb-stockgrid = { path = "./providers/stockgrid" , optional = true,  develop = true }
 openbb_tmx = { path = "./providers/tmx", optional = true, develop = true }

--- a/openbb_platform/providers/nse/README.md
+++ b/openbb_platform/providers/nse/README.md
@@ -1,0 +1,40 @@
+# OpenBB NSE Provider
+
+This extension integrates data from the [National Stock Exchange of India (NSE)](https://www.nseindia.com) into the OpenBB Platform.
+
+Index data is sourced from the official constituent files published by **NSE Indices Limited** (`niftyindices.com`). These are statically published files, so **no API key is required** and there is no dependency on the anti-bot `nseindia.com` quote API.
+
+## Installation
+
+```bash
+pip install openbb-nse
+```
+
+Documentation is available [here](https://docs.openbb.co/platform).
+
+## Coverage
+
+| Command | Standard model | Source |
+| --- | --- | --- |
+| `obb.index.constituents` | `IndexConstituents` | NSE Indices official constituent files |
+
+## Usage
+
+```python
+from openbb import obb
+
+# Constituents of the NIFTY 500
+obb.index.constituents("nifty_500", provider="nse")
+
+# Bank Nifty
+obb.index.constituents("nifty_bank", provider="nse")
+```
+
+### Supported indices
+
+`nifty_50`, `nifty_100`, `nifty_200`, `nifty_500`, `nifty_next_50`, `nifty_bank`,
+`nifty_it`, `nifty_auto`, `nifty_pharma`, `nifty_fmcg`, `nifty_metal`, `nifty_energy`,
+`nifty_fin_service`, `nifty_midcap_100`, `nifty_smallcap_100`.
+
+In addition to the standard `symbol` and `name` fields, this provider enriches each
+constituent with the India-native `industry`, `isin`, and `series` fields.

--- a/openbb_platform/providers/nse/openbb_nse/__init__.py
+++ b/openbb_platform/providers/nse/openbb_nse/__init__.py
@@ -1,0 +1,18 @@
+"""OpenBB NSE Provider module."""
+
+from openbb_core.provider.abstract.provider import Provider
+
+from openbb_nse.models.index_constituents import NseIndexConstituentsFetcher
+
+nse_provider = Provider(
+    name="nse",
+    website="https://www.niftyindices.com",
+    description=(
+        "Data for the National Stock Exchange of India (NSE), sourced from the official"
+        " constituent files published by NSE Indices Limited. No API key is required."
+    ),
+    fetcher_dict={
+        "IndexConstituents": NseIndexConstituentsFetcher,
+    },
+    repr_name="National Stock Exchange of India (NSE)",
+)

--- a/openbb_platform/providers/nse/openbb_nse/models/__init__.py
+++ b/openbb_platform/providers/nse/openbb_nse/models/__init__.py
@@ -1,0 +1,1 @@
+"""OpenBB NSE Provider models."""

--- a/openbb_platform/providers/nse/openbb_nse/models/index_constituents.py
+++ b/openbb_platform/providers/nse/openbb_nse/models/index_constituents.py
@@ -1,0 +1,148 @@
+"""NSE Index Constituents Model."""
+
+# pylint: disable=unused-argument
+
+from typing import Any
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.index_constituents import (
+    IndexConstituentsData,
+    IndexConstituentsQueryParams,
+)
+from pydantic import Field
+
+# Friendly index identifiers -> official NSE Indices constituent files.
+# The files are published by NSE Indices Limited and refreshed on index rebalancing.
+INDEX_FILE_MAP = {
+    "NIFTY_50": "ind_nifty50list.csv",
+    "NIFTY_100": "ind_nifty100list.csv",
+    "NIFTY_200": "ind_nifty200list.csv",
+    "NIFTY_500": "ind_nifty500list.csv",
+    "NIFTY_NEXT_50": "ind_niftynext50list.csv",
+    "NIFTY_BANK": "ind_niftybanklist.csv",
+    "NIFTY_IT": "ind_niftyitlist.csv",
+    "NIFTY_AUTO": "ind_niftyautolist.csv",
+    "NIFTY_PHARMA": "ind_niftypharmalist.csv",
+    "NIFTY_FMCG": "ind_niftyfmcglist.csv",
+    "NIFTY_METAL": "ind_niftymetallist.csv",
+    "NIFTY_ENERGY": "ind_niftyenergylist.csv",
+    "NIFTY_FIN_SERVICE": "ind_niftyfinservicelist.csv",
+    "NIFTY_MIDCAP_100": "ind_niftymidcap100list.csv",
+    "NIFTY_SMALLCAP_100": "ind_niftysmallcap100list.csv",
+}
+
+BASE_URL = "https://www.niftyindices.com/IndexConstituent/"
+
+
+class NseIndexConstituentsQueryParams(IndexConstituentsQueryParams):
+    """NSE Index Constituents Query.
+
+    Source: https://www.niftyindices.com
+
+    The `symbol` is an index identifier, e.g. 'nifty_50' or 'nifty_bank'.
+    """
+
+
+class NseIndexConstituentsData(IndexConstituentsData):
+    """NSE Index Constituents Data."""
+
+    industry: str | None = Field(
+        default=None,
+        description="Industry classification of the constituent, as assigned by NSE.",
+    )
+    isin: str | None = Field(
+        default=None,
+        description="International Securities Identification Number (ISIN) of the constituent.",
+    )
+    series: str | None = Field(
+        default=None,
+        description="Trading series of the constituent on the NSE, e.g. 'EQ'.",
+    )
+
+
+class NseIndexConstituentsFetcher(
+    Fetcher[
+        NseIndexConstituentsQueryParams,
+        list[NseIndexConstituentsData],
+    ]
+):
+    """Transform the query, extract and transform the data from the NSE Indices files."""
+
+    @staticmethod
+    def transform_query(params: dict[str, Any]) -> NseIndexConstituentsQueryParams:
+        """Transform the query params."""
+        return NseIndexConstituentsQueryParams(**params)
+
+    @staticmethod
+    def extract_data(
+        query: NseIndexConstituentsQueryParams,
+        credentials: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> list[dict]:
+        """Return the raw data from the NSE Indices endpoint."""
+        # pylint: disable=import-outside-toplevel
+        from io import BytesIO
+
+        from openbb_core.provider.utils.errors import EmptyDataError
+        from openbb_core.provider.utils.helpers import make_request
+        from pandas import read_csv
+
+        key = query.symbol.upper().replace(" ", "_").replace("-", "_")
+
+        if key not in INDEX_FILE_MAP:
+            supported = ", ".join(sorted(INDEX_FILE_MAP))
+            raise ValueError(f"Unsupported index '{query.symbol}'. Supported indices are: {supported}.")
+
+        url = BASE_URL + INDEX_FILE_MAP[key]
+        # The NSE Indices host expects a browser-like User-Agent.
+        headers = {
+            "User-Agent": (
+                "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36"
+                " (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+            )
+        }
+
+        response = make_request(url, headers=headers, **kwargs)
+
+        if response.status_code != 200 or not response.content:
+            raise EmptyDataError(f"No data returned for index '{query.symbol}' (HTTP {response.status_code}).")
+
+        df = read_csv(BytesIO(response.content))
+        df.columns = [str(col).strip() for col in df.columns]
+
+        return df.to_dict("records")
+
+    @staticmethod
+    def transform_data(
+        query: NseIndexConstituentsQueryParams,
+        data: list[dict],
+        **kwargs: Any,
+    ) -> list[NseIndexConstituentsData]:
+        """Return the transformed data."""
+
+        def _clean(value: Any) -> str | None:
+            """Strip whitespace and normalize empty values to None."""
+            if value is None:
+                return None
+            text = str(value).strip()
+            return text or None
+
+        results: list[NseIndexConstituentsData] = []
+
+        for row in data:
+            symbol = _clean(row.get("Symbol"))
+            if not symbol:
+                continue
+            results.append(
+                NseIndexConstituentsData.model_validate(
+                    {
+                        "symbol": symbol,
+                        "name": _clean(row.get("Company Name")),
+                        "industry": _clean(row.get("Industry")),
+                        "isin": _clean(row.get("ISIN Code")),
+                        "series": _clean(row.get("Series")),
+                    }
+                )
+            )
+
+        return results

--- a/openbb_platform/providers/nse/pyproject.toml
+++ b/openbb_platform/providers/nse/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "openbb-nse"
+version = "1.0.0"
+description = "National Stock Exchange of India (NSE) data extension for OpenBB"
+authors = ["OpenBB <hello@openbb.co>"]
+license = "AGPL-3.0-only"
+readme = "README.md"
+packages = [{ include = "openbb_nse" }]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4"
+openbb-core = "^1.6.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins."openbb_provider_extension"]
+nse = "openbb_nse:nse_provider"

--- a/openbb_platform/providers/nse/tests/__init__.py
+++ b/openbb_platform/providers/nse/tests/__init__.py
@@ -1,0 +1,1 @@
+"""NSE provider tests."""

--- a/openbb_platform/providers/nse/tests/record/http/test_nse_fetchers/test_nse_index_constituents_fetcher_urllib3_v2.yaml
+++ b/openbb_platform/providers/nse/tests/record/http/test_nse_fetchers/test_nse_index_constituents_fetcher_urllib3_v2.yaml
@@ -1,0 +1,170 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate, zstd
+      Connection:
+      - keep-alive
+    method: GET
+    uri: https://www.niftyindices.com/IndexConstituent/ind_nifty50list.csv
+  response:
+    body:
+      string: 'Company Name,Industry,Symbol,Series,ISIN Code
+
+        Adani Enterprises Ltd.,Metals & Mining,ADANIENT,EQ,INE423A01024
+
+        Adani Ports and Special Economic Zone Ltd.,Services,ADANIPORTS,EQ,INE742F01042
+
+        Apollo Hospitals Enterprise Ltd.,Healthcare,APOLLOHOSP,EQ,INE437A01024
+
+        Asian Paints Ltd.,Consumer Durables,ASIANPAINT,EQ,INE021A01026
+
+        Axis Bank Ltd.,Financial Services,AXISBANK,EQ,INE238A01034
+
+        Bajaj Auto Ltd.,Automobile and Auto Components,BAJAJ-AUTO,EQ,INE917I01010
+
+        Bajaj Finance Ltd.,Financial Services,BAJFINANCE,EQ,INE296A01032
+
+        Bajaj Finserv Ltd.,Financial Services,BAJAJFINSV,EQ,INE918I01026
+
+        Bharat Electronics Ltd.,Capital Goods,BEL,EQ,INE263A01024
+
+        Bharti Airtel Ltd.,Telecommunication,BHARTIARTL,EQ,INE397D01024
+
+        Cipla Ltd.,Healthcare,CIPLA,EQ,INE059A01026
+
+        Coal India Ltd.,Oil Gas & Consumable Fuels,COALINDIA,EQ,INE522F01014
+
+        Dr. Reddy''s Laboratories Ltd.,Healthcare,DRREDDY,EQ,INE089A01031
+
+        Eicher Motors Ltd.,Automobile and Auto Components,EICHERMOT,EQ,INE066A01021
+
+        Eternal Ltd.,Consumer Services,ETERNAL,EQ,INE758T01015
+
+        Grasim Industries Ltd.,Construction Materials,GRASIM,EQ,INE047A01021
+
+        HCL Technologies Ltd.,Information Technology,HCLTECH,EQ,INE860A01027
+
+        HDFC Bank Ltd.,Financial Services,HDFCBANK,EQ,INE040A01034
+
+        HDFC Life Insurance Company Ltd.,Financial Services,HDFCLIFE,EQ,INE795G01014
+
+        Hindalco Industries Ltd.,Metals & Mining,HINDALCO,EQ,INE038A01020
+
+        Hindustan Unilever Ltd.,Fast Moving Consumer Goods,HINDUNILVR,EQ,INE030A01027
+
+        ICICI Bank Ltd.,Financial Services,ICICIBANK,EQ,INE090A01021
+
+        ITC Ltd.,Fast Moving Consumer Goods,ITC,EQ,INE154A01025
+
+        Infosys Ltd.,Information Technology,INFY,EQ,INE009A01021
+
+        InterGlobe Aviation Ltd.,Services,INDIGO,EQ,INE646L01027
+
+        JSW Steel Ltd.,Metals & Mining,JSWSTEEL,EQ,INE019A01038
+
+        Jio Financial Services Ltd.,Financial Services,JIOFIN,EQ,INE758E01017
+
+        Kotak Mahindra Bank Ltd.,Financial Services,KOTAKBANK,EQ,INE237A01036
+
+        Larsen & Toubro Ltd.,Construction,LT,EQ,INE018A01030
+
+        Mahindra & Mahindra Ltd.,Automobile and Auto Components,M&M,EQ,INE101A01026
+
+        Maruti Suzuki India Ltd.,Automobile and Auto Components,MARUTI,EQ,INE585B01010
+
+        Max Healthcare Institute Ltd.,Healthcare,MAXHEALTH,EQ,INE027H01010
+
+        NTPC Ltd.,Power,NTPC,EQ,INE733E01010
+
+        Nestle India Ltd.,Fast Moving Consumer Goods,NESTLEIND,EQ,INE239A01024
+
+        Oil & Natural Gas Corporation Ltd.,Oil Gas & Consumable Fuels,ONGC,EQ,INE213A01029
+
+        Power Grid Corporation of India Ltd.,Power,POWERGRID,EQ,INE752E01010
+
+        Reliance Industries Ltd.,Oil Gas & Consumable Fuels,RELIANCE,EQ,INE002A01018
+
+        SBI Life Insurance Company Ltd.,Financial Services,SBILIFE,EQ,INE123W01016
+
+        Shriram Finance Ltd.,Financial Services,SHRIRAMFIN,EQ,INE721A01047
+
+        State Bank of India,Financial Services,SBIN,EQ,INE062A01020
+
+        Sun Pharmaceutical Industries Ltd.,Healthcare,SUNPHARMA,EQ,INE044A01036
+
+        Tata Consultancy Services Ltd.,Information Technology,TCS,EQ,INE467B01029
+
+        Tata Consumer Products Ltd.,Fast Moving Consumer Goods,TATACONSUM,EQ,INE192A01025
+
+        Tata Motors Passenger Vehicles Ltd.,Automobile and Auto Components,TMPV,EQ,INE155A01022
+
+        Tata Steel Ltd.,Metals & Mining,TATASTEEL,EQ,INE081A01020
+
+        Tech Mahindra Ltd.,Information Technology,TECHM,EQ,INE669C01036
+
+        Titan Company Ltd.,Consumer Durables,TITAN,EQ,INE280A01028
+
+        Trent Ltd.,Consumer Services,TRENT,EQ,INE849A01020
+
+        UltraTech Cement Ltd.,Construction Materials,ULTRACEMCO,EQ,INE481G01011
+
+        Wipro Ltd.,Information Technology,WIPRO,EQ,INE075A01022
+
+        '
+    headers:
+      Accept-Ranges:
+      - bytes
+      Access-Control-Allow-Origin:
+      - '*'
+      - '*'
+      Connection:
+      - keep-alive
+      Content-Encoding:
+      - gzip
+      Content-Length:
+      - '1341'
+      Content-Security-Policy:
+      - default-src 'self'; script-src 'report-sample' 'unsafe-inline' 'unsafe-eval'
+        'self' https://ajax.aspnetcdn.com https://www.googletagmanager.com https://liveindexsa.niftyindices.com/
+        https://code.jquery.com https://cdnjs.cloudflare.com https://d2i2wahzwrm1n5.cloudfront.net
+        https://www.gstatic.com http://kendo.cdn.telerik.com https://www.google.com
+        https://cdn.siteimprove.net https://cdn.jsdelivr.net; style-src 'report-sample'
+        'unsafe-inline' 'self' https://liveindexsa.niftyindices.com/ https://fonts.googleapis.com
+        https://d35islomi5rx1v.cloudfront.net; object-src 'none'; base-uri 'self';
+        connect-src 'self' https://liveindexsa.niftyindices.com/ https://www.google-analytics.com
+        https://cdn.jsdelivr.net; font-src 'self' https://liveindexsa.niftyindices.com/
+        https://cdn.blerp.com https://fonts.gstatic.com; frame-src 'self' https://www.google.com;
+        frame-ancestors 'self' https://www.google.com; img-src 'self' https://liveindexsa.niftyindices.com/;
+        manifest-src 'self'; media-src 'self'; report-uri https://new.niftyindices.com/;
+        worker-src 'none';
+      Content-Type:
+      - application/octet-stream
+      Date:
+      - Wed, 15 Jul 2026 09:24:48 GMT
+      ETag:
+      - '"805529a4ba13dd1:0"'
+      Last-Modified:
+      - Tue, 14 Jul 2026 18:00:23 GMT
+      Strict-Transport-Security:
+      - max-age=15768000 ; includeSubDomains ; preload
+      Vary:
+      - Accept-Encoding
+      referrer-policy:
+      - strict-origin-when-cross-origin
+      request-context:
+      - appId=cid-v1:e1ac18a0-4a17-4467-980e-b6788780204d
+      x-content-type-options:
+      - nosniff
+      x-frame-options:
+      - SAMEORIGIN
+      - SAMEORIGIN
+      x-xss-protection:
+      - 1; mode=block
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/openbb_platform/providers/nse/tests/test_nse_fetchers.py
+++ b/openbb_platform/providers/nse/tests/test_nse_fetchers.py
@@ -1,0 +1,26 @@
+"""Test NSE fetchers."""
+
+import pytest
+from openbb_core.app.service.user_service import UserService
+from openbb_nse.models.index_constituents import NseIndexConstituentsFetcher
+
+test_credentials = UserService().default_user_settings.credentials.model_dump(mode="json")
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    """VCR config."""
+    return {
+        "filter_headers": [("User-Agent", None)],
+        "filter_query_parameters": [],
+    }
+
+
+@pytest.mark.record_http
+def test_nse_index_constituents_fetcher(credentials=test_credentials):
+    """Test the NSE Index Constituents fetcher."""
+    params = {"symbol": "nifty_50"}
+
+    fetcher = NseIndexConstituentsFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None

--- a/openbb_platform/pyproject.toml
+++ b/openbb_platform/pyproject.toml
@@ -57,6 +57,7 @@ openbb-finra = { version = "^1.6.1", optional = true }
 openbb-finviz = { version = "^1.5.1", optional = true }
 openbb-multpl = { version = "^1.3.1", optional = true }
 openbb-nasdaq = { version = "^1.6.3", optional = true }
+openbb-nse = { version = "^1.0.0", optional = true }
 openbb-seeking-alpha = { version = "^1.6.1", optional = true }
 openbb-stockgrid = { version = "^1.6.1", optional = true }
 openbb-tmx = { version = "^1.5.2", optional = true }
@@ -82,6 +83,7 @@ finra = ["openbb-finra"]
 finviz = ["openbb-finviz"]
 mcp_server = ["openbb-mcp-server"]
 nasdaq = ["openbb-nasdaq"]
+nse = ["openbb-nse"]
 multpl = ["openbb-multpl"]
 quantitative = ["openbb-quantitative"]
 seeking_alpha = ["openbb-seeking-alpha"]
@@ -106,6 +108,7 @@ all = [
     "openbb-mcp-server",
     "openbb-multpl",
     "openbb-nasdaq",
+    "openbb-nse",
     "openbb-quantitative",
     "openbb-seeking-alpha",
     "openbb-stockgrid",


### PR DESCRIPTION
Adds an `nse` provider for National Stock Exchange of India index constituents, mapped onto the existing `IndexConstituents` model.

```python
obb.index.constituents("nifty_500", provider="nse")
```

Indian equities are already reachable via yfinance/fmp, so I didn't want to just re-add prices. The thing that's actually missing is index membership (NIFTY 50/500, Bank Nifty, the sectoral ones), so that's what this covers. It reads the official constituent files NSE Indices publishes (the `ind_*list.csv` files on niftyindices.com), which are static and need no key or session handling, so none of the usual nseindia.com anti-bot dance. I also kept the industry/isin/series columns from those files as extra fields since they come for free and are useful.

Supported indices right now: nifty_50, nifty_100, nifty_200, nifty_500, nifty_next_50, nifty_bank, nifty_it, nifty_auto, nifty_pharma, nifty_fmcg, nifty_metal, nifty_energy, nifty_fin_service, nifty_midcap_100, nifty_smallcap_100. Adding more is one line in the map.

Marking it draft because I want to check the approach is wanted before building more. If it is, the obvious next step is the India-only data nobody else exposes (delivery volumes, bulk/block deals, FII/DII flows), but that needs new models so I'd keep it to a separate PR. For context, I work with SEBI and Indian market data at my day job, so I use this and can keep it maintained.

## How has this been tested?

Added a fetcher test with a recorded cassette, passes in replay. Also ran it live: nifty_50 returns 50 names, nifty_bank returns 14, with industry/isin/series populated. An unknown index symbol raises a ValueError listing the valid ones. ruff is clean.

- [x] Ensure all unit and integration tests pass.
- New provider / fetcher:
  - [x] Existing tests pass.
  - [x] Provider and fetcher are stable and usable.
  - [x] Added a test for the fetcher, with a recorded cassette.

I registered `openbb-nse` in pyproject.toml (optional dep plus the `nse` and `all` extras) and in dev_install.py. I couldn't find PROVIDERS.md, EXTENSIONS.md, or the community integration workflow the template points at on this branch, so I left those alone. Let me know if I missed a spot.

## Checklist

- [x] I self-reviewed the code.
- [x] I commented the trickier bits.
- [x] I'm following the CONTRIBUTING guidelines.

Branch is `feat/nse-index-constituents` rather than `feature/...`. Happy to rename it if you want strict GitFlow.

Closes #4247
