### PR TITLE
fix(cli): surface actionable errors when OpenAPI spec generation fails

### DIFF
--- a/cli/openbb_cli/cli.py
+++ b/cli/openbb_cli/cli.py
@@ -14,6 +14,16 @@ from typing import Any
 from openbb_cli.utils.utils import change_logging_sub_app, reset_logging_sub_app
 
 
+def _debug_enabled() -> bool:
+    """Return True when debug output (full tracebacks) is requested."""
+    return os.environ.get("OPENBB_DEBUG_MODE", "").strip().lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
 def _materialize_socrata_spec(story_source: str) -> str:
     """Build a Socrata spec from a story and write it to a temp file."""
     import tempfile
@@ -379,6 +389,10 @@ def _launch_repl(
             sys.stderr.write(
                 f"failed to fetch the OpenAPI document from {server_url}: {exc}\n"
             )
+            if _debug_enabled():
+                import traceback
+
+                sys.stderr.write(traceback.format_exc())
             return 2
         spec_doc = build_spec_document(openapi, base_url=server_url)
         if not spec_doc["commands"]:
@@ -471,6 +485,10 @@ def _generate_spec(
         sys.stderr.write(
             f"failed to fetch the OpenAPI document from {server_url}: {exc}\n"
         )
+        if _debug_enabled():
+            import traceback
+
+            sys.stderr.write(traceback.format_exc())
         return 2
     if openapi_path and (
         openapi_path.startswith("http://") or openapi_path.startswith("https://")

--- a/cli/openbb_cli/cli.py
+++ b/cli/openbb_cli/cli.py
@@ -364,13 +364,31 @@ def _launch_repl(
         )
         backend = SpecBackend(dispatcher._spec_doc, dispatcher)
     elif server_url:
+        import httpx
+
         from openbb_cli.backend import SpecBackend
         from openbb_cli.dispatchers.http import http_dispatcher_from_server
         from openbb_cli.dispatchers.openapi_schema import fetch_openapi
         from openbb_cli.dispatchers.spec import build_spec_document
 
-        openapi = fetch_openapi(server_url, headers=headers, query_params=query_params)
+        try:
+            openapi = fetch_openapi(
+                server_url, headers=headers, query_params=query_params
+            )
+        except (httpx.HTTPError, ValueError) as exc:
+            sys.stderr.write(
+                f"failed to fetch the OpenAPI document from {server_url}: {exc}\n"
+            )
+            return 2
         spec_doc = build_spec_document(openapi, base_url=server_url)
+        if not spec_doc["commands"]:
+            sys.stderr.write(
+                f"generated 0 commands from {server_url} — the document exposes no "
+                "GET/POST operations OpenBB can map. Multi-file specs that split "
+                "paths across documents with external $refs must be bundled into "
+                "a single file first.\n"
+            )
+            return 2
         backend = SpecBackend(
             spec_doc,
             http_dispatcher_from_server(
@@ -440,12 +458,20 @@ def _generate_spec(
         )
         return 2
 
+    import httpx
+
     from openbb_cli.dispatchers.openapi_schema import fetch_openapi
     from openbb_cli.dispatchers.spec import build_spec_document
 
-    openapi = fetch_openapi(
-        server_url, path=openapi_path, headers=headers, query_params=query_params
-    )
+    try:
+        openapi = fetch_openapi(
+            server_url, path=openapi_path, headers=headers, query_params=query_params
+        )
+    except (httpx.HTTPError, ValueError) as exc:
+        sys.stderr.write(
+            f"failed to fetch the OpenAPI document from {server_url}: {exc}\n"
+        )
+        return 2
     if openapi_path and (
         openapi_path.startswith("http://") or openapi_path.startswith("https://")
     ):

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -591,10 +591,14 @@ def _parse_spec_text(text: str, *, content_type: str = "") -> dict[str, Any]:
 
 
 def _yaml_load(text: str) -> dict[str, Any]:
-    """Parse a YAML document."""
+    """Parse a YAML document, raising ``ValueError`` on malformed input."""
     import yaml
 
-    return yaml.safe_load(text)
+    try:
+        return yaml.safe_load(text)
+    except yaml.YAMLError as exc:
+        first_line = str(exc).splitlines()[0] if str(exc) else exc.__class__.__name__
+        raise ValueError(f"Document is not valid YAML: {first_line}") from exc
 
 
 _EMBEDDED_SPEC_MARKERS: tuple[str, ...] = (
@@ -673,9 +677,20 @@ def _resolve_json_pointer(document: Any, fragment: str) -> Any:
     for raw_part in pointer[1:].split("/"):
         part = raw_part.replace("~1", "/").replace("~0", "~")
         if isinstance(node, dict):
+            if part not in node:
+                raise ValueError(
+                    f"OpenAPI reference pointer #{fragment} not found: "
+                    f"no member {part!r}"
+                )
             node = node[part]
         elif isinstance(node, list):
-            node = node[int(part)]
+            try:
+                node = node[int(part)]
+            except (ValueError, IndexError) as exc:
+                raise ValueError(
+                    f"OpenAPI reference pointer #{fragment} not found: "
+                    f"invalid array index {part!r}"
+                ) from exc
         else:
             raise ValueError(f"Invalid OpenAPI reference fragment: #{fragment}")
     return node

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -578,6 +578,18 @@ def build_reference(
 def _parse_spec_text(text: str, *, content_type: str = "") -> dict[str, Any]:
     """Parse a fetched spec body, choosing JSON or YAML by content sniff."""
     stripped = text.lstrip()
+    looks_html = "html" in content_type.lower() or stripped[:15].lower().startswith(
+        ("<!doctype html", "<html")
+    )
+    if looks_html:
+        embedded = _extract_embedded_spec(text)
+        if embedded is not None:
+            return embedded
+        raise ValueError(
+            "the URL returned an HTML page, not an OpenAPI document. "
+            "If this is a GitHub 'blob' link, use the raw file URL "
+            "(or append '?raw=true')."
+        )
     if stripped.startswith(("{", "[")):
         return json.loads(text)
     if "yaml" in content_type or "yml" in content_type:

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -985,6 +985,82 @@ def test_generate_spec_errors_when_zero_commands(tmp_path, capsys):
     assert not (tmp_path / "x.spec").exists()
 
 
+def test_generate_spec_errors_when_fetch_fails(tmp_path, capsys):
+    """A connection failure is a one-line actionable error, not a traceback."""
+    import httpx
+
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        rc = cli._generate_spec(
+            "http://localhost:1",
+            str(tmp_path / "x.spec"),
+            None,
+        )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to fetch the OpenAPI document" in err
+    assert "http://localhost:1" in err
+    assert "connection refused" in err
+    assert not (tmp_path / "x.spec").exists()
+
+
+def test_generate_spec_errors_on_http_status_error(tmp_path, capsys):
+    """An HTTP error status from the spec endpoint surfaces its cause."""
+    import httpx
+
+    error = httpx.HTTPStatusError(
+        "Server error '500 Internal Server Error'",
+        request=httpx.Request("GET", "http://localhost:8000/openapi.json"),
+        response=httpx.Response(500),
+    )
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        side_effect=error,
+    ):
+        rc = cli._generate_spec(
+            "http://localhost:8000",
+            str(tmp_path / "x.spec"),
+            None,
+        )
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to fetch the OpenAPI document" in err
+    assert "500" in err
+
+
+def test_launch_repl_server_fetch_failure_is_actionable(capsys):
+    """``openbb --server URL`` with an unreachable server exits 2 with a message."""
+    import httpx
+
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        rc = cli._launch_repl(False, False, None, "http://localhost:1")
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to fetch the OpenAPI document" in err
+    assert "http://localhost:1" in err
+
+
+def test_launch_repl_server_zero_commands_is_loud(capsys):
+    """A spec that maps to no commands never launches an empty REPL."""
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        return_value={
+            "openapi": "3.1.0",
+            "paths": {"/x": {"$ref": "./paths/x.yaml#/~1x"}},
+        },
+    ):
+        rc = cli._launch_repl(False, False, None, "http://localhost:8000")
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "0 commands" in err
+    assert "external $refs" in err
+
+
 def test_generate_extension_aborts_when_spec_has_zero_commands(tmp_path, capsys):
     """An empty spec never reaches codegen — no zero-command skeleton package."""
     from openbb_cli.dispatchers.spec import SPEC_VERSION, write_spec

--- a/cli/tests/test_cli.py
+++ b/cli/tests/test_cli.py
@@ -1006,6 +1006,42 @@ def test_generate_spec_errors_when_fetch_fails(tmp_path, capsys):
     assert not (tmp_path / "x.spec").exists()
 
 
+def test_generate_spec_fetch_failure_hides_traceback_by_default(
+    tmp_path, capsys, monkeypatch
+):
+    """Without OPENBB_DEBUG_MODE the failure stays a one-line message."""
+    import httpx
+
+    monkeypatch.delenv("OPENBB_DEBUG_MODE", raising=False)
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        rc = cli._generate_spec("http://localhost:1", str(tmp_path / "x.spec"), None)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to fetch the OpenAPI document" in err
+    assert "Traceback" not in err
+
+
+def test_generate_spec_fetch_failure_shows_traceback_in_debug(
+    tmp_path, capsys, monkeypatch
+):
+    """With OPENBB_DEBUG_MODE the full traceback is emitted for diagnosis."""
+    import httpx
+
+    monkeypatch.setenv("OPENBB_DEBUG_MODE", "1")
+    with patch(
+        "openbb_cli.dispatchers.openapi_schema.fetch_openapi",
+        side_effect=httpx.ConnectError("connection refused"),
+    ):
+        rc = cli._generate_spec("http://localhost:1", str(tmp_path / "x.spec"), None)
+    assert rc == 2
+    err = capsys.readouterr().err
+    assert "failed to fetch the OpenAPI document" in err
+    assert "Traceback" in err
+
+
 def test_generate_spec_errors_on_http_status_error(tmp_path, capsys):
     """An HTTP error status from the spec endpoint surfaces its cause."""
     import httpx

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -1824,6 +1824,69 @@ def test_bundle_external_refs_rejects_resource_identifiers():
         )
 
 
+def test_resolve_json_pointer_missing_member_is_actionable():
+    from openbb_cli.dispatchers.openapi_schema import _resolve_json_pointer
+
+    with pytest.raises(ValueError, match=r"no member 'missing'"):
+        _resolve_json_pointer({"paths": {}}, "/paths/missing")
+
+
+def test_resolve_json_pointer_bad_array_index_is_actionable():
+    from openbb_cli.dispatchers.openapi_schema import _resolve_json_pointer
+
+    with pytest.raises(ValueError, match=r"invalid array index 'x'"):
+        _resolve_json_pointer({"servers": []}, "/servers/x")
+    with pytest.raises(ValueError, match=r"invalid array index '3'"):
+        _resolve_json_pointer({"servers": [1]}, "/servers/3")
+
+
+def test_bundle_external_refs_dangling_pointer_is_actionable(monkeypatch):
+    """A modular spec whose external ref points at a missing member names the
+    pointer instead of raising a bare ``KeyError``."""
+    from openbb_cli.dispatchers import openapi_schema
+
+    class _Response:
+        status_code = 200
+        headers = {"content-type": "application/json"}
+        is_redirect = False
+        encoding = "utf-8"
+        content = b'{"paths": {}}'
+
+        def __enter__(self):
+            return self
+
+        def __exit__(self, *_args):
+            return None
+
+        def iter_bytes(self, *, chunk_size):
+            yield self.content
+
+        def raise_for_status(self):
+            return None
+
+    monkeypatch.setattr(
+        openapi_schema.httpx, "stream", lambda *_args, **_kwargs: _Response()
+    )
+    with pytest.raises(ValueError, match=r"pointer #/paths/~1x not found"):
+        _bundle_external_refs(
+            {
+                "openapi": "3.1.0",
+                "paths": {"/x": {"$ref": "paths.json#/paths/~1x"}},
+            },
+            "https://api.example/openapi.json",
+            timeout=1,
+            headers={},
+        )
+
+
+def test_parse_spec_text_malformed_yaml_raises_value_error():
+    """Broken YAML surfaces as ``ValueError``, not a raw ``yaml.YAMLError``."""
+    from openbb_cli.dispatchers.openapi_schema import _parse_spec_text
+
+    with pytest.raises(ValueError, match="not valid YAML"):
+        _parse_spec_text("openapi: 3.1.0\n\tpaths: {", content_type="application/yaml")
+
+
 def test_bundle_external_refs_leaves_type_arrays_to_ingestion_normalization():
     """Bundling only inlines refs — 3.1 type arrays are ``expand_type_arrays``'
     job inside ``_ensure_openapi_dict``, which every fetched document passes

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -590,6 +590,27 @@ def test_parse_spec_text_recognizes_json_array_form():
     assert _parse_spec_text("[1, 2]") == [1, 2]
 
 
+def test_parse_spec_text_rejects_html_page_before_yaml_parser():
+    """An HTML page (e.g. a GitHub blob URL) is caught before the YAML parser."""
+    from openbb_cli.dispatchers.openapi_schema import _parse_spec_text
+
+    html = (
+        "<!DOCTYPE html><html><head><style>--tab-size-preference: 4;</style>"
+        "</head><body>page</body></html>"
+    )
+    with pytest.raises(ValueError, match="HTML page"):
+        _parse_spec_text(html, content_type="text/html; charset=utf-8")
+
+
+def test_parse_spec_text_returns_embedded_spec_from_html():
+    """HTML that embeds an OpenAPI spec (Swagger UI) is still parsed."""
+    from openbb_cli.dispatchers.openapi_schema import _parse_spec_text
+
+    html = '<html><script>var spec = {"openapi": "3.0.0", "paths": {}};</script></html>'
+    out = _parse_spec_text(html, content_type="text/html")
+    assert out.get("openapi") == "3.0.0"
+
+
 def test_fetch_openapi_default_path_and_user_agent(monkeypatch):
     """Default appends ``/openapi.json`` and merges the default User-Agent."""
     from openbb_cli.dispatchers import openapi_schema


### PR DESCRIPTION
Follow-up to #7585, as invited by @deeleeramone in https://github.com/OpenBB-finance/OpenBB/issues/7585#issuecomment-4973275161. #7586 and #7589 fixed the modular spec resolution and added zero-command guards to `--generate-spec` and `--generate-extension`. This PR covers the remaining places where a bad document or an unreachable server still produced a raw traceback or a silent empty session.

## What changed

1. Interactive `openbb --server URL` startup (`cli/openbb_cli/cli.py`)
   - A fetch failure (connection refused, timeout, HTTP error status, unparseable document) now prints a one-line actionable message to stderr and exits 2 instead of dumping a traceback through the top-level exception handler.
   - A document that resolves to zero GET/POST commands now aborts with the same guard message used by `--generate-spec`, instead of silently launching an empty REPL.

2. `--generate-spec` fetch errors (`cli/openbb_cli/cli.py`)
   - `httpx` transport and status errors, and `ValueError` from parsing or bundling, are caught and reported as `failed to fetch the OpenAPI document from <url>: <cause>`, exit 2.

3. Dangling JSON pointers in external refs (`cli/openbb_cli/dispatchers/openapi_schema.py`)
   - `_resolve_json_pointer` previously raised a bare `KeyError: 'foo'` or `IndexError` when a modular spec pointed at a missing member. It now raises `ValueError` naming the pointer and the failing part, for example: `OpenAPI reference pointer #/paths/~1x not found: no member '/x'`.

4. Malformed YAML (`cli/openbb_cli/dispatchers/openapi_schema.py`)
   - `yaml.YAMLError` escaped the existing `except (json.JSONDecodeError, ValueError)` handling in `fetch_openapi`, so a broken YAML endpoint produced a raw scanner traceback. `_yaml_load` now converts it to `ValueError("Document is not valid YAML: <first line>")`, which integrates with the existing fallback logic.

## Tests

- `cli/tests/test_cli.py`: fetch failure and HTTP 500 during `--generate-spec`; fetch failure and zero-command guard on interactive `--server` startup.
- `cli/tests/test_dispatchers_openapi_schema.py`: missing member and bad array index in `_resolve_json_pointer`; dangling pointer through `_bundle_external_refs`; malformed YAML through `_parse_spec_text`.

All of `cli/tests/test_cli.py`, `cli/tests/test_dispatchers_openapi_schema.py`, and `cli/tests/test_dispatchers_spec.py` pass locally (309 tests).
