### PR TITLE
fix(mcp): support stdio transport on Windows

### DIFF
--- a/openbb_platform/extensions/mcp_server/openbb_mcp_server/app/app.py
+++ b/openbb_platform/extensions/mcp_server/openbb_mcp_server/app/app.py
@@ -942,7 +942,12 @@ async def stdio_main(mcp_server):
         os._exit(0)  # pylint: disable=protected-access
 
     for sig in (signal.SIGINT, signal.SIGTERM):
-        loop.add_signal_handler(sig, signal_handler)
+        try:
+            loop.add_signal_handler(sig, signal_handler)
+        except NotImplementedError:
+            # Windows event loops do not support signal handlers. The MCP client
+            # owns the stdio child process and closes it directly.
+            break
 
     logger.info("Starting OpenBB MCP Server in STDIO mode. Press Ctrl+C to stop.")
 

--- a/openbb_platform/extensions/mcp_server/tests/app/test_app.py
+++ b/openbb_platform/extensions/mcp_server/tests/app/test_app.py
@@ -1,5 +1,6 @@
 """Unit tests for app module."""
 
+import asyncio
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -13,6 +14,7 @@ from openbb_mcp_server.app.app import (
     _read_system_prompt_file,
     _strip_api_prefix,
     create_mcp_server,
+    stdio_main,
 )
 from openbb_mcp_server.models.settings import MCPSettings
 
@@ -54,6 +56,18 @@ def test_read_system_prompt_file(tmp_path):
     prompt_file.write_text("Test prompt")
     assert _read_system_prompt_file(str(prompt_file)) == "Test prompt"
     assert _read_system_prompt_file("nonexistent.txt") is None
+
+
+@pytest.mark.asyncio
+async def test_stdio_main_runs_when_signal_handlers_are_unsupported():
+    """Windows event loops can serve stdio without registering signal handlers."""
+    loop = asyncio.get_running_loop()
+    mcp_server = MagicMock()
+
+    with patch.object(loop, "add_signal_handler", side_effect=NotImplementedError):
+        await stdio_main(mcp_server)
+
+    mcp_server.run.assert_called_once_with("stdio")
 
 
 @patch("openbb_mcp_server.app.app.process_fastapi_routes_for_mcp")


### PR DESCRIPTION
## Description

- [x] Fixes #7595. Windows asyncio loops raise `NotImplementedError` when registering signal handlers, so stdio now treats that registration as optional and continues serving the MCP client.
- [x] No dependencies required.

## How has this been tested?

- [x] `python -m pytest tests -q` — 174 passed, 4 skipped.
- [x] Regression test simulates an event loop without signal-handler support and verifies the stdio server still starts.
- [x] `ruff check` passes on both changed files.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented the Windows-specific behavior.
- [x] I have adhered to the GitFlow naming convention (`hotfix/mcp-stdio-windows`).
- [x] I am following the contributing guidelines.
- [x] Tests cover the bug fix.
