### PR TITLE
`generate-extension`: Update generated tests to get python param names instead of raw names

### DIFF
--- a/cli/openbb_cli/codegen/test_gen.py
+++ b/cli/openbb_cli/codegen/test_gen.py
@@ -5,6 +5,8 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import TYPE_CHECKING, Any
 
+from openbb_cli.codegen.pydantic_gen import safe_field_name
+
 if TYPE_CHECKING:
     from openbb_cli.codegen.fetcher_gen import GeneratedFetcher
 
@@ -251,13 +253,14 @@ def _derive_test_params(
         param_providers = raw.get("providers") or []
         if param_providers and provider_name not in param_providers:
             continue
+        field_name, _ = safe_field_name(name)
         if raw.get("required"):
             value = _spec_supplied_value(raw)
             if value is None:
                 return None
-            out[name] = value
+            out[field_name] = value
         elif _is_date_param(name):
-            out[name] = _refresh_date_shape(name, "1970-01-01")
+            out[field_name] = _refresh_date_shape(name, "1970-01-01")
     return out
 
 


### PR DESCRIPTION
This PR fixes an issue in the tests that get generated for that showed up in [`test_eodhd_fetchers.py`](https://github.com/rockbound/openbb-eodhd/blob/main/tests/test_eodhd_fetchers.py) in the generated openbb-eodhd extension. 

There are parameter names for the API provider endpoints that are not valid python function parameters (like python keyword `from` or bracketed string `page[limit]`), and this is fine because we create aliases for those names. This PR fixes the minor bug where before we were using those raw parameter names in certain tests, and now we are correctly using the aliases. (This is a bugfix for tests inside the newly generated extension code, not tests in OpenBB.)

The test failures were `test_news_fetcher`, `test_ust_bill_rates_fetcher`, `test_ust_long_term_rates_fetcher`, `test_ust_real_yield_rates_fetcher`, and `test_ust_yield_rates_fetcher`. You can see the passing tests here: https://github.com/rockbound/openbb-eodhd/actions/workflows/tests.yml

(Follows from discussion in #7582.)