### PR TITLE
fix(mcp): log exception type and traceback on fatal server error

### DIFF
--- a/openbb_platform/extensions/mcp_server/openbb_mcp_server/app/app.py
+++ b/openbb_platform/extensions/mcp_server/openbb_mcp_server/app/app.py
@@ -1024,7 +1024,7 @@ def main():
         logger.info("Shutdown requested via keyboard interrupt.")
         sys.exit(0)
     except Exception as e:
-        logger.error("Server error: %s", e)
+        logger.exception("Server error: %s: %s", type(e).__name__, e)
         sys.exit(1)
 
 

--- a/openbb_platform/extensions/mcp_server/tests/app/test_app.py
+++ b/openbb_platform/extensions/mcp_server/tests/app/test_app.py
@@ -1,5 +1,6 @@
 """Unit tests for app module."""
 
+import argparse
 from unittest.mock import MagicMock, patch
 
 import pytest
@@ -54,6 +55,37 @@ def test_read_system_prompt_file(tmp_path):
     prompt_file.write_text("Test prompt")
     assert _read_system_prompt_file(str(prompt_file)) == "Test prompt"
     assert _read_system_prompt_file("nonexistent.txt") is None
+
+
+@patch("openbb_mcp_server.app.app.create_mcp_server")
+@patch("openbb_mcp_server.app.app.MCPService")
+@patch("openbb_mcp_server.app.app.parse_args")
+@patch("openbb_mcp_server.app.app.logger")
+def test_main_logs_exception_type_on_fatal_error(
+    mock_logger, mock_parse_args, _mock_service, mock_create
+):
+    """A fatal error with an empty str() still logs its type, not a blank message."""
+    from openbb_mcp_server.app.app import main
+
+    mock_parse_args.return_value = argparse.Namespace(
+        transport="stdio",
+        imported_app=None,
+        uvicorn_config={},
+        allowed_categories=None,
+        default_categories=None,
+        tool_discovery=None,
+        system_prompt=None,
+        server_prompts=None,
+    )
+    # NotImplementedError() has an empty str(); the old logger.error left the line blank.
+    mock_create.side_effect = NotImplementedError()
+
+    with pytest.raises(SystemExit) as exc_info:
+        main()
+
+    assert exc_info.value.code == 1
+    mock_logger.exception.assert_called_once()
+    assert "NotImplementedError" in mock_logger.exception.call_args.args
 
 
 @patch("openbb_mcp_server.app.app.process_fastapi_routes_for_mcp")


### PR DESCRIPTION
## Description

Complements #7596 by covering the second problem raised in #7595.

`openbb-mcp --transport stdio` on Windows exits with a blank `ERROR Server error: ` line and no detail. #7596 fixes the underlying crash (`loop.add_signal_handler` raising `NotImplementedError` on Windows event loops). This PR fixes why the failure was undiagnosable: `main()` logged the exception with `logger.error("Server error: %s", e)`, and because `str(NotImplementedError())` is empty the line was blank, with no type and no traceback.

The handler now uses `logger.exception` and prepends `type(e).__name__`:

```python
except Exception as e:
    logger.exception("Server error: %s: %s", type(e).__name__, e)
    sys.exit(1)
```

So any fatal error, including empty-string exceptions, is logged with its type and full traceback.

## How has this been tested?

- Added `test_main_logs_exception_type_on_fatal_error`: forces a fatal `NotImplementedError()` (empty `str()`) through `main()` and asserts it exits 1 and logs the exception type.
- `pytest openbb_platform/extensions/mcp_server/tests` on Windows 11 (build 26200): 176 passed, 2 skipped.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] Tests cover the fix.
- [x] No new dependencies.
