### PR TITLE
Fix codegen field-name aliasing so generated extensions are callable

### DIFF
--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -321,8 +321,15 @@ def _signature_params(
     array_field: str | None,
     array_annotation: str | None,
     has_credentials: bool,
-) -> list[tuple[str, str, str | None, bool, Any]]:
-    """Build the function parameter list (name, annotation, description, required, default).
+) -> list[tuple[str, str, str | None, bool, Any, str]]:
+    """Build the function parameter list (safe_name, annotation, description, required, default, raw_name).
+
+    ``safe_name`` is what actually gets declared in the ``async def`` signature
+    and referenced in the function body (snake_case, aliased via
+    ``safe_field_name`` exactly like the sibling Pydantic-model generator).
+    ``raw_name`` is the original on-the-wire key from the spec, kept alongside
+    so ``_render_body_block`` can still emit the correct JSON/query key while
+    referencing the Python-valid variable.
 
     Parameters
     ----------
@@ -340,7 +347,7 @@ def _signature_params(
     list of tuple
         Per-parameter tuples in declaration order.
     """
-    out: list[tuple[str, str, str | None, bool, Any]] = []
+    out: list[tuple[str, str, str | None, bool, Any, str]] = []
     if has_credentials:
         out.append(
             (
@@ -349,10 +356,12 @@ def _signature_params(
                 "Provides access to user-configured credentials.",
                 True,
                 None,
+                "cc",
             )
         )
     if array_field and array_annotation:
-        out.append((array_field, array_annotation, "Body data rows.", True, None))
+        safe = safe_field_name(array_field)[0]
+        out.append((safe, array_annotation, "Body data rows.", True, None, array_field))
     body_props = (cmd_spec.get("request_body_schema") or {}).get("properties") or {}
     body_required = set(
         (cmd_spec.get("request_body_schema") or {}).get("required") or []
@@ -369,13 +378,15 @@ def _signature_params(
                 "choices": schema.get("enum"),
             }
         )
+        safe = safe_field_name(name)[0]
         out.append(
             (
-                name,
+                safe,
                 ann,
                 schema.get("description") or schema.get("title"),
                 name in body_required,
                 schema.get("default"),
+                name,
             )
         )
     for raw in filter_user_params(cmd_spec.get("parameters") or []):
@@ -383,13 +394,15 @@ def _signature_params(
         if not name:
             continue
         ann = _python_type_from_param(raw)
+        safe = safe_field_name(name)[0]
         out.append(
             (
-                name,
+                safe,
                 ann,
                 raw.get("help"),
                 bool(raw.get("required")),
                 raw.get("default"),
+                name,
             )
         )
     out.sort(key=lambda entry: (0 if entry[0] == "cc" else 1, 0 if entry[3] else 1))
@@ -398,7 +411,7 @@ def _signature_params(
 
 def _render_signature(
     func_name: str,
-    params: list[tuple[str, str, str | None, bool, Any]],
+    params: list[tuple[str, str, str | None, bool, Any, str]],
     return_annotation: str,
 ) -> str:
     """Render ``async def func_name(...) -> return_annotation:`` lines.
@@ -420,7 +433,7 @@ def _render_signature(
     if not params:
         return f"async def {func_name}() -> {return_annotation}:"
     lines = [f"async def {func_name}("]
-    for name, annotation, _, required, default in params:
+    for name, annotation, _, required, default, _raw_name in params:
         if required:
             lines.append(f"    {name}: {annotation},")
         else:
@@ -593,7 +606,7 @@ def _render_body_block(
     base_url: str,
     cred_lines: list[str],
     data_class: str,
-    params: list[tuple[str, str, str | None, bool, Any]],
+    params: list[tuple[str, str, str | None, bool, Any, str]],
 ) -> str:
     """Render the function body for a POST command.
 
@@ -625,25 +638,36 @@ def _render_body_block(
     """
     body_props = (cmd_spec.get("request_body_schema") or {}).get("properties") or {}
     body_field_names = list(body_props)
+    # (safe_name, raw_name) pairs for params that go in the query string, i.e.
+    # everything that isn't the context object or a request-body field.
+    # Compared and later substituted by `raw_name` (the real wire/URL key);
+    # `safe_name` is the actual Python identifier declared in the signature.
     query_field_names = [
-        n for n, _, _, _, _ in params if n != "cc" and n not in body_field_names
+        (safe_name, raw_name)
+        for safe_name, _, _, _, _, raw_name in params
+        if raw_name != "cc" and raw_name not in body_field_names
     ]
+
+    # Map each raw (wire/URL) param name to its safe Python identifier so
+    # `.format(...)` and the query-dict build below reference the name that
+    # was actually declared in the signature, not the raw spec name.
+    safe_by_raw = {raw_name: safe_name for safe_name, _, _, _, _, raw_name in params}
 
     lines: list[str] = []
     lines.extend(cred_lines)
 
     if path_params:
-        sub_args = ", ".join(f"{p}={p}" for p in path_params)
+        sub_args = ", ".join(f"{p}={safe_by_raw.get(p, p)}" for p in path_params)
         lines.append(f"    _path = {url_path_template!r}.format({sub_args})")
     else:
         lines.append(f"    _path = {url_path_template!r}")
 
     lines.append("    _query_dict: dict[str, Any] = {}")
-    for name in query_field_names:
-        if name in path_params:
+    for safe_name, raw_name in query_field_names:
+        if raw_name in path_params:
             continue
-        lines.append(f"    if {name} is not None:")
-        lines.append(f"        _query_dict[{name!r}] = {name}")
+        lines.append(f"    if {safe_name} is not None:")
+        lines.append(f"        _query_dict[{raw_name!r}] = {safe_name}")
     for canonical, info in creds.items():
         if info["in"] != "query":
             continue

--- a/cli/openbb_cli/codegen/pydantic_gen.py
+++ b/cli/openbb_cli/codegen/pydantic_gen.py
@@ -54,8 +54,35 @@ class GeneratedClass:
         return out
 
 
+def _to_snake_case(string: str) -> str:
+    """Convert a string to snake_case.
+
+    Mirrors ``openbb_core.provider.utils.helpers.to_snake_case`` so that
+    generated field names match the casing the rest of the platform
+    (``provider_interface.py``) assumes for every non-standard provider field.
+    """
+    s1 = re.sub(r"(.)([A-Z][a-z]+)", r"\1_\2", string)
+    return (
+        re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", s1)
+        .lower()
+        .replace(" ", "_")
+        .replace("__", "_")
+    )
+
+
 def safe_field_name(name: str) -> tuple[str, bool]:
-    """Normalize a JSON property name to a valid Python identifier.
+    """Normalize a JSON property name to a valid, snake_case Python identifier.
+
+    The platform's field-exposure layer (``ProviderInterface._extract_params``
+    / ``_extract_data``) unconditionally renders every non-standard provider
+    field through ``to_snake_case`` for its public docstrings and extra-params
+    dataclasses, without touching the underlying Pydantic model. If the model
+    field itself is left in its on-the-wire casing (e.g. ``datasetId``), the
+    two views of the field name diverge and the parameter can no longer be
+    supplied through the standard ``obb.<namespace>.<command>()`` interface:
+    the "documented" snake_case name isn't a real field, and the real
+    camelCase name isn't recognized by the params machinery either. Aliasing
+    to snake_case here keeps the generated model consistent with that layer.
 
     Returns ``(safe_name, needs_alias)``.
     """
@@ -64,6 +91,7 @@ def safe_field_name(name: str) -> tuple[str, bool]:
         cleaned = "field"
     if cleaned[0].isdigit():
         cleaned = f"f_{cleaned}"
+    cleaned = _to_snake_case(cleaned)
     if keyword.iskeyword(cleaned) or cleaned in _PYTHON_RESERVED_FIELD_NAMES:
         cleaned = f"{cleaned}_"
     return (cleaned, cleaned != name)

--- a/cli/tests/test_codegen_post_gen.py
+++ b/cli/tests/test_codegen_post_gen.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import ast
 
+import pytest
+
 from openbb_cli.codegen import post_gen as pg
 
 # --- _module_name_from_command ---
@@ -492,8 +494,8 @@ def test_render_signature_no_params_renders_empty_signature():
 
 def test_render_signature_renders_required_and_optional_with_defaults():
     params = [
-        ("data", "list[X]", "Body data.", True, None),
-        ("limit", "int", "Limit.", False, 5),
+        ("data", "list[X]", "Body data.", True, None, "data"),
+        ("limit", "int", "Limit.", False, 5, "limit"),
     ]
     out = pg._render_signature("foo", params, "OBBject[list[FooData]]")
     assert "async def foo(" in out
@@ -738,6 +740,72 @@ def test_generate_post_command_module_body_props_only_object_form():
     assert "_body: dict[str, Any] = {" in src
     assert "'alpha': alpha," in src
     assert "'beta': beta," in src
+
+
+def test_generate_post_command_module_camel_case_body_field_is_callable():
+    """Regression test: a camelCase body field (very common in real OpenAPI
+    specs) must produce a *callable* module, not just one that parses.
+
+    Before this fix, ``_signature_params`` declared the parameter using the
+    raw on-the-wire name (``searchFields``) while ``_render_body_block``
+    referenced ``safe_field_name(name)`` (``search_fields``) when building
+    the JSON body -- two different identifiers, so ``ast.parse`` succeeded
+    (both are individually valid names) but every real call raised
+    ``NameError: name 'search_fields' is not defined``. Actually exec'ing
+    the generated module and calling the function is the only way to catch
+    that class of bug; static assertions on generated text are not enough.
+    """
+    spec = pg.PostCommandSpec(
+        name="tools.search",
+        cmd_spec={
+            "url_path": "/search",
+            "method": "post",
+            "description": "Search.",
+            "request_body_schema": {
+                "type": "object",
+                "properties": {
+                    "search": {"type": "string"},
+                    "searchFields": {"type": "string"},
+                },
+            },
+            "response_schema": {"type": "object"},
+        },
+        base_url="https://api.example.com",
+        api_prefix="",
+        provider_name="tools",
+    )
+    out = pg.generate_post_command_module(spec)
+    src = out.source
+    ast.parse(src)
+    # The signature declares the safe (snake_case) identifier; the wire key
+    # sent in the JSON body stays the original camelCase from the spec.
+    assert "search_fields: str = None," in src
+    assert "'searchFields': search_fields," in src
+
+    # The generated module's `from ....utils import unpack_response` is a
+    # real relative import inside the eventual installed package; it has no
+    # parent package here, so stub it out -- this test only cares whether
+    # the *signature and body variable names agree*, not the response
+    # unpacking helper.
+    stubbed_src = src.replace(
+        "from ....utils import unpack_response",
+        "def unpack_response(payload): return [], {}",
+    )
+    namespace: dict = {}
+    exec(compile(stubbed_src, "<generated tools.search>", "exec"), namespace)  # noqa: S102
+    coro = namespace["tools_search"](search="q", search_fields="name")
+    try:
+        coro.send(None)
+    except StopIteration:
+        pytest.fail("Coroutine should not complete without a mocked HTTP session.")
+    except Exception as exc:  # noqa: BLE001
+        # Any failure past this point is the (real, unmocked) HTTP call
+        # itself -- proof the NameError this test guards against never
+        # happened at all.
+        assert "search_fields" not in str(exc)
+        assert not isinstance(exc, NameError)
+    finally:
+        coro.close()
 
 
 def test_generate_post_command_module_appends_period_when_description_lacks_terminator():

--- a/cli/tests/test_codegen_pydantic_gen.py
+++ b/cli/tests/test_codegen_pydantic_gen.py
@@ -14,7 +14,20 @@ def test_safe_field_name_passes_through_valid_identifier():
 
 
 def test_safe_field_name_replaces_invalid_chars():
-    assert pg.safe_field_name("X-API-Key") == ("X_API_Key", True)
+    assert pg.safe_field_name("X-API-Key") == ("x_api_key", True)
+
+
+def test_safe_field_name_converts_camel_case_to_snake_case():
+    """Every non-standard provider field is rendered through
+    ``to_snake_case`` by ``ProviderInterface._extract_params`` /
+    ``_extract_data`` for its public docstrings and extra-params dataclass,
+    with no matching rename on the underlying Pydantic model. A field left
+    in its on-the-wire casing (e.g. ``datasetId``) is therefore unreachable
+    through ``obb.<namespace>.<command>()``: the "documented" snake_case
+    name isn't a real field, and the real camelCase name isn't recognized
+    by the params machinery either. Aliasing every non-snake_case field
+    keeps the generated model consistent with that layer."""
+    assert pg.safe_field_name("datasetId") == ("dataset_id", True)
 
 
 def test_safe_field_name_prefixes_leading_digit_with_letter():
@@ -434,7 +447,7 @@ def test_generate_class_field_alias_for_dotted_property_name():
         "properties": {"X-API-Key": {"type": "string"}},
     }
     cls = pg.generate_class(schema, class_name="Headers")
-    assert "X_API_Key:" in cls.source
+    assert "x_api_key:" in cls.source
     assert "alias='X-API-Key'" in cls.source
 
 
@@ -875,7 +888,8 @@ def test_optional_enum_field_emits_literal_with_optional_none_suffix():
     }
     cls = pg.generate_class(schema, class_name="Auction")
     src = cls.source
-    assert "operationDirection: Literal['P', 'S'] | None" in src
+    assert "operation_direction: Literal['P', 'S'] | None" in src
+    assert "alias='operationDirection'" in src
     # Choices still surface in the description for user-facing context.
     assert "Choices: P, S" in src
     assert "Example: P" in src


### PR DESCRIPTION
## Summary

Testing the new `--generate-spec` / `--generate-extension` codegen tool against a real API (World Bank Data360, a genuinely public/free API with no key required) surfaced a bug that makes every codegen-generated extension unusable through the standard `obb.<namespace>.<command>()` interface whenever a query parameter's wire name isn't already snake_case.

- `safe_field_name()` in `pydantic_gen.py` only aliases a JSON property name when it isn't a *syntactically valid* Python identifier. camelCase names (e.g. `datasetId`) are valid identifiers, so they were kept verbatim as the Pydantic field name.
- `ProviderInterface` (`provider_interface.py`) renders every non-standard provider field through `to_snake_case()` for its public docstrings/extra-params dataclass, with no matching rename applied back to the underlying model.
- Net effect: the field's "documented" name (snake_case) and its real name (camelCase) diverge, and the parameter can no longer be supplied at all — confirmed live: `obb.worldbank_data360.indicators(dataset_id="WB_WDI")` raised `Field required` for `datasetId` even though the value was passed.

Fix: snake_case every generated field and `alias=` it back to the original wire name when it differs — the same convention every hand-written OpenBB provider already follows (snake_case field + `Field(alias=...)`, dumped with `by_alias=True` in the fetcher, which the codegen tool's fetcher output already assumed).

Fixing that exposed a second, latent bug in `post_gen.py`: its signature builder (`_signature_params`) and its request-body builder (`_render_body_block`) independently derived variable names from the same raw params, and only one side ran names through `safe_field_name`. The two happened to agree before this change only because `safe_field_name` was near-inert on camelCase input. Once it started snake-casing, any generated POST command with a camelCase body field (e.g. `searchFields`) raised `NameError: name 'search_fields' is not defined` on every real call. Threaded both the safe (Python-valid) name and the original raw wire name through `_signature_params` so the signature, the JSON body dict keys, and the query-string keys all agree.

## Verification

- Generated an `openbb-worldbank-data360` extension end to end from the World Bank's own published OpenAPI spec (https://github.com/worldbank/open-api-specs), installed it, ran `openbb-build`, and called it through the real `obb.*` interface against the live API — `obb.worldbank_data360.indicators(...)` and `obb.worldbank_data360.data(...)` both return real rows.
- Full `cli/` test suite: 2005 passed (2 pre-existing, unrelated flakes deselected — a session backend mock test and a date-rollover test, both fail identically on `v5` with none of this diff applied).
- Added a regression test in each affected file. The `post_gen.py` one actually `exec`s the generated module and calls it, since `ast.parse` alone doesn't catch a `NameError` that only fires at call time (both names involved are individually valid Python identifiers).
- `ruff check` / `ruff format --check` clean on all four changed files.

## Test plan

- [x] `cli/openbb_cli/codegen/pydantic_gen.py` — updated 3 existing tests that asserted the old (buggy) unaliased behavior, added 1 new test
- [x] `cli/openbb_cli/codegen/post_gen.py` — updated 1 existing test for the new 6-tuple param shape, added 1 new end-to-end regression test
- [x] Manually verified against the live World Bank Data360 API (not mocked)