### PR TITLE
Add CryptoCompare Real-time Cryptocurrency Data Provider

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/crypto_quote.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/crypto_quote.py
@@ -1,0 +1,109 @@
+"""Crypto Quote Standard Model."""
+
+from datetime import datetime
+
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.abstract.query_params import QueryParams
+from openbb_core.provider.utils.descriptions import (
+    DATA_DESCRIPTIONS,
+    QUERY_DESCRIPTIONS,
+)
+from pydantic import Field, field_validator
+
+
+class CryptoQuoteQueryParams(QueryParams):
+    """Crypto Quote Query.
+
+    Source: https://www.cryptocompare.com/api/
+    """
+
+    symbol: str = Field(
+        description=QUERY_DESCRIPTIONS.get("symbol", "")
+        + " Can be a comma-separated list of crypto symbols (e.g., BTC,ETH,SOL)."
+    )
+
+    @field_validator("symbol", mode="before", check_fields=False)
+    @classmethod
+    def _to_upper(cls, v):
+        """Convert field to uppercase."""
+        return str(v).upper()
+
+
+class CryptoQuoteData(Data):
+    """Crypto Quote Data."""
+
+    symbol: str = Field(description=DATA_DESCRIPTIONS.get("symbol", ""))
+    name: str | None = Field(default=None, description="Name of the cryptocurrency.")
+    price: float = Field(
+        description="The last price of the cryptocurrency in the given currency."
+    )
+    currency: str = Field(
+        default="USD",
+        description="The currency in which the price is denominated.",
+    )
+    bid: float | None = Field(
+        default=None, description="The current highest bid price."
+    )
+    ask: float | None = Field(
+        default=None, description="The current lowest ask price."
+    )
+    change: float | None = Field(
+        default=None, description="Change in price from the previous close."
+    )
+    change_percent: float | None = Field(
+        default=None,
+        description="Change in price from the previous close, as a normalized percentage.",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
+    )
+    volume_24h: float | None = Field(
+        default=None, description="Trading volume over the last 24 hours."
+    )
+    high_24h: float | None = Field(
+        default=None, description="Highest price over the last 24 hours."
+    )
+    low_24h: float | None = Field(
+        default=None, description="Lowest price over the last 24 hours."
+    )
+    market_cap: float | None = Field(
+        default=None, description="Market capitalization of the cryptocurrency."
+    )
+    supply_circulating: float | None = Field(
+        default=None, description="Circulating supply of the cryptocurrency."
+    )
+    supply_total: float | None = Field(
+        default=None, description="Total supply of the cryptocurrency."
+    )
+    last_timestamp: datetime | None = Field(
+        default=None, description="Timestamp of the last recorded price."
+    )
+    open: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("open", "")
+    )
+    high: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("high", "")
+    )
+    low: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("low", "")
+    )
+    close: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("close", "")
+    )
+    volume: float | None = Field(
+        default=None, description=DATA_DESCRIPTIONS.get("volume", "")
+    )
+
+    @field_validator("change_percent", mode="before", check_fields=False)
+    @classmethod
+    def _normalize_percent(cls, v):
+        """Normalize percent to decimal."""
+        if v is not None and abs(v) > 1:
+            return v / 100
+        return v
+
+    @field_validator("last_timestamp", mode="before", check_fields=False)
+    @classmethod
+    def _validate_timestamp(cls, v):
+        """Convert Unix timestamp to datetime."""
+        if isinstance(v, (int, float)):
+            return datetime.fromtimestamp(v)
+        return v

--- a/openbb_platform/providers/openbb_cryptocompare/README.md
+++ b/openbb_platform/providers/openbb_cryptocompare/README.md
@@ -1,0 +1,50 @@
+# OpenBB CryptoCompare Provider
+
+Real-time and historical cryptocurrency market data from [CryptoCompare](https://www.cryptocompare.com).
+
+## Models
+
+| Model | Endpoint | Description |
+|---|---|---|
+| CryptoQuote | /data/pricemultifull | Real-time price quotes |
+| CryptoHistorical | /data/v2/histoday | Historical daily price data |
+| CryptoSearch | /data/blockchain/list | Cryptocurrency search/lookup |
+
+## Installation
+
+```bash
+pip install openbb-cryptocompare
+```
+
+## Usage
+
+```python
+from openbb_core.app import OpenBB
+
+ob = OpenBB()
+
+# Real-time quotes
+btc_quote = ob.crypto.quote(
+    symbol="BTC",
+    provider="cryptocompare",
+)
+
+# Historical data
+btc_hist = ob.crypto.historical(
+    symbol="BTC",
+    provider="cryptocompare",
+    limit=30,
+)
+
+# Search
+coins = ob.crypto.search(
+    query="BTC",
+    provider="cryptocompare",
+)
+```
+
+## API Key
+
+Free tier (100k calls/month) does not require an API key.
+For higher rate limits, set environment variable:
+`OPENBB_CRYPTOCOMPARE_API_KEY`

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/__init__.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/__init__.py
@@ -1,0 +1,22 @@
+"""CryptoCompare provider module."""
+
+from openbb_core.provider.abstract.provider import Provider
+from openbb_cryptocompare.models.crypto_quote import CryptoCompareCryptoQuoteFetcher
+from openbb_cryptocompare.models.crypto_historical import (
+    CryptoCompareCryptoHistoricalFetcher,
+)
+from openbb_cryptocompare.models.crypto_search import (
+    CryptoCompareCryptoSearchFetcher,
+)
+
+cryptocompare_provider = Provider(
+    name="cryptocompare",
+    website="https://www.cryptocompare.com",
+    description="CryptoCompare provides real-time and historical cryptocurrency market data.",
+    credentials=["api_key"],
+    fetcher_dict={
+        "CryptoQuote": CryptoCompareCryptoQuoteFetcher,
+        "CryptoHistorical": CryptoCompareCryptoHistoricalFetcher,
+        "CryptoSearch": CryptoCompareCryptoSearchFetcher,
+    },
+)

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/__init__.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/__init__.py
@@ -1,0 +1,1 @@
+"""CryptoCompare model implementations."""

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_historical.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_historical.py
@@ -1,0 +1,104 @@
+"""CryptoCompare CryptoHistorical Model."""
+
+# pylint: disable=unused-argument
+
+from datetime import datetime
+from typing import Any
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.crypto_historical import (
+    CryptoHistoricalData,
+    CryptoHistoricalQueryParams,
+)
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_cryptocompare.utils.helpers import build_historical_request_url
+
+
+class CryptoCompareCryptoHistoricalQueryParams(CryptoHistoricalQueryParams):
+    """CryptoCompare Crypto Historical Query Parameters.
+
+    Source: https://min-api.cryptocompare.com/documentation
+    """
+
+    currency: str = "USD"
+    aggregate: int = 1
+    limit: int = 100
+
+
+class CryptoCompareCryptoHistoricalData(CryptoHistoricalData):
+    """CryptoCompare Crypto Historical Data."""
+
+
+class CryptoCompareCryptoHistoricalFetcher(
+    Fetcher[
+        CryptoCompareCryptoHistoricalQueryParams,
+        list[CryptoCompareCryptoHistoricalData],
+    ]
+):
+    """CryptoCompare Crypto Historical Fetcher."""
+
+    @staticmethod
+    def transform_query(
+        params: dict[str, Any],
+    ) -> CryptoCompareCryptoHistoricalQueryParams:
+        """Transform the query parameters."""
+        return CryptoCompareCryptoHistoricalQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: CryptoCompareCryptoHistoricalQueryParams,
+        credentials: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Fetch historical crypto data from CryptoCompare."""
+        symbol = query.symbol.replace(" ", "")
+        currency = query.currency or "USD"
+        limit = query.limit or 100
+        aggregate = query.aggregate or 1
+
+        url = build_historical_request_url(
+            symbol=symbol, currency=currency, limit=limit, aggregate=aggregate
+        )
+
+        api_key = credentials.get("api_key") if credentials else None
+        if api_key:
+            url += f"&api_key={api_key}"
+
+        return await amake_request(url, timeout=30)
+
+    @staticmethod
+    def transform_data(
+        query: CryptoCompareCryptoHistoricalQueryParams,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> list[CryptoCompareCryptoHistoricalData]:
+        """Transform the API response into a list of CryptoHistoricalData."""
+        if data.get("Err"):
+            raise RuntimeError(f"CryptoCompare API error: {data['Err'].get('message', str(data['Err']))}")
+
+        result_data = (
+            data.get("Data", {}).get("Data", [])
+            if isinstance(data.get("Data"), dict)
+            else data.get("Data", [])
+        )
+        results: list[CryptoCompareCryptoHistoricalData] = []
+
+        for entry in result_data:
+            timestamp = entry.get("time")
+            if isinstance(timestamp, (int, float)):
+                date_val = datetime.fromtimestamp(timestamp)
+            else:
+                date_val = None
+
+            results.append(
+                CryptoCompareCryptoHistoricalData(
+                    date=date_val,
+                    open=entry.get("open"),
+                    high=entry.get("high"),
+                    low=entry.get("low"),
+                    close=entry.get("close"),
+                    volume=entry.get("volumeto"),
+                )
+            )
+
+        return results

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_quote.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_quote.py
@@ -1,0 +1,122 @@
+"""CryptoCompare CryptoQuote Model."""
+
+# pylint: disable=unused-argument
+
+from datetime import datetime
+from typing import Any
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.crypto_quote import (
+    CryptoQuoteData,
+    CryptoQuoteQueryParams,
+)
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_cryptocompare.utils.helpers import build_price_request_url
+from pydantic import field_validator
+
+
+class CryptoCompareCryptoQuoteQueryParams(CryptoQuoteQueryParams):
+    """CryptoCompare Crypto Quote Query Parameters.
+
+    Source: https://min-api.cryptocompare.com/documentation
+    """
+
+    currency: str = "USD"
+
+
+class CryptoCompareCryptoQuoteData(CryptoQuoteData):
+    """CryptoCompare Crypto Quote Data."""
+
+    # Override the standard model validator to prevent double-normalization.
+    # CryptoCompare already returns decimal-form percentages from the fetcher.
+    @field_validator("change_percent", mode="before", check_fields=False)
+    @classmethod
+    def _normalize_percent(cls, v):
+        """Return the value as-is (already normalized in fetcher)."""
+        return v
+
+
+class CryptoCompareCryptoQuoteFetcher(
+    Fetcher[
+        CryptoCompareCryptoQuoteQueryParams,
+        list[CryptoCompareCryptoQuoteData],
+    ]
+):
+    """CryptoCompare Crypto Quote Fetcher."""
+
+    @staticmethod
+    def transform_query(params: dict[str, Any]) -> CryptoCompareCryptoQuoteQueryParams:
+        """Transform the query parameters."""
+        return CryptoCompareCryptoQuoteQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: CryptoCompareCryptoQuoteQueryParams,
+        credentials: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Fetch real-time crypto quote data from CryptoCompare."""
+        symbols = query.symbol.replace(" ", "")
+        currency = query.currency or "USD"
+        url = build_price_request_url(symbols=symbols, currency=currency)
+
+        api_key = credentials.get("api_key") if credentials else None
+        if api_key:
+            url += f"&api_key={api_key}"
+
+        return await amake_request(url, timeout=30)
+
+    @staticmethod
+    def transform_data(
+        query: CryptoCompareCryptoQuoteQueryParams,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> list[CryptoCompareCryptoQuoteData]:
+        """Transform the API response into a list of CryptoQuoteData."""
+        if data.get("Err"):
+            raise RuntimeError(
+                f"CryptoCompare API error: {data['Err'].get('message', str(data['Err']))}"
+            )
+
+        raw = data.get("RAW", {})
+        currency = query.currency or "USD"
+        results: list[CryptoCompareCryptoQuoteData] = []
+
+        for symbol, currencies in raw.items():
+            coin_data = currencies.get(currency.upper())
+            price = coin_data.get("PRICE") if coin_data else None
+            if price is None:
+                continue
+
+            last_timestamp = coin_data.get("LASTUPDATE")
+            if isinstance(last_timestamp, (int, float)):
+                last_timestamp = datetime.fromtimestamp(last_timestamp)
+
+            # CryptoCompare returns CHANGEPCT24HOUR as a percentage value
+            # (e.g., 0.5 = 0.5% change). Normalize to decimal (0.005 = 0.5%).
+            change_pct = coin_data.get("CHANGEPCT24HOUR")
+            if change_pct is not None:
+                change_pct = change_pct / 100
+
+            results.append(
+                CryptoCompareCryptoQuoteData(
+                    symbol=symbol,
+                    price=price,
+                    currency=currency.upper(),
+                    change=coin_data.get("CHANGE24HOUR"),
+                    change_percent=change_pct,
+                    volume_24h=coin_data.get("VOLUME24HOUR"),
+                    high_24h=coin_data.get("HIGH24HOUR"),
+                    low_24h=coin_data.get("LOW24HOUR"),
+                    market_cap=coin_data.get("MKTCAP"),
+                    supply_circulating=coin_data.get("SUPPLY"),
+                    supply_total=coin_data.get("TOTALSUPPLY"),
+                    last_timestamp=last_timestamp,
+                    open=coin_data.get("OPEN24HOUR"),
+                    high=coin_data.get("HIGH24HOUR"),
+                    low=coin_data.get("LOW24HOUR"),
+                    volume=coin_data.get("VOLUME24HOURTO"),
+                )
+            )
+
+        return results

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_search.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/models/crypto_search.py
@@ -1,0 +1,88 @@
+"""CryptoCompare CryptoSearch Model."""
+
+# pylint: disable=unused-argument
+
+from typing import Any
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.crypto_search import (
+    CryptoSearchData,
+    CryptoSearchQueryParams,
+)
+from openbb_core.provider.utils.helpers import amake_request
+from openbb_cryptocompare.utils.helpers import build_search_request_url
+
+
+class CryptoCompareCryptoSearchQueryParams(CryptoSearchQueryParams):
+    """CryptoCompare Crypto Search Query Parameters.
+
+    Source: https://min-api.cryptocompare.com/documentation
+    """
+
+
+class CryptoCompareCryptoSearchData(CryptoSearchData):
+    """CryptoCompare Crypto Search Data."""
+
+    market_cap_rank: int | None = None
+
+
+class CryptoCompareCryptoSearchFetcher(
+    Fetcher[
+        CryptoCompareCryptoSearchQueryParams,
+        list[CryptoCompareCryptoSearchData],
+    ]
+):
+    """CryptoCompare Crypto Search Fetcher."""
+
+    @staticmethod
+    def transform_query(
+        params: dict[str, Any],
+    ) -> CryptoCompareCryptoSearchQueryParams:
+        """Transform the query parameters."""
+        return CryptoCompareCryptoSearchQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: CryptoCompareCryptoSearchQueryParams,
+        credentials: dict[str, str] | None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        """Fetch the full cryptocurrency list from CryptoCompare."""
+        url = build_search_request_url()
+
+        api_key = credentials.get("api_key") if credentials else None
+        if api_key:
+            url += f"?api_key={api_key}"
+
+        return await amake_request(url, timeout=30)
+
+    @staticmethod
+    def transform_data(
+        query: CryptoCompareCryptoSearchQueryParams,
+        data: dict[str, Any],
+        **kwargs: Any,
+    ) -> list[CryptoCompareCryptoSearchData]:
+        """Transform the API response into a list of CryptoSearchData."""
+        if data.get("Err"):
+            raise RuntimeError(f"CryptoCompare API error: {data['Err'].get('message', str(data['Err']))}")
+
+        coins = data.get("Data", {})
+        query_text = (query.query or "").lower()
+        results: list[CryptoCompareCryptoSearchData] = []
+
+        for sym, info in coins.items():
+            name = info.get("coin_name", "") or ""
+            symbol = info.get("symbol", "")
+
+            if query_text and query_text not in symbol.lower() and query_text not in name.lower():
+                continue
+
+            results.append(
+                CryptoCompareCryptoSearchData(
+                    symbol=symbol,
+                    name=name,
+                    market_cap_rank=info.get("rank"),
+                )
+            )
+
+        return results

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/utils/__init__.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/utils/__init__.py
@@ -1,0 +1,1 @@
+"""CryptoCompare utility functions."""

--- a/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/utils/helpers.py
+++ b/openbb_platform/providers/openbb_cryptocompare/openbb_cryptocompare/utils/helpers.py
@@ -1,0 +1,23 @@
+"""Helper utilities for the CryptoCompare provider."""
+
+from typing import Any
+
+
+def build_price_request_url(symbols: str, currency: str = "USD") -> str:
+    """Build the pricemultifull request URL."""
+    return f"https://min-api.cryptocompare.com/data/pricemultifull?fsyms={symbols}&tsyms={currency}"
+
+
+def build_historical_request_url(
+    symbol: str, currency: str = "USD", limit: int = 100, aggregate: int = 1
+) -> str:
+    """Build the histoday request URL."""
+    return (
+        f"https://min-api.cryptocompare.com/data/v2/histoday"
+        f"?fsym={symbol}&tsym={currency}&limit={limit}&aggregate={aggregate}"
+    )
+
+
+def build_search_request_url() -> str:
+    """Build the coin list request URL."""
+    return "https://min-api.cryptocompare.com/data/blockchain/list"

--- a/openbb_platform/providers/openbb_cryptocompare/pyproject.toml
+++ b/openbb_platform/providers/openbb_cryptocompare/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "openbb-cryptocompare"
+version = "1.0.0"
+description = "CryptoCompare provider for the OpenBB Platform"
+authors = ["OpenBB Team <hello@openbb.co>"]
+license = "AGPL-3.0-only"
+readme = "README.md"
+packages = [{ include = "openbb_cryptocompare" }]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4"
+openbb-core = "^1.6.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins."openbb_provider_extension"]
+cryptocompare = "openbb_cryptocompare:cryptocompare_provider"

--- a/openbb_platform/providers/openbb_cryptocompare/tests/__init__.py
+++ b/openbb_platform/providers/openbb_cryptocompare/tests/__init__.py
@@ -1,0 +1,1 @@
+"""Test the CryptoCompare fetchers."""

--- a/openbb_platform/providers/openbb_cryptocompare/tests/test_cryptocompare_fetchers.py
+++ b/openbb_platform/providers/openbb_cryptocompare/tests/test_cryptocompare_fetchers.py
@@ -1,0 +1,281 @@
+"""Test the CryptoCompare fetchers."""
+
+from datetime import datetime
+
+import pytest
+from openbb_core.app.service.user_service import UserService
+
+from openbb_cryptocompare.models.crypto_quote import (
+    CryptoCompareCryptoQuoteData,
+    CryptoCompareCryptoQuoteFetcher,
+    CryptoCompareCryptoQuoteQueryParams,
+)
+from openbb_cryptocompare.models.crypto_historical import (
+    CryptoCompareCryptoHistoricalData,
+    CryptoCompareCryptoHistoricalFetcher,
+    CryptoCompareCryptoHistoricalQueryParams,
+)
+from openbb_cryptocompare.models.crypto_search import (
+    CryptoCompareCryptoSearchData,
+    CryptoCompareCryptoSearchFetcher,
+    CryptoCompareCryptoSearchQueryParams,
+)
+
+
+test_credentials = UserService().default_user_settings.credentials.model_dump(
+    mode="json"
+)
+
+
+# ── Unit Tests (no API key required) ──────────────────────────────────────
+
+
+class TestCryptoQuoteTransform:
+    """Test the CryptoQuote transform_data logic with mock API responses."""
+
+    def test_transform_quote_single_coin(self):
+        """Test parsing a single coin from the pricemultifull response."""
+        mock_response = {
+            "RAW": {
+                "BTC": {
+                    "USD": {
+                        "PRICE": 50000.0,
+                        "CHANGE24HOUR": 100.0,
+                        "CHANGEPCT24HOUR": 0.5,
+                        "OPEN24HOUR": 49900.0,
+                        "HIGH24HOUR": 50200.0,
+                        "LOW24HOUR": 49800.0,
+                        "VOLUME24HOUR": 100000.0,
+                        "VOLUME24HOURTO": 95000.0,
+                        "MKTCAP": 1000000000.0,
+                        "SUPPLY": 19000000.0,
+                        "TOTALSUPPLY": 21000000.0,
+                        "LASTUPDATE": 1700000000,
+                    }
+                }
+            }
+        }
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="BTC")
+        results = CryptoCompareCryptoQuoteFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 1
+        assert results[0].symbol == "BTC"
+        assert results[0].price == 50000.0
+        assert results[0].change == 100.0
+        assert results[0].change_percent == 0.005
+        assert results[0].volume_24h == 100000.0
+        assert results[0].market_cap == 1000000000.0
+        assert results[0].last_timestamp == datetime.fromtimestamp(1700000000)
+
+    def test_transform_quote_multiple_coins(self):
+        """Test parsing multiple coins."""
+        mock_response = {
+            "RAW": {
+                "BTC": {"USD": {"PRICE": 50000.0, "CHANGE24HOUR": 100.0}},
+                "ETH": {"USD": {"PRICE": 3000.0, "CHANGE24HOUR": 20.0}},
+                "SOL": {"USD": {"PRICE": 150.0, "CHANGE24HOUR": 5.0}},
+            }
+        }
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="BTC,ETH,SOL")
+        results = CryptoCompareCryptoQuoteFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 3
+
+    def test_transform_quote_custom_currency(self):
+        """Test parsing with a custom currency."""
+        mock_response = {
+            "RAW": {"BTC": {"EUR": {"PRICE": 46000.0, "CHANGE24HOUR": 90.0}}}
+        }
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="BTC", currency="EUR")
+        results = CryptoCompareCryptoQuoteFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 1
+        assert results[0].price == 46000.0
+        assert results[0].currency == "EUR"
+
+    def test_transform_quote_empty_coins(self):
+        """Test that coins not in the response are skipped."""
+        mock_response = {"RAW": {}}
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="DOGE")
+        results = CryptoCompareCryptoQuoteFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 0
+
+    def test_transform_quote_error_response(self):
+        """Test error handling."""
+        mock_response = {"Err": {"type": 2, "message": "API key required"}}
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="BTC")
+        with pytest.raises(RuntimeError, match="API key required"):
+            CryptoCompareCryptoQuoteFetcher.transform_data(
+                query=query, data=mock_response
+            )
+
+    def test_missing_coin_data(self):
+        """Test that a coin with no price data is skipped."""
+        mock_response = {"RAW": {"BTC": {"USD": {"PRICE": 50000.0}}, "ETH": {"USD": {}}}}
+        query = CryptoCompareCryptoQuoteQueryParams(symbol="BTC,ETH")
+        results = CryptoCompareCryptoQuoteFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 1
+        assert results[0].symbol == "BTC"
+
+
+class TestCryptoHistoricalTransform:
+    """Test the CryptoHistorical transform_data logic."""
+
+    def test_transform_historical_data(self):
+        """Test parsing historical OHLCV data."""
+        mock_response = {
+            "Data": {
+                "Data": [
+                    {"time": 1700000000, "open": 49000.0, "high": 50200.0, "low": 48800.0, "close": 50000.0, "volumefrom": 10000.0, "volumeto": 500000000.0},
+                    {"time": 1700086400, "open": 50000.0, "high": 51000.0, "low": 49800.0, "close": 50500.0, "volumefrom": 12000.0, "volumeto": 600000000.0},
+                    {"time": 1700172800, "open": 50500.0, "high": 51500.0, "low": 50300.0, "close": 51000.0, "volumefrom": 8000.0, "volumeto": 400000000.0},
+                ]
+            }
+        }
+        query = CryptoCompareCryptoHistoricalQueryParams(symbol="BTC", limit=3)
+        results = CryptoCompareCryptoHistoricalFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 3
+        assert results[0].open == 49000.0
+        assert results[0].close == 50000.0
+        assert results[0].volume == 500000000.0
+
+    def test_transform_historical_empty(self):
+        """Test empty historical data."""
+        mock_response = {"Data": {"Data": []}}
+        query = CryptoCompareCryptoHistoricalQueryParams(symbol="BTC")
+        results = CryptoCompareCryptoHistoricalFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 0
+
+    def test_transform_historical_error(self):
+        """Test error handling."""
+        mock_response = {"Err": {"type": 1, "message": "Invalid symbol"}}
+        query = CryptoCompareCryptoHistoricalQueryParams(symbol="INVALID")
+        with pytest.raises(RuntimeError, match="Invalid symbol"):
+            CryptoCompareCryptoHistoricalFetcher.transform_data(
+                query=query, data=mock_response
+            )
+
+
+class TestCryptoSearchTransform:
+    """Test the CryptoSearch transform_data logic."""
+
+    def test_transform_search_results(self):
+        """Test parsing the coin list."""
+        mock_response = {
+            "Data": {
+                "BTC": {"symbol": "BTC", "coin_name": "Bitcoin", "rank": 1},
+                "ETH": {"symbol": "ETH", "coin_name": "Ethereum", "rank": 2},
+                "SOL": {"symbol": "SOL", "coin_name": "Solana", "rank": 5},
+            }
+        }
+        query = CryptoCompareCryptoSearchQueryParams(query="BTC")
+        results = CryptoCompareCryptoSearchFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 1
+        assert results[0].symbol == "BTC"
+        assert results[0].name == "Bitcoin"
+        assert results[0].market_cap_rank == 1
+
+    def test_transform_search_no_query(self):
+        """Test without filtering."""
+        mock_response = {
+            "Data": {
+                "BTC": {"symbol": "BTC", "coin_name": "Bitcoin"},
+                "ETH": {"symbol": "ETH", "coin_name": "Ethereum"},
+            }
+        }
+        query = CryptoCompareCryptoSearchQueryParams(query=None)
+        results = CryptoCompareCryptoSearchFetcher.transform_data(
+            query=query, data=mock_response
+        )
+        assert len(results) == 2
+
+    def test_transform_search_error(self):
+        """Test error handling."""
+        mock_response = {"Err": {"type": 2, "message": "API key required"}}
+        query = CryptoCompareCryptoSearchQueryParams(query="BTC")
+        with pytest.raises(RuntimeError, match="API key required"):
+            CryptoCompareCryptoSearchFetcher.transform_data(
+                query=query, data=mock_response
+            )
+
+
+class TestCryptoQuoteQueryParams:
+    """Test the CryptoQuote query params."""
+
+    def test_symbol_uppercase(self):
+        """Test that symbols are uppercased."""
+        params = CryptoCompareCryptoQuoteQueryParams(symbol="btc")
+        assert params.symbol == "BTC"
+
+    def test_default_currency(self):
+        """Test default currency."""
+        params = CryptoCompareCryptoQuoteQueryParams(symbol="BTC")
+        assert params.currency == "USD"
+
+    def test_multiple_symbols(self):
+        """Test comma-separated symbols."""
+        params = CryptoCompareCryptoQuoteQueryParams(symbol="btc,eth,sol")
+        assert params.symbol == "BTC,ETH,SOL"
+
+
+class TestCryptoQuoteDataModel:
+    """Test the CryptoQuote data model."""
+
+    def test_change_percent_passes_through(self):
+        """Test that change_percent passes through (normalized in fetcher)."""
+        data = CryptoCompareCryptoQuoteData(
+            symbol="BTC", price=50000.0, change_percent=2.5
+        )
+        assert data.change_percent == 2.5
+
+    def test_change_percent_keeps_decimal(self):
+        """Test that values already in decimal format are not modified."""
+        data = CryptoCompareCryptoQuoteData(
+            symbol="BTC", price=50000.0, change_percent=0.025
+        )
+        assert data.change_percent == 0.025
+
+
+# ── Integration Tests (require API key credential for recording) ──────────
+
+@pytest.mark.record_http
+def test_cryptocompare_crypto_quote_fetcher(credentials=test_credentials):
+    """Test the crypto quote fetcher."""
+    creds = dict(credentials)
+    params = {"symbol": "BTC", "currency": "USD"}
+    fetcher = CryptoCompareCryptoQuoteFetcher()
+    result = fetcher.test(params, creds)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_cryptocompare_crypto_historical_fetcher(credentials=test_credentials):
+    """Test the crypto historical fetcher."""
+    creds = dict(credentials)
+    params = {"symbol": "BTC", "currency": "USD", "limit": 5}
+    fetcher = CryptoCompareCryptoHistoricalFetcher()
+    result = fetcher.test(params, creds)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_cryptocompare_crypto_search_fetcher(credentials=test_credentials):
+    """Test the crypto search fetcher."""
+    creds = dict(credentials)
+    params = {"query": "BTC"}
+    fetcher = CryptoCompareCryptoSearchFetcher()
+    result = fetcher.test(params, creds)
+    assert result is None


### PR DESCRIPTION

## Description

Adds a new data provider integration for **CryptoCompare** (CoinDesk) real-time and historical cryptocurrency data.

Closes #7177

## Features

- **CryptoQuote**: Real-time price quotes with 24h stats (high, low, volume, change %)
- **CryptoHistorical**: Historical OHLCV data for any crypto pair
- **CryptoSearch**: Search/listing of available cryptocurrency coins

## Implementation

- New standard model `CryptoQuoteQueryParams` / `CryptoQuoteData` in `core/standard_models/`
- New provider package `openbb_cryptocompare` with three fetchers
- Utility helpers for CryptoCompare REST API URL building
- 17 unit tests covering transform logic, query param validation, and error handling

## Testing

```
cd openbb_platform/providers/openbb_cryptocompare
pytest tests/ -v -m "not record_http"
```

All 17 tests pass. Integration tests (`record_http`) require a CoinDesk API key and VCR cassettes.

## Notes

- CryptoCompare now requires an API key (acquired by CoinDesk in 2024). The provider accepts the key via `credentials['api_key']`.
- `change_percent` is normalized from CryptoCompare's percentage format (e.g., `0.5` = 0.5% → decimal `0.005`) in the fetcher transform.
- Coins with missing price data are skipped to maintain data model integrity.
