### PR TITLE
fix(cli): inherit path-item-level OpenAPI parameters

### DIFF
--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -385,7 +385,11 @@ def _signature_params(
         )
         out.append(
             (
-                name,
+                # ``_render_body_block`` already writes ``{'from': from_}``, keying the
+                # payload by the wire name and reading the safe identifier, so the
+                # signature has to declare the safe one. Codat's Transfer body has a
+                # property named ``from``, which is a keyword.
+                safe_field_name(name)[0],
                 ann,
                 schema.get("description") or schema.get("title"),
                 name in body_required,
@@ -639,8 +643,13 @@ def _render_body_block(
     """
     body_props = (cmd_spec.get("request_body_schema") or {}).get("properties") or {}
     body_field_names = list(body_props)
+    # The signature declares the safe identifier for a body property, so the
+    # body/query split has to compare against those, not the wire names.
+    # Otherwise a keyword-named property such as ``from`` is not recognized as a
+    # body field and leaks into the query string as ``from_``.
+    body_safe_names = {safe_field_name(n)[0] for n in body_field_names}
     query_field_names = [
-        n for n, _, _, _, _ in params if n != "cc" and n not in body_field_names
+        n for n, _, _, _, _ in params if n != "cc" and n not in body_safe_names
     ]
 
     lines: list[str] = []

--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -380,13 +380,12 @@ def _signature_params(
     for name, schema in body_props.items():
         if name == array_field:
             continue
-        if name in operation_param_names:
-            continue
-        if safe_field_name(name)[0] in operation_param_names | emitted:
-            continue
         if not isinstance(schema, dict):
             continue
-        emitted.add(safe_field_name(name)[0])
+        safe = safe_field_name(name)[0]
+        if safe in operation_param_names or safe in emitted:
+            continue
+        emitted.add(safe)
         ann = _python_type_from_param(
             {
                 "type": schema.get("type"),
@@ -400,7 +399,7 @@ def _signature_params(
                 # payload by the wire name and reading the safe identifier, so the
                 # signature has to declare the safe one. Codat's Transfer body has a
                 # property named ``from``, which is a keyword.
-                safe_field_name(name)[0],
+                safe,
                 ann,
                 schema.get("description") or schema.get("title"),
                 name in body_required,

--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -403,7 +403,11 @@ def _signature_params(
         ann = _python_type_from_param(raw)
         out.append(
             (
-                name,
+                # Wire names are not always identifiers. Rebilly declares
+                # ``Organization-Id`` and a ``REB-APIKEY`` security header, which
+                # emitted ``REB-APIKEY: str = None``. The fetcher path already
+                # sanitizes these; this one has to match it.
+                safe_field_name(name)[0],
                 ann,
                 raw.get("help"),
                 bool(raw.get("required")),
@@ -651,6 +655,13 @@ def _render_body_block(
     query_field_names = [
         n for n, _, _, _, _ in params if n != "cc" and n not in body_safe_names
     ]
+    # The signature carries safe identifiers, but the request has to go out under
+    # the wire names, so keep a map back for the query keys and the path check.
+    wire_by_safe = {
+        safe_field_name(p["name"])[0]: p["name"]
+        for p in filter_user_params(cmd_spec.get("parameters") or [])
+        if p.get("name")
+    }
 
     lines: list[str] = []
     lines.extend(cred_lines)
@@ -663,10 +674,11 @@ def _render_body_block(
 
     lines.append("    _query_dict: dict[str, Any] = {}")
     for name in query_field_names:
-        if name in path_params:
+        wire = wire_by_safe.get(name, name)
+        if wire in path_params or name in path_params:
             continue
         lines.append(f"    if {name} is not None:")
-        lines.append(f"        _query_dict[{name!r}] = {name}")
+        lines.append(f"        _query_dict[{wire!r}] = {name}")
     for canonical, info in creds.items():
         if info["in"] != "query":
             continue

--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -364,18 +364,29 @@ def _signature_params(
     # placeholder and its own ``required``. The payload is unaffected, because
     # ``_render_body_block`` reads the body fields from ``request_body_schema``
     # rather than from this list.
-    operation_param_names = {
-        p.get("name")
-        for p in filter_user_params(cmd_spec.get("parameters") or [])
-        if p.get("name")
-    }
+    #
+    # Two wire names can also collapse onto one identifier once sanitized
+    # (``from`` and ``from_``, ``Organization-Id`` and ``Organization_Id``), and
+    # ``operation_parameters`` keeps a name declared twice under different ``in``
+    # locations. Collisions are therefore resolved on the emitted identifier, not
+    # on the wire name, so a duplicate argument cannot be generated at all.
+    operation_params = [
+        p for p in filter_user_params(cmd_spec.get("parameters") or []) if p.get("name")
+    ]
+    operation_param_names = {p["name"] for p in operation_params}
+    operation_param_names |= {safe_field_name(p["name"])[0] for p in operation_params}
+    emitted: set[str] = {entry[0] for entry in out}
+
     for name, schema in body_props.items():
         if name == array_field:
             continue
         if name in operation_param_names:
             continue
+        if safe_field_name(name)[0] in operation_param_names | emitted:
+            continue
         if not isinstance(schema, dict):
             continue
+        emitted.add(safe_field_name(name)[0])
         ann = _python_type_from_param(
             {
                 "type": schema.get("type"),
@@ -396,10 +407,12 @@ def _signature_params(
                 schema.get("default"),
             )
         )
-    for raw in filter_user_params(cmd_spec.get("parameters") or []):
-        name = raw.get("name")
-        if not name:
+    for raw in operation_params:
+        name = raw["name"]
+        safe = safe_field_name(name)[0]
+        if safe in emitted:
             continue
+        emitted.add(safe)
         ann = _python_type_from_param(raw)
         out.append(
             (
@@ -407,7 +420,7 @@ def _signature_params(
                 # ``Organization-Id`` and a ``REB-APIKEY`` security header, which
                 # emitted ``REB-APIKEY: str = None``. The fetcher path already
                 # sanitizes these; this one has to match it.
-                safe_field_name(name)[0],
+                safe,
                 ann,
                 raw.get("help"),
                 bool(raw.get("required")),

--- a/cli/openbb_cli/codegen/post_gen.py
+++ b/cli/openbb_cli/codegen/post_gen.py
@@ -357,8 +357,22 @@ def _signature_params(
     body_required = set(
         (cmd_spec.get("request_body_schema") or {}).get("required") or []
     )
+    # A name can be declared both as an operation parameter and as a request-body
+    # property — Codat's push endpoints put ``accountId`` in the URL template and
+    # in the body. Emitting both produces two parameters with the same name, which
+    # is a SyntaxError. The operation parameter wins: it carries the path
+    # placeholder and its own ``required``. The payload is unaffected, because
+    # ``_render_body_block`` reads the body fields from ``request_body_schema``
+    # rather than from this list.
+    operation_param_names = {
+        p.get("name")
+        for p in filter_user_params(cmd_spec.get("parameters") or [])
+        if p.get("name")
+    }
     for name, schema in body_props.items():
         if name == array_field:
+            continue
+        if name in operation_param_names:
             continue
         if not isinstance(schema, dict):
             continue

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -347,7 +347,7 @@ def extract_request_body_schema(
     schema = media.get("schema")
     if not isinstance(schema, dict):
         return None
-    return deref_schema(spec, schema)
+    return merge_allof(deref_schema(spec, schema))
 
 
 def extract_response_schemas(

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -190,23 +190,32 @@ def deref_schema(
     return node
 
 
-_MERGEABLE_ALLOF_KEYS = frozenset({"properties", "required", "type", "description"})
+_ALLOF_BLOCKING_KEYS = frozenset(
+    {"oneOf", "anyOf", "allOf", "not", "$ref", "enum", "const", "items"}
+)
 
 
 def _mergeable_allof_members(members: list[Any]) -> list[dict[str, Any]] | None:
     """Return the members if every one is a plain object subschema, else ``None``.
 
-    Only object-shaped members are merged. A member carrying its own combinator
-    (``oneOf`` / ``anyOf`` / a nested ``allOf`` that did not collapse), or a
-    non-object ``type``, means the composition is not a simple intersection of
-    property bags and is left untouched rather than merged into something the
-    spec does not describe.
+    A member is not mergeable when it carries its own combinator (``oneOf`` /
+    ``anyOf`` / a nested ``allOf`` that did not collapse), an unresolved
+    ``$ref`` left behind by a reference cycle, a scalar constraint (``enum`` /
+    ``const`` / ``items``), or a ``type`` other than ``object``. Any of those
+    means the composition is not a plain intersection of property bags, and
+    merging it would describe something the spec does not.
+
+    Everything else is annotation that does not affect the intersection —
+    ``title``, ``description``, ``examples``, ``definitions``, vendor ``x-``
+    keys — and does not block the merge. Keying off a blocklist rather than a
+    whitelist matters: Codat's ``PagingInfo`` carries ``definitions``, and
+    treating that as disqualifying left the composition unmerged.
     """
     out: list[dict[str, Any]] = []
     for member in members:
         if not isinstance(member, dict):
             return None
-        if member.keys() - _MERGEABLE_ALLOF_KEYS - {"examples", "x-internal", "title"}:
+        if member.keys() & _ALLOF_BLOCKING_KEYS:
             return None
         declared = member.get("type")
         if declared is not None and declared != "object":

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -122,6 +122,38 @@ def deref_parameter(spec: dict[str, Any], param: dict[str, Any]) -> dict[str, An
     return param
 
 
+def operation_parameters(
+    spec: dict[str, Any], path_item: dict[str, Any], op: dict[str, Any]
+) -> list[dict[str, Any]]:
+    """Return an operation's parameters, including those inherited from its path item.
+
+    OpenAPI 3.x lets a Path Item Object declare ``parameters`` that apply to every
+    operation under that path. An operation-level parameter overrides an inherited
+    one when both match on ``(name, in)``; anything else is inherited as-is.
+
+    Entries are returned dereferenced, inherited first, then the operation's own.
+    """
+    inherited = path_item.get("parameters") or []
+    own_raw = op.get("parameters") or []
+    own = [deref_parameter(spec, p) for p in own_raw if isinstance(p, dict)]
+    own = [p for p in own if p]
+    if not inherited:
+        return own
+    overridden = {(p.get("name"), p.get("in")) for p in own}
+    merged: list[dict[str, Any]] = []
+    for raw in inherited:
+        if not isinstance(raw, dict):
+            continue
+        resolved = deref_parameter(spec, raw)
+        if not resolved or not resolved.get("name"):
+            continue
+        if (resolved.get("name"), resolved.get("in")) in overridden:
+            continue
+        merged.append(resolved)
+    merged.extend(own)
+    return merged
+
+
 def deref_schema(
     spec: dict[str, Any],
     node: Any,
@@ -426,9 +458,15 @@ def parameter_to_kwargs(param: dict[str, Any]) -> tuple[str, dict[str, Any]] | N
 
 
 def build_parser_from_operation(
-    op: dict[str, Any], spec: dict[str, Any] | None = None
+    op: dict[str, Any],
+    spec: dict[str, Any] | None = None,
+    path_item: dict[str, Any] | None = None,
 ) -> argparse.ArgumentParser:
-    """Build an ``ArgumentParser`` from an OpenAPI operation object."""
+    """Build an ``ArgumentParser`` from an OpenAPI operation object.
+
+    When ``path_item`` is given, parameters shared by every operation under that
+    path are inherited by the parser (see :func:`operation_parameters`).
+    """
     parser = argparse.ArgumentParser(
         prog=op.get("operationId", "cmd"),
         description=(op.get("description") or op.get("summary") or "").strip() or None,
@@ -440,7 +478,12 @@ def build_parser_from_operation(
         if spec is not None
         else []
     )
-    for param in [*op.get("parameters", []), *body_params]:
+    params = (
+        operation_parameters(spec, path_item or {}, op)
+        if spec is not None
+        else list(op.get("parameters", []) or [])
+    )
+    for param in [*params, *body_params]:
         translated = parameter_to_kwargs(param)
         if translated is None:
             continue
@@ -509,7 +552,7 @@ def build_command_index(
         if not op:
             continue
         index[url_to_command(url, api_prefix=api_prefix)] = build_parser_from_operation(
-            op, spec
+            op, spec, methods
         )
     return index
 

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -190,6 +190,89 @@ def deref_schema(
     return node
 
 
+_MERGEABLE_ALLOF_KEYS = frozenset({"properties", "required", "type", "description"})
+
+
+def _mergeable_allof_members(members: list[Any]) -> list[dict[str, Any]] | None:
+    """Return the members if every one is a plain object subschema, else ``None``.
+
+    Only object-shaped members are merged. A member carrying its own combinator
+    (``oneOf`` / ``anyOf`` / a nested ``allOf`` that did not collapse), or a
+    non-object ``type``, means the composition is not a simple intersection of
+    property bags and is left untouched rather than merged into something the
+    spec does not describe.
+    """
+    out: list[dict[str, Any]] = []
+    for member in members:
+        if not isinstance(member, dict):
+            return None
+        if member.keys() - _MERGEABLE_ALLOF_KEYS - {"examples", "x-internal", "title"}:
+            return None
+        declared = member.get("type")
+        if declared is not None and declared != "object":
+            return None
+        out.append(member)
+    return out
+
+
+def merge_allof(node: Any, max_depth: int = 32) -> Any:
+    """Collapse ``allOf`` compositions of object subschemas into one object schema.
+
+    An ``allOf`` is an intersection: the instance must satisfy every member. A
+    consumer reading ``properties`` off the composition itself finds nothing,
+    because the properties live one level down inside the members. This merges
+    them into a single object schema so the composition can be read like any
+    other object.
+
+    ``properties`` are unioned, with the first member to declare a name winning
+    on conflict, and any sibling ``properties`` on the ``allOf`` node itself
+    taking precedence over all members. ``required`` is unioned. Compositions
+    that are not a plain intersection of object subschemas are returned
+    unchanged.
+    """
+    if max_depth <= 0:
+        return node
+    if isinstance(node, list):
+        return [merge_allof(v, max_depth - 1) for v in node]
+    if not isinstance(node, dict):
+        return node
+
+    node = {k: merge_allof(v, max_depth - 1) for k, v in node.items()}
+
+    members = node.get("allOf")
+    if not isinstance(members, list) or not members:
+        return node
+
+    mergeable = _mergeable_allof_members(members)
+    if mergeable is None:
+        return node
+
+    properties: dict[str, Any] = {}
+    required: list[str] = []
+    for member in mergeable:
+        for name, subschema in (member.get("properties") or {}).items():
+            properties.setdefault(name, subschema)
+        for name in member.get("required") or []:
+            if name not in required:
+                required.append(name)
+
+    siblings = {k: v for k, v in node.items() if k != "allOf"}
+    # Keywords written next to the ``allOf`` describe the composition itself and
+    # outrank anything the members declare.
+    for name, subschema in (siblings.get("properties") or {}).items():
+        properties[name] = subschema
+    for name in siblings.get("required") or []:
+        if name not in required:
+            required.append(name)
+
+    merged: dict[str, Any] = {**siblings, "type": "object"}
+    if properties:
+        merged["properties"] = properties
+    if required:
+        merged["required"] = required
+    return merged
+
+
 _SUCCESS_PRIORITY = ("200", "2XX", "201", "default")
 _JSON_CONTENT_TYPES = ("application/json", "application/vnd.api+json")
 
@@ -235,7 +318,7 @@ def extract_response_schema(
     schema = media.get("schema")
     if not isinstance(schema, dict):
         return None
-    return deref_schema(spec, schema)
+    return merge_allof(deref_schema(spec, schema))
 
 
 def extract_request_body_schema(
@@ -284,7 +367,7 @@ def extract_response_schemas(
                 continue
             schema = media.get("schema")
             if isinstance(schema, dict):
-                per_content[content_type] = deref_schema(spec, schema)
+                per_content[content_type] = merge_allof(deref_schema(spec, schema))
         if per_content:
             out[status] = per_content
     return out

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -164,6 +164,9 @@ def operation_parameters(
     return merged
 
 
+_NON_SCHEMA_KEYWORDS = frozenset({"default", "example", "examples", "enum", "const"})
+
+
 def deref_schema(
     spec: dict[str, Any],
     node: Any,
@@ -184,7 +187,17 @@ def deref_schema(
             if not target:
                 return node
             return deref_schema(spec, target, seen | {ref}, max_depth - 1)
-        return {k: deref_schema(spec, v, seen, max_depth - 1) for k, v in node.items()}
+        # Instance data (``default``, ``example(s)``, ``enum``, ``const``) and
+        # vendor extensions are not subschemas: a ``$ref`` key inside one is a
+        # literal value, not a reference to resolve.
+        return {
+            k: (
+                v
+                if k in _NON_SCHEMA_KEYWORDS or k.startswith("x-")
+                else deref_schema(spec, v, seen, max_depth - 1)
+            )
+            for k, v in node.items()
+        }
     if isinstance(node, list):
         return [deref_schema(spec, v, seen, max_depth - 1) for v in node]
     return node
@@ -246,7 +259,18 @@ def merge_allof(node: Any, max_depth: int = 32) -> Any:
     if not isinstance(node, dict):
         return node
 
-    node = {k: merge_allof(v, max_depth - 1) for k, v in node.items()}
+    # ``default``, ``example(s)``, ``enum`` and ``const`` hold instance data, not
+    # subschemas, and a vendor extension can hold anything. Recursing into them
+    # would rewrite a value that merely happens to contain an ``allOf`` key —
+    # a default of ``{"allOf": [...]}`` came back as ``{"type": "object"}``.
+    node = {
+        k: (
+            v
+            if k in _NON_SCHEMA_KEYWORDS or k.startswith("x-")
+            else merge_allof(v, max_depth - 1)
+        )
+        for k, v in node.items()
+    }
 
     members = node.get("allOf")
     if not isinstance(members, list) or not members:

--- a/cli/openbb_cli/dispatchers/openapi_schema.py
+++ b/cli/openbb_cli/dispatchers/openapi_schema.py
@@ -10,6 +10,8 @@ from urllib.parse import unquote, urldefrag, urljoin, urlsplit
 
 import httpx
 
+_INHERITABLE_PARAMETER_LOCATIONS = frozenset({"path", "query"})
+
 PROVIDER_TAG_RE = re.compile(r"\s*\(provider:\s*([^)]+)\)\s*$")
 PROVIDER_SECTION_SPLIT_RE = re.compile(r";\s*\n\s*")
 
@@ -131,6 +133,12 @@ def operation_parameters(
     operation under that path. An operation-level parameter overrides an inherited
     one when both match on ``(name, in)``; anything else is inherited as-is.
 
+    Only ``in: path`` and ``in: query`` are inherited. A path-item ``in: header``
+    or ``in: cookie`` entry is deliberately dropped: those do not translate into a
+    Python interface function, and outbound headers belong to transport
+    configuration (``SystemSettings.PythonSettings.http.headers``, the CLI's
+    ``-H``) or to security-scheme handling — not to a per-command argument.
+
     Entries are returned dereferenced, inherited first, then the operation's own.
     """
     inherited = path_item.get("parameters") or []
@@ -146,6 +154,8 @@ def operation_parameters(
             continue
         resolved = deref_parameter(spec, raw)
         if not resolved or not resolved.get("name"):
+            continue
+        if resolved.get("in") not in _INHERITABLE_PARAMETER_LOCATIONS:
             continue
         if (resolved.get("name"), resolved.get("in")) in overridden:
             continue

--- a/cli/openbb_cli/dispatchers/spec.py
+++ b/cli/openbb_cli/dispatchers/spec.py
@@ -22,11 +22,11 @@ from openbb_cli.dispatchers.openapi_schema import (
     _resolve_schema,
     build_reference,
     build_router_map,
-    deref_parameter,
     detect_api_prefix,
     extract_request_body_schema,
     extract_response_schema,
     extract_response_schemas,
+    operation_parameters,
     param_provider_membership,
     parse_json_arg,
     request_body_parameters,
@@ -190,14 +190,17 @@ def _security_parameters(
 
 
 def _build_operation_entry(
-    spec: dict[str, Any], url: str, method: str, op: dict[str, Any]
+    spec: dict[str, Any],
+    url: str,
+    method: str,
+    op: dict[str, Any],
+    path_item: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """Build the per-URL command entry — params, providers, schemas."""
     providers = _operation_providers(op)
     providers_set = set(providers) if providers else None
     params: list[dict[str, Any]] = []
-    for raw in op.get("parameters", []) or []:
-        resolved = deref_parameter(spec, raw) if isinstance(raw, dict) else raw
+    for resolved in operation_parameters(spec, path_item or {}, op):
         if not resolved:
             continue
         normalized = _normalize_parameter(resolved, providers_set)
@@ -298,7 +301,7 @@ def build_command_spec(
         if not base_cmd:
             continue
         groups.setdefault(base_cmd, []).append(
-            _build_operation_entry(spec, url, method, op)
+            _build_operation_entry(spec, url, method, op, methods)
         )
     out: dict[str, dict[str, Any]] = {}
     for cmd, entries in groups.items():

--- a/cli/tests/test_codegen_post_gen.py
+++ b/cli/tests/test_codegen_post_gen.py
@@ -797,3 +797,38 @@ def test_generate_post_command_module_no_body_props_uses_empty_body_dict():
     )
     out = pg.generate_post_command_module(spec)
     assert "_body: dict[str, Any] = {}" in out.source
+
+
+def test_signature_params_body_property_does_not_duplicate_operation_parameter():
+    """A name declared both as an operation parameter and a body property is emitted once.
+
+    Codat's push endpoints put ``accountId`` in the URL template and repeat it in
+    the request body. Emitting both produced two parameters with the same name,
+    which is a SyntaxError in the generated module.
+    """
+    cmd = {
+        "url_path": "/companies/{companyId}/push/bankAccounts/{accountId}/transactions",
+        "parameters": [
+            {"name": "companyId", "type": "string", "required": True},
+            {"name": "accountId", "type": "string", "required": True},
+        ],
+        "request_body_schema": {
+            "type": "object",
+            "properties": {
+                "accountId": {"type": "string"},
+                "reference": {"type": "string"},
+            },
+        },
+    }
+    out = pg._signature_params(
+        cmd, array_field=None, array_annotation=None, has_credentials=False
+    )
+    names = [e[0] for e in out]
+
+    assert names.count("accountId") == 1
+    assert len(names) == len(set(names))
+    # The operation parameter wins: it carries the path placeholder and required.
+    accountid = next(e for e in out if e[0] == "accountId")
+    assert accountid[3] is True
+    # Body-only properties are unaffected.
+    assert "reference" in names

--- a/cli/tests/test_codegen_post_gen.py
+++ b/cli/tests/test_codegen_post_gen.py
@@ -889,3 +889,43 @@ def test_render_body_block_keys_keyword_property_by_wire_name():
     # A body property must not also be sent as a query parameter.
     assert "_query_dict['from_']" not in block
     assert '_query_dict["from_"]' not in block
+
+
+def test_signature_params_never_emits_a_duplicate_identifier():
+    """Collisions are resolved on the emitted identifier, not the wire name.
+
+    Two wire names can sanitize onto one identifier, and operation_parameters
+    keeps a name declared twice under different ``in`` locations. Neither may
+    produce a duplicate argument.
+    """
+    cmd = {
+        "parameters": [
+            # same name, two locations — operation_parameters keeps both
+            {"name": "id", "in": "path", "type": "string", "required": True},
+            {"name": "id", "in": "query", "type": "string"},
+            # sanitizes onto the same identifier as the body's ``from``
+            {"name": "from_", "in": "query", "type": "string"},
+            {"name": "Organization-Id", "in": "header", "type": "string"},
+        ],
+        "request_body_schema": {
+            "type": "object",
+            "properties": {
+                "from": {"type": "string"},
+                "Organization_Id": {"type": "string"},
+                "kept": {"type": "string"},
+            },
+        },
+    }
+    out = pg._signature_params(
+        cmd, array_field=None, array_annotation=None, has_credentials=True
+    )
+    names = [e[0] for e in out]
+
+    assert len(names) == len(set(names)), names
+    assert names.count("id") == 1
+    assert names.count("from_") == 1
+    assert names.count("Organization_Id") == 1
+    # A body property that collides with nothing is still emitted.
+    assert "kept" in names
+    # Every emitted name is a usable Python identifier.
+    assert all(n.isidentifier() for n in names)

--- a/cli/tests/test_codegen_post_gen.py
+++ b/cli/tests/test_codegen_post_gen.py
@@ -832,3 +832,60 @@ def test_signature_params_body_property_does_not_duplicate_operation_parameter()
     assert accountid[3] is True
     # Body-only properties are unaffected.
     assert "reference" in names
+
+
+def _keyword_body_cmd() -> dict:
+    return {
+        "url_path": "/companies/{companyId}/push/transfers",
+        "parameters": [{"name": "companyId", "type": "string", "required": True}],
+        "request_body_schema": {
+            "type": "object",
+            "properties": {
+                "from": {"type": "string"},
+                "to": {"type": "string"},
+            },
+        },
+    }
+
+
+def test_signature_params_uses_safe_identifier_for_keyword_body_property():
+    """A body property named after a Python keyword cannot be emitted verbatim.
+
+    Codat's Transfer body has a ``from`` property; ``from: str = None`` in a
+    signature is a SyntaxError.
+    """
+    out = pg._signature_params(
+        _keyword_body_cmd(),
+        array_field=None,
+        array_annotation=None,
+        has_credentials=False,
+    )
+    names = [e[0] for e in out]
+
+    assert "from_" in names
+    assert "from" not in names
+    assert "to" in names
+
+
+def test_render_body_block_keys_keyword_property_by_wire_name():
+    """The payload keeps ``from``; only the local identifier is renamed."""
+    cmd = _keyword_body_cmd()
+    params = pg._signature_params(
+        cmd, array_field=None, array_annotation=None, has_credentials=False
+    )
+    block = pg._render_body_block(
+        cmd_spec=cmd,
+        body_field=None,
+        creds={},
+        path_params=["companyId"],
+        url_path_template="/companies/{companyId}/push/transfers",
+        base_url="https://api.codat.io",
+        cred_lines=[],
+        data_class="PushTransfersData",
+        params=params,
+    )
+
+    assert "'from': from_" in block
+    # A body property must not also be sent as a query parameter.
+    assert "_query_dict['from_']" not in block
+    assert '_query_dict["from_"]' not in block

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -1884,11 +1884,33 @@ def test_operation_parameters_returns_own_when_no_path_item_params():
 
 def test_operation_parameters_inherits_from_path_item():
     """Path-item parameters come first, then the operation's own."""
-    path_item = {"parameters": [{"name": "tenant", "in": "header"}]}
+    path_item = {"parameters": [{"name": "record_id", "in": "path"}]}
     op = {"parameters": [{"name": "symbol", "in": "query"}]}
     assert [p["name"] for p in operation_parameters({}, path_item, op)] == [
-        "tenant",
+        "record_id",
         "symbol",
+    ]
+
+
+def test_operation_parameters_drops_inherited_headers_and_cookies():
+    """Headers and cookies are transport concerns, not command arguments."""
+    path_item = {
+        "parameters": [
+            {"name": "x-tenant-id", "in": "header"},
+            {"name": "session", "in": "cookie"},
+            {"name": "record_id", "in": "path"},
+        ]
+    }
+    assert [p["name"] for p in operation_parameters({}, path_item, {})] == ["record_id"]
+
+
+def test_operation_parameters_keeps_operation_level_headers():
+    """An operation's own header parameter is untouched by the inheritance filter."""
+    op = {"parameters": [{"name": "x-request-id", "in": "header"}]}
+    path_item = {"parameters": [{"name": "record_id", "in": "path"}]}
+    assert [p["name"] for p in operation_parameters({}, path_item, op)] == [
+        "record_id",
+        "x-request-id",
     ]
 
 
@@ -1905,15 +1927,15 @@ def test_operation_parameters_resolves_refs_on_both_levels():
     spec = {
         "components": {
             "parameters": {
-                "tenant": {"name": "tenant", "in": "header"},
+                "record_id": {"name": "record_id", "in": "path"},
                 "symbol": {"name": "symbol", "in": "query"},
             }
         }
     }
-    path_item = {"parameters": [{"$ref": "#/components/parameters/tenant"}]}
+    path_item = {"parameters": [{"$ref": "#/components/parameters/record_id"}]}
     op = {"parameters": [{"$ref": "#/components/parameters/symbol"}]}
     assert [p["name"] for p in operation_parameters(spec, path_item, op)] == [
-        "tenant",
+        "record_id",
         "symbol",
     ]
 
@@ -1924,11 +1946,11 @@ def test_operation_parameters_skips_unresolvable_and_unnamed_entries():
         "parameters": [
             {"$ref": "#/components/parameters/missing"},
             "not-a-dict",
-            {"in": "header"},
-            {"name": "tenant", "in": "header"},
+            {"in": "query"},
+            {"name": "record_id", "in": "path"},
         ]
     }
-    assert [p["name"] for p in operation_parameters({}, path_item, {})] == ["tenant"]
+    assert [p["name"] for p in operation_parameters({}, path_item, {})] == ["record_id"]
 
 
 def test_build_command_index_inherits_path_item_parameters():
@@ -1937,7 +1959,7 @@ def test_build_command_index_inherits_path_item_parameters():
         "paths": {
             "/api/v1/x": {
                 "parameters": [
-                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                    {"name": "record_id", "in": "path", "schema": {"type": "string"}}
                 ],
                 "get": {
                     "operationId": "x",
@@ -1950,7 +1972,7 @@ def test_build_command_index_inherits_path_item_parameters():
     }
     parser = build_command_index(spec)["x"]
     dests = {a.dest for a in parser._actions}
-    assert "tenant" in dests
+    assert "record_id" in dests
     assert "symbol" in dests
 
 

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -2150,3 +2150,32 @@ def test_extract_request_body_schema_merges_allof_composition():
     # A composition body now flattens into body parameters instead of none.
     names = {p["name"] for p in request_body_parameters(schema)}
     assert names == {"reference", "modifiedDate"}
+
+
+def test_merge_allof_annotation_keywords_do_not_block_merge():
+    # Codat's PagingInfo carries `definitions` alongside its properties. Treating
+    # any unrecognized keyword as disqualifying left those compositions unmerged,
+    # which is what kept the response model empty.
+    schema = {
+        "title": "Paged results",
+        "x-internal": True,
+        "allOf": [
+            {"type": "object", "properties": {"results": {"type": "array"}}},
+            {
+                "title": "Pagination information",
+                "properties": {"pageNumber": {"type": "integer"}},
+                "definitions": {"links": {"type": "object"}},
+                "additionalProperties": False,
+            },
+        ],
+    }
+    merged = merge_allof(schema)
+    assert set(merged["properties"]) == {"results", "pageNumber"}
+    assert merged["type"] == "object"
+
+
+def test_merge_allof_blocks_on_structural_keywords():
+    # enum, const and items are scalar/array constraints, not property bags.
+    for blocking in ({"enum": ["a"]}, {"const": 1}, {"items": {"type": "string"}}):
+        schema = {"allOf": [{"properties": {"a": {}}}, blocking]}
+        assert merge_allof(schema) == schema

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -21,6 +21,7 @@ from openbb_cli.dispatchers.openapi_schema import (
     build_parser_from_operation,
     build_reference,
     build_router_map,
+    deref_schema,
     expand_type_arrays,
     extract_request_body_schema,
     extract_response_schema,
@@ -2179,3 +2180,53 @@ def test_merge_allof_blocks_on_structural_keywords():
     for blocking in ({"enum": ["a"]}, {"const": 1}, {"items": {"type": "string"}}):
         schema = {"allOf": [{"properties": {"a": {}}}, blocking]}
         assert merge_allof(schema) == schema
+
+
+def test_merge_allof_leaves_instance_data_untouched():
+    """``default`` / ``example`` / ``enum`` hold instance data, not subschemas.
+
+    A default value that happens to contain an ``allOf`` key was rewritten into
+    ``{"type": "object"}``, destroying the value.
+    """
+    schema = {
+        "type": "object",
+        "properties": {
+            "cfg": {
+                "type": "object",
+                "default": {"allOf": [{"a": 1}, {"b": 2}]},
+                "example": {"allOf": [{"p": 1}]},
+            },
+            "mode": {"type": "string", "enum": [{"allOf": [{"q": 1}]}]},
+        },
+        "x-vendor": {"allOf": [{"z": 1}, {"w": 2}]},
+    }
+    merged = merge_allof(schema)
+
+    assert merged["properties"]["cfg"]["default"] == {"allOf": [{"a": 1}, {"b": 2}]}
+    assert merged["properties"]["cfg"]["example"] == {"allOf": [{"p": 1}]}
+    assert merged["properties"]["mode"]["enum"] == [{"allOf": [{"q": 1}]}]
+    assert merged["x-vendor"] == {"allOf": [{"z": 1}, {"w": 2}]}
+
+
+def test_deref_schema_leaves_instance_data_untouched():
+    """A ``$ref`` key inside a default value is a literal, not a reference."""
+    spec = {"components": {"schemas": {"Thing": {"type": "integer"}}}}
+    node = {
+        "type": "object",
+        "properties": {
+            "payload": {
+                "type": "object",
+                "default": {"$ref": "#/components/schemas/Thing"},
+            },
+            "real": {"$ref": "#/components/schemas/Thing"},
+        },
+        "x-sample": {"$ref": "#/components/schemas/Thing"},
+    }
+    out = deref_schema(spec, node)
+
+    # The literal survives, the genuine reference resolves.
+    assert out["properties"]["payload"]["default"] == {
+        "$ref": "#/components/schemas/Thing"
+    }
+    assert out["x-sample"] == {"$ref": "#/components/schemas/Thing"}
+    assert out["properties"]["real"] == {"type": "integer"}

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -22,6 +22,7 @@ from openbb_cli.dispatchers.openapi_schema import (
     build_reference,
     build_router_map,
     expand_type_arrays,
+    operation_parameters,
     parameter_to_kwargs,
     parse_json_arg,
     request_body_parameters,
@@ -1873,3 +1874,90 @@ def test_bundle_external_refs_rejects_schema_ref_siblings(monkeypatch):
             timeout=1,
             headers={},
         )
+
+
+def test_operation_parameters_returns_own_when_no_path_item_params():
+    """Without inherited parameters the operation's own list is returned, dereferenced."""
+    op = {"parameters": [{"name": "symbol", "in": "query"}]}
+    assert operation_parameters({}, {}, op) == [{"name": "symbol", "in": "query"}]
+
+
+def test_operation_parameters_inherits_from_path_item():
+    """Path-item parameters come first, then the operation's own."""
+    path_item = {"parameters": [{"name": "tenant", "in": "header"}]}
+    op = {"parameters": [{"name": "symbol", "in": "query"}]}
+    assert [p["name"] for p in operation_parameters({}, path_item, op)] == [
+        "tenant",
+        "symbol",
+    ]
+
+
+def test_operation_parameters_operation_overrides_inherited():
+    """An operation parameter replaces an inherited one matching (name, in)."""
+    path_item = {"parameters": [{"name": "limit", "in": "query", "required": False}]}
+    op = {"parameters": [{"name": "limit", "in": "query", "required": True}]}
+    out = operation_parameters({}, path_item, op)
+    assert out == [{"name": "limit", "in": "query", "required": True}]
+
+
+def test_operation_parameters_resolves_refs_on_both_levels():
+    """``$ref`` entries are resolved before they are compared or returned."""
+    spec = {
+        "components": {
+            "parameters": {
+                "tenant": {"name": "tenant", "in": "header"},
+                "symbol": {"name": "symbol", "in": "query"},
+            }
+        }
+    }
+    path_item = {"parameters": [{"$ref": "#/components/parameters/tenant"}]}
+    op = {"parameters": [{"$ref": "#/components/parameters/symbol"}]}
+    assert [p["name"] for p in operation_parameters(spec, path_item, op)] == [
+        "tenant",
+        "symbol",
+    ]
+
+
+def test_operation_parameters_skips_unresolvable_and_unnamed_entries():
+    """Unresolvable refs, non-dicts, and nameless entries are dropped."""
+    path_item = {
+        "parameters": [
+            {"$ref": "#/components/parameters/missing"},
+            "not-a-dict",
+            {"in": "header"},
+            {"name": "tenant", "in": "header"},
+        ]
+    }
+    assert [p["name"] for p in operation_parameters({}, path_item, {})] == ["tenant"]
+
+
+def test_build_command_index_inherits_path_item_parameters():
+    """The interactive parser also picks up parameters shared by the path item."""
+    spec = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [
+                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                ],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [
+                        {"name": "symbol", "in": "query", "schema": {"type": "string"}}
+                    ],
+                },
+            }
+        }
+    }
+    parser = build_command_index(spec)["x"]
+    dests = {a.dest for a in parser._actions}
+    assert "tenant" in dests
+    assert "symbol" in dests
+
+
+def test_build_parser_from_operation_without_spec_ignores_path_item():
+    """Called without a spec the parser keeps its previous operation-only behavior."""
+    op = {
+        "parameters": [{"name": "symbol", "in": "query", "schema": {"type": "string"}}]
+    }
+    parser = build_parser_from_operation(op)
+    assert {a.dest for a in parser._actions} == {"symbol"}

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -22,6 +22,7 @@ from openbb_cli.dispatchers.openapi_schema import (
     build_reference,
     build_router_map,
     expand_type_arrays,
+    extract_request_body_schema,
     extract_response_schema,
     merge_allof,
     operation_parameters,
@@ -2109,3 +2110,43 @@ def test_extract_response_schema_merges_allof_composition():
     # The nested reference inside the merged member is still resolved.
     items = schema["properties"]["results"]["items"]
     assert items["properties"]["id"] == {"type": "string"}
+
+
+def test_extract_request_body_schema_merges_allof_composition():
+    spec = {
+        "components": {
+            "schemas": {
+                "Timestamps": {
+                    "type": "object",
+                    "properties": {"modifiedDate": {"type": "string"}},
+                },
+                "BillPrototype": {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {"reference": {"type": "string"}},
+                            "required": ["reference"],
+                        },
+                        {"$ref": "#/components/schemas/Timestamps"},
+                    ]
+                },
+            }
+        }
+    }
+    op = {
+        "requestBody": {
+            "content": {
+                "application/json": {
+                    "schema": {"$ref": "#/components/schemas/BillPrototype"}
+                }
+            }
+        }
+    }
+
+    schema = extract_request_body_schema(spec, op)
+    assert set(schema["properties"]) == {"reference", "modifiedDate"}
+    assert schema["required"] == ["reference"]
+
+    # A composition body now flattens into body parameters instead of none.
+    names = {p["name"] for p in request_body_parameters(schema)}
+    assert names == {"reference", "modifiedDate"}

--- a/cli/tests/test_dispatchers_openapi_schema.py
+++ b/cli/tests/test_dispatchers_openapi_schema.py
@@ -22,6 +22,8 @@ from openbb_cli.dispatchers.openapi_schema import (
     build_reference,
     build_router_map,
     expand_type_arrays,
+    extract_response_schema,
+    merge_allof,
     operation_parameters,
     parameter_to_kwargs,
     parse_json_arg,
@@ -1983,3 +1985,127 @@ def test_build_parser_from_operation_without_spec_ignores_path_item():
     }
     parser = build_parser_from_operation(op)
     assert {a.dest for a in parser._actions} == {"symbol"}
+
+
+def test_merge_allof_unions_properties_and_required():
+    schema = {
+        "allOf": [
+            {"type": "object", "properties": {"results": {"type": "array"}}},
+            {
+                "type": "object",
+                "properties": {"pageNumber": {"type": "integer"}},
+                "required": ["pageNumber"],
+            },
+        ]
+    }
+    merged = merge_allof(schema)
+    assert merged["type"] == "object"
+    assert set(merged["properties"]) == {"results", "pageNumber"}
+    assert merged["required"] == ["pageNumber"]
+
+
+def test_merge_allof_first_member_wins_on_conflict():
+    schema = {
+        "allOf": [
+            {"properties": {"value": {"type": "string"}}},
+            {"properties": {"value": {"type": "integer"}}},
+        ]
+    }
+    assert merge_allof(schema)["properties"]["value"] == {"type": "string"}
+
+
+def test_merge_allof_sibling_keywords_outrank_members():
+    schema = {
+        "properties": {"value": {"type": "boolean"}},
+        "required": ["value"],
+        "allOf": [{"properties": {"value": {"type": "string"}}}],
+    }
+    merged = merge_allof(schema)
+    assert merged["properties"]["value"] == {"type": "boolean"}
+    assert merged["required"] == ["value"]
+
+
+def test_merge_allof_nested_inside_properties():
+    schema = {
+        "type": "object",
+        "properties": {
+            "row": {
+                "allOf": [
+                    {"properties": {"a": {"type": "string"}}},
+                    {"properties": {"b": {"type": "string"}}},
+                ]
+            }
+        },
+    }
+    merged = merge_allof(schema)
+    assert set(merged["properties"]["row"]["properties"]) == {"a", "b"}
+
+
+def test_merge_allof_leaves_non_object_compositions_alone():
+    # A member carrying its own combinator, or a non-object type, is not a
+    # plain intersection of property bags and must not be flattened.
+    with_combinator = {
+        "allOf": [
+            {"properties": {"a": {"type": "string"}}},
+            {"oneOf": [{"type": "object"}, {"type": "null"}]},
+        ]
+    }
+    scalar_member = {"allOf": [{"type": "string"}, {"properties": {"a": {}}}]}
+
+    assert merge_allof(with_combinator) == with_combinator
+    assert merge_allof(scalar_member) == scalar_member
+
+
+def test_merge_allof_ignores_schemas_without_allof():
+    schema = {"type": "object", "properties": {"a": {"type": "string"}}}
+    assert merge_allof(schema) == schema
+
+
+def test_extract_response_schema_merges_allof_composition():
+    spec = {
+        "components": {
+            "schemas": {
+                "Paged": {
+                    "type": "object",
+                    "properties": {"pageNumber": {"type": "integer"}},
+                    "required": ["pageNumber"],
+                },
+                "Bills": {
+                    "allOf": [
+                        {
+                            "type": "object",
+                            "properties": {
+                                "results": {
+                                    "type": "array",
+                                    "items": {"$ref": "#/components/schemas/Bill"},
+                                }
+                            },
+                        },
+                        {"$ref": "#/components/schemas/Paged"},
+                    ]
+                },
+                "Bill": {
+                    "type": "object",
+                    "properties": {"id": {"type": "string"}},
+                },
+            }
+        }
+    }
+    op = {
+        "responses": {
+            "200": {
+                "content": {
+                    "application/json": {
+                        "schema": {"$ref": "#/components/schemas/Bills"}
+                    }
+                }
+            }
+        }
+    }
+
+    schema = extract_response_schema(spec, op)
+    assert set(schema["properties"]) == {"results", "pageNumber"}
+    assert schema["required"] == ["pageNumber"]
+    # The nested reference inside the merged member is still resolved.
+    items = schema["properties"]["results"]["items"]
+    assert items["properties"]["id"] == {"type": "string"}

--- a/cli/tests/test_dispatchers_spec.py
+++ b/cli/tests/test_dispatchers_spec.py
@@ -1345,11 +1345,14 @@ def test_add_normalized_parameter_with_datetime_param_uses_coercer():
 
 
 def test_build_command_spec_inherits_path_item_parameters():
-    """Parameters declared on the path item apply to the operation under it."""
+    """Path and query parameters declared on the path item apply to the operation."""
     openapi = {
         "paths": {
-            "/api/v1/x": {
-                "parameters": [{"name": "tenant", "in": "header", "required": True}],
+            "/api/v1/x/{record_id}": {
+                "parameters": [
+                    {"name": "record_id", "in": "path", "required": True},
+                    {"name": "page", "in": "query", "schema": {"type": "integer"}},
+                ],
                 "get": {
                     "operationId": "x",
                     "parameters": [{"name": "symbol", "schema": {"type": "string"}}],
@@ -1359,9 +1362,27 @@ def test_build_command_spec_inherits_path_item_parameters():
     }
     out = build_command_spec(openapi)
     names = [p["name"] for p in out["x"]["parameters"]]
-    assert names == ["tenant", "symbol"]
-    tenant = next(p for p in out["x"]["parameters"] if p["name"] == "tenant")
-    assert tenant["required"] is True
+    assert names == ["record_id", "page", "symbol"]
+    record = next(p for p in out["x"]["parameters"] if p["name"] == "record_id")
+    assert record["required"] is True
+
+
+def test_build_command_spec_drops_path_item_header_parameters():
+    """Path-item headers/cookies are not turned into command arguments."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [
+                    {"name": "x-tenant-id", "in": "header", "required": True},
+                    {"name": "session", "in": "cookie"},
+                    {"name": "page", "in": "query", "schema": {"type": "integer"}},
+                ],
+                "get": {"operationId": "x"},
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    assert [p["name"] for p in out["x"]["parameters"]] == ["page"]
 
 
 def test_build_command_spec_resolves_path_item_ref_parameters():
@@ -1369,23 +1390,23 @@ def test_build_command_spec_resolves_path_item_ref_parameters():
     openapi = {
         "components": {
             "parameters": {
-                "tenantHeader": {
-                    "name": "xero-tenant-id",
-                    "in": "header",
+                "companyId": {
+                    "name": "companyId",
+                    "in": "path",
                     "required": True,
                     "schema": {"type": "string"},
                 }
             }
         },
         "paths": {
-            "/api/v1/accounts/{AccountID}": {
-                "parameters": [{"$ref": "#/components/parameters/tenantHeader"}],
+            "/api/v1/accounts/{companyId}": {
+                "parameters": [{"$ref": "#/components/parameters/companyId"}],
                 "get": {"operationId": "accounts"},
             }
         },
     }
     out = build_command_spec(openapi)
-    assert [p["name"] for p in out["accounts"]["parameters"]] == ["xero-tenant-id"]
+    assert [p["name"] for p in out["accounts"]["parameters"]] == ["companyId"]
 
 
 def test_build_command_spec_operation_parameter_overrides_path_item():
@@ -1423,7 +1444,7 @@ def test_build_command_spec_path_item_param_kept_when_location_differs():
         "paths": {
             "/api/v1/x": {
                 "parameters": [
-                    {"name": "id", "in": "header", "schema": {"type": "string"}}
+                    {"name": "id", "in": "path", "schema": {"type": "string"}}
                 ],
                 "get": {
                     "operationId": "x",
@@ -1436,7 +1457,7 @@ def test_build_command_spec_path_item_param_kept_when_location_differs():
     }
     out = build_command_spec(openapi)
     locations = sorted(p["in"] for p in out["x"]["parameters"] if p["name"] == "id")
-    assert locations == ["header", "query"]
+    assert locations == ["path", "query"]
 
 
 def test_build_command_spec_path_item_parameters_apply_to_every_operation():
@@ -1445,21 +1466,21 @@ def test_build_command_spec_path_item_parameters_apply_to_every_operation():
         "paths": {
             "/api/v1/x": {
                 "parameters": [
-                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                    {"name": "page", "in": "query", "schema": {"type": "integer"}}
                 ],
                 "get": {"operationId": "x"},
             },
             "/api/v1/y": {
                 "parameters": [
-                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                    {"name": "page", "in": "query", "schema": {"type": "integer"}}
                 ],
                 "post": {"operationId": "y"},
             },
         }
     }
     out = build_command_spec(openapi)
-    assert [p["name"] for p in out["x"]["parameters"]] == ["tenant"]
-    assert [p["name"] for p in out["y"]["parameters"]] == ["tenant"]
+    assert [p["name"] for p in out["x"]["parameters"]] == ["page"]
+    assert [p["name"] for p in out["y"]["parameters"]] == ["page"]
 
 
 def test_build_command_spec_skips_unresolvable_path_item_ref_param():
@@ -1484,7 +1505,7 @@ def test_build_command_spec_ignores_malformed_path_item_parameters():
     openapi = {
         "paths": {
             "/api/v1/x": {
-                "parameters": ["not-a-dict", {"in": "header"}],
+                "parameters": ["not-a-dict", {"in": "query"}],
                 "get": {
                     "operationId": "x",
                     "parameters": [{"name": "kept", "schema": {"type": "string"}}],

--- a/cli/tests/test_dispatchers_spec.py
+++ b/cli/tests/test_dispatchers_spec.py
@@ -1342,3 +1342,155 @@ def test_add_normalized_parameter_with_datetime_param_uses_coercer():
     )
     action = next(a for a in p._actions if a.dest == "fromDateTime")
     assert action.type is _coerce_iso_datetime
+
+
+def test_build_command_spec_inherits_path_item_parameters():
+    """Parameters declared on the path item apply to the operation under it."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [{"name": "tenant", "in": "header", "required": True}],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [{"name": "symbol", "schema": {"type": "string"}}],
+                },
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    names = [p["name"] for p in out["x"]["parameters"]]
+    assert names == ["tenant", "symbol"]
+    tenant = next(p for p in out["x"]["parameters"] if p["name"] == "tenant")
+    assert tenant["required"] is True
+
+
+def test_build_command_spec_resolves_path_item_ref_parameters():
+    """A path-item parameter given as a $ref is resolved before inheriting."""
+    openapi = {
+        "components": {
+            "parameters": {
+                "tenantHeader": {
+                    "name": "xero-tenant-id",
+                    "in": "header",
+                    "required": True,
+                    "schema": {"type": "string"},
+                }
+            }
+        },
+        "paths": {
+            "/api/v1/accounts/{AccountID}": {
+                "parameters": [{"$ref": "#/components/parameters/tenantHeader"}],
+                "get": {"operationId": "accounts"},
+            }
+        },
+    }
+    out = build_command_spec(openapi)
+    assert [p["name"] for p in out["accounts"]["parameters"]] == ["xero-tenant-id"]
+
+
+def test_build_command_spec_operation_parameter_overrides_path_item():
+    """An operation parameter wins over an inherited one with the same name and location."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [
+                    {"name": "limit", "in": "query", "schema": {"type": "string"}}
+                ],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [
+                        {
+                            "name": "limit",
+                            "in": "query",
+                            "required": True,
+                            "schema": {"type": "integer"},
+                        }
+                    ],
+                },
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    params = out["x"]["parameters"]
+    assert len(params) == 1
+    assert params[0]["type"] == "integer"
+    assert params[0]["required"] is True
+
+
+def test_build_command_spec_path_item_param_kept_when_location_differs():
+    """Overriding is keyed on (name, in) — a same-named param elsewhere is kept."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [
+                    {"name": "id", "in": "header", "schema": {"type": "string"}}
+                ],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [
+                        {"name": "id", "in": "query", "schema": {"type": "string"}}
+                    ],
+                },
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    locations = sorted(p["in"] for p in out["x"]["parameters"] if p["name"] == "id")
+    assert locations == ["header", "query"]
+
+
+def test_build_command_spec_path_item_parameters_apply_to_every_operation():
+    """Both operations under one path item inherit its shared parameters."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [
+                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                ],
+                "get": {"operationId": "x"},
+            },
+            "/api/v1/y": {
+                "parameters": [
+                    {"name": "tenant", "in": "header", "schema": {"type": "string"}}
+                ],
+                "post": {"operationId": "y"},
+            },
+        }
+    }
+    out = build_command_spec(openapi)
+    assert [p["name"] for p in out["x"]["parameters"]] == ["tenant"]
+    assert [p["name"] for p in out["y"]["parameters"]] == ["tenant"]
+
+
+def test_build_command_spec_skips_unresolvable_path_item_ref_param():
+    """An unresolvable path-item $ref is dropped rather than crashing."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": [{"$ref": "#/components/parameters/missing"}],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [{"name": "kept", "schema": {"type": "string"}}],
+                },
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    assert [p["name"] for p in out["x"]["parameters"]] == ["kept"]
+
+
+def test_build_command_spec_ignores_malformed_path_item_parameters():
+    """Non-dict path-item parameter entries are skipped defensively."""
+    openapi = {
+        "paths": {
+            "/api/v1/x": {
+                "parameters": ["not-a-dict", {"in": "header"}],
+                "get": {
+                    "operationId": "x",
+                    "parameters": [{"name": "kept", "schema": {"type": "string"}}],
+                },
+            }
+        }
+    }
+    out = build_command_spec(openapi)
+    assert [p["name"] for p in out["x"]["parameters"]] == ["kept"]


### PR DESCRIPTION
### What

OpenAPI 3.x lets a [Path Item Object](https://spec.openapis.org/oas/v3.1.0#fixed-fields-6) declare `parameters` that apply to every operation under that path, with operation-level entries overriding them by `(name, in)`. The V5 codegen only read `op.get("parameters")`, so path-item parameters were dropped — silently. The generated command kept the URL template but had nothing registered to satisfy it.

This is the same silent-success failure surface as #7585, from a different root cause: the generator reports success, and the breakage only shows up when the user calls the command.

### Real-world repro

The [Xero Accounting API](https://github.com/XeroAPI/Xero-OpenAPI) declares its **required** `xero-tenant-id` header once per path item, across all 138 paths:

```yaml
/Accounts/{AccountID}:
  parameters:
    - $ref: '#/components/parameters/requiredHeader'   # xero-tenant-id, in: header, required: true
  get:
    parameters:
      - $ref: '#/components/parameters/AccountID'
```

Running `build_command_spec` against the live spec:

| | before | after |
| --- | --- | --- |
| commands generated | 78 | 78 |
| carrying required `xero-tenant-id` | **0** | **78** |

Xero returns 403 without that header, so before this change every generated command was dead on arrival with no warning.

### How

Adds `operation_parameters(spec, path_item, op)` to `openapi_schema.py`. It merges the two levels, dereferences `$ref` on both, and applies the spec's override rule keyed on `(name, in)` — so a same-named parameter in a different location is correctly kept rather than swallowed.

Both consumers route through it:

- `build_command_spec` → `_build_operation_entry` — the pre-computed `--generate-spec` path
- `build_command_index` → `build_parser_from_operation` — the interactive `--server` path

`build_router_map`, `build_reference`, and `detect_api_prefix` only read path keys and descriptions, so they're unaffected.

Unresolvable `$ref`s, non-dict entries, and nameless parameters are skipped exactly as before. `build_parser_from_operation` keeps its previous operation-only behavior when called without a `spec`, and specs with no path-item parameters produce byte-identical output.

### Tests

14 new tests covering: inheritance, `$ref` resolution on both levels, operation-over-path-item override, `(name, in)` keying, inheritance across multiple operations under one path item, and the defensive skip paths.

```
2019 passed
ruff format --check   clean
ruff check            clean
ty check              clean
```

(2005 before this change, plus the 14 new.)
