### PR TITLE
perf(core): drop a redundant deepcopy of command kwargs

### DIFF
--- a/openbb_platform/core/openbb_core/app/command_runner.py
+++ b/openbb_platform/core/openbb_core/app/command_runner.py
@@ -330,7 +330,6 @@ class StaticCommandRunner:
                 # added to the function signature in the router decorator
                 # If the ProviderInterface is not in use, we need to pass a copy of the
                 # kwargs dictionary before it is validated, otherwise we lose those items.
-                kwargs_copy = deepcopy(kwargs)
                 chart = kwargs.pop("chart", False)
                 kwargs_copy = deepcopy(kwargs)
                 kwargs = ParametersBuilder.build(
@@ -480,7 +479,7 @@ class StaticCommandRunner:
                     dependency_param_names.add(dep_name)
 
                 for dep_key in dependency_param_names:
-                    _ = obbject._extra_params.pop(  # type:ignore  # pylint: disable=W0212
+                    _ = obbject._extra_params.pop(  # type: ignore  # pylint: disable=W0212
                         dep_key, None
                     )
 


### PR DESCRIPTION
`StaticCommandRunner._execute_func` deep-copies `kwargs`, pops `"chart"` from the original, then deep-copies again:

```python
kwargs_copy = deepcopy(kwargs)
chart = kwargs.pop("chart", False)
kwargs_copy = deepcopy(kwargs)   # overwrites the line above
```

The first copy is never read — it is overwritten two lines later — so every command dispatch pays two full deep copies of the caller's payload where one is needed. This removes the dead store.

## What it costs today

The copy is of `kwargs`, so the cost tracks the payload. For `obb.equity.price.historical(...)`-style commands the kwargs are a handful of scalars and the redundant copy is **2.7 µs** — genuinely irrelevant next to the provider HTTP call, and I would not have opened a PR for that alone.

It matters for the commands that take a `data` payload — `technical`, `econometrics` and `quantitative` all accept `list[Data]` — because there the payload *is* the dataset and the computation is local, so there is no network call to hide behind. Measured on the region itself, median of 15 samples per round, 3 interleaved rounds:

| payload | today (2 copies) | this PR (1 copy) | saved per call |
|---|---:|---:|---:|
| 250 rows | 1.45 ms | 0.72 ms | 0.73 ms |
| 1,000 rows | 5.83 ms | 2.88 ms | 2.95 ms |
| 5,000 rows | 30.5 ms | 14.6 ms | 15.9 ms |

Frequency is one per command dispatch, unconditionally — it is not behind the `chart` branch or any provider check. It also runs synchronously inside `async _execute_func`, so under the API server it occupies the event loop for that whole duration.

A control confirms where the cost is: keeping both copies but moving the `pop` first measures 5.87 ms at 1,000 rows, i.e. unchanged. The `pop` is not the cost; the second copy is.

## Behaviour

Unchanged. The removed line's value was overwritten before any read, so the surviving copy — taken after `"chart"` is popped — is exactly what the rest of the function already used.

`openbb_platform/core/tests/app/test_command_runner.py`: 25 passed, 1 failed. That one failure, `test_static_command_runner_chart`, reproduces identically on unmodified `develop` at `3e071fcc` in the same environment, so it is pre-existing and not from this change. I did not touch any test.

## What I deliberately left out

Several alternatives are faster than this patch and I am not proposing them:

- copying via `json` (1.78 ms) or `pickle` (0.59 ms) round-trips — both change which payload types survive;
- skipping the deep copy for the `data` key, or a shallow copy, or copying only when charting was requested (0.001–0.002 ms) — all alias the caller's data, so a downstream mutation could leak back;
- the other `deepcopy` calls in this file, at `merge_args_and_kwargs`, are **not** dead — their values flow into `parameter_map` — so removing them would be a real semantic change rather than a cleanup, and they are out of scope here.

This PR is only the dead store.

## Exploration record

Twelve variants of this region were implemented and measured, including the ones above that do not qualify and a no-copy floor reference. Three structurally different ways of expressing "copy once" — deleting the dead store, popping from the copy, and a single copy with an explicit memo — land at 2.881 / 2.860 / 2.858 ms, within 0.8% of each other, so there is one improving move here rather than a spectrum. Public record of that exploration: https://dashboard.weco.ai/share/DJSi5Z0pwQGnRZN3ZJhlFAdbCs8GHIX5
