### PR TITLE
perf: avoid duplicate yfinance options chain request

### DIFF
--- a/openbb_platform/providers/yfinance/openbb_yfinance/models/options_chains.py
+++ b/openbb_platform/providers/yfinance/openbb_yfinance/models/options_chains.py
@@ -44,9 +44,7 @@ class YFinanceOptionsChainsData(OptionsChainsData):
     )
 
 
-class YFinanceOptionsChainsFetcher(
-    Fetcher[YFinanceOptionsChainsQueryParams, YFinanceOptionsChainsData]
-):
+class YFinanceOptionsChainsFetcher(Fetcher[YFinanceOptionsChainsQueryParams, YFinanceOptionsChainsData]):
     """YFinance Options Chains Fetcher."""
 
     @staticmethod
@@ -78,15 +76,20 @@ class YFinanceOptionsChainsFetcher(
             if not expirations or len(expirations) == 0:
                 return None, None, []
 
-            underlying = t.option_chain(expirations[0])[2]
+            first_chain_data = t.option_chain(expirations[0])
+            underlying = first_chain_data[2]
             chains_output: list = []
             tz = timezone(underlying.get("exchangeTimezoneName", "UTC"))
 
-            for expiration in expirations:
+            for frame in first_chain_data[:2]:
+                if frame is not None and "lastTradeDate" in frame:
+                    frame["lastTradeDate"] = frame["lastTradeDate"].dt.tz_convert(tz)
+
+            for index, expiration in enumerate(expirations):
                 exp = datetime.strptime(expiration, "%Y-%m-%d").date()
                 now = datetime.now().date()
                 dte = (exp - now).days
-                chain_data = t.option_chain(expiration, tz=tz)
+                chain_data = first_chain_data if index == 0 else t.option_chain(expiration, tz=tz)
                 calls = chain_data[0]
                 calls["option_type"] = "call"
                 calls["expiration"] = expiration
@@ -94,31 +97,21 @@ class YFinanceOptionsChainsFetcher(
                 puts["option_type"] = "put"
                 puts["expiration"] = expiration
                 chain = concat([calls, puts])
-                chain = (
-                    chain.set_index(["strike", "option_type", "contractSymbol"])
-                    .sort_index()
-                    .reset_index()
-                )
+                chain = chain.set_index(["strike", "option_type", "contractSymbol"]).sort_index().reset_index()
                 chain = chain.drop(columns=["contractSize"])
                 chain["dte"] = dte
-                underlying_price = underlying.get(
-                    "postMarketPrice", underlying.get("regularMarketPrice")
-                )
+                underlying_price = underlying.get("postMarketPrice", underlying.get("regularMarketPrice"))
                 if underlying_price is not None:
                     chain["underlying_price"] = underlying_price
                     chain["underlying_symbol"] = symbol
                 chain["percentChange"] = chain["percentChange"] / 100
 
                 if len(chain) > 0:
-                    chains_output.extend(
-                        chain.fillna("N/A").replace("N/A", None).to_dict("records")
-                    )
+                    chains_output.extend(chain.fillna("N/A").replace("N/A", None).to_dict("records"))
 
             return underlying, chains_output, expirations
 
-        underlying, chains_output, expirations = await asyncio.to_thread(
-            _get_all_data, symbol
-        )
+        underlying, chains_output, expirations = await asyncio.to_thread(_get_all_data, symbol)
 
         if not expirations or len(expirations) == 0:
             raise OpenBBError(f"No options found for {symbol}")
@@ -137,7 +130,8 @@ class YFinanceOptionsChainsFetcher(
             "ask": underlying.get("ask"),  # type: ignore
             "ask_size": underlying.get("askSize"),  # type: ignore
             "last_price": underlying.get(  # type: ignore
-                "postMarketPrice", underlying.get("regularMarketPrice")  # type: ignore
+                "postMarketPrice",
+                underlying.get("regularMarketPrice"),  # type: ignore
             ),
             "open": underlying.get("regularMarketOpen"),  # type: ignore
             "high": underlying.get("regularMarketDayHigh"),  # type: ignore

--- a/openbb_platform/providers/yfinance/tests/test_yfinance_fetchers.py
+++ b/openbb_platform/providers/yfinance/tests/test_yfinance_fetchers.py
@@ -41,9 +41,7 @@ from openbb_yfinance.models.undervalued_growth_equities import (
 )
 from openbb_yfinance.models.undervalued_large_caps import YFUndervaluedLargeCapsFetcher
 
-test_credentials = UserService().default_user_settings.credentials.model_dump(
-    mode="json"
-)
+test_credentials = UserService().default_user_settings.credentials.model_dump(mode="json")
 
 
 def scrub_string(key, value):
@@ -426,3 +424,90 @@ def test_y_finance_equity_screener_fetcher(credentials=test_credentials):
     fetcher = YFinanceEquityScreenerFetcher()
     result = fetcher.test(params, credentials)
     assert result is None
+
+
+@pytest.mark.asyncio
+async def test_y_finance_options_chains_fetches_each_expiration_once(
+    monkeypatch,
+):
+    """Test that each options expiration is requested only once."""
+    from openbb_yfinance.models.options_chains import (
+        YFinanceOptionsChainsQueryParams,
+    )
+    from pandas import DataFrame, Timestamp
+
+    class FakeTicker:
+        """Deterministic replacement for yfinance.Ticker."""
+
+        instance = None
+
+        def __init__(self, symbol):
+            self.symbol = symbol
+            self.options = ["2099-01-16", "2099-01-23"]
+            self.option_chain_calls = []
+            FakeTicker.instance = self
+
+        def option_chain(self, expiration, tz=None):
+            self.option_chain_calls.append(expiration)
+
+            last_trade_date = Timestamp(
+                "2099-01-01 15:00:00",
+                tz="UTC",
+            )
+
+            if tz is not None:
+                last_trade_date = last_trade_date.tz_convert(tz)
+
+            expiration_code = expiration.replace("-", "")
+
+            calls = DataFrame(
+                [
+                    {
+                        "strike": 100.0,
+                        "contractSymbol": (f"AAPL{expiration_code}C00100000"),
+                        "contractSize": "REGULAR",
+                        "percentChange": 0.0,
+                        "lastTradeDate": last_trade_date,
+                    }
+                ]
+            )
+
+            puts = DataFrame(
+                [
+                    {
+                        "strike": 100.0,
+                        "contractSymbol": (f"AAPL{expiration_code}P00100000"),
+                        "contractSize": "REGULAR",
+                        "percentChange": 0.0,
+                        "lastTradeDate": last_trade_date,
+                    }
+                ]
+            )
+
+            underlying = {
+                "exchangeTimezoneName": "America/New_York",
+                "regularMarketPrice": 100.0,
+            }
+
+            return calls, puts, underlying
+
+    monkeypatch.setattr("yfinance.Ticker", FakeTicker)
+
+    query = YFinanceOptionsChainsQueryParams(symbol="AAPL")
+
+    result = await YFinanceOptionsChainsFetcher.aextract_data(
+        query,
+        credentials=None,
+    )
+
+    ticker = FakeTicker.instance
+    assert ticker is not None
+
+    assert ticker.option_chain_calls == [
+        "2099-01-16",
+        "2099-01-23",
+    ]
+    assert len(result["chains"]) == 4
+
+    first_last_trade_date = result["chains"][0]["lastTradeDate"]
+    assert str(first_last_trade_date.tz) == "America/New_York"


### PR DESCRIPTION
## Summary

Avoids requesting the first YFinance options-chain expiration twice.

Previously, the first expiration was fetched once to retrieve underlying metadata and then fetched again while iterating through all expirations. This resulted in `N + 1` requests for `N` expirations.

This change:

- Reuses the first options-chain response for the first expiration
- Continues fetching all remaining expirations normally
- Preserves exchange-timezone conversion for `lastTradeDate`
- Adds a deterministic regression test verifying each expiration is fetched exactly once

## Before

For two expirations, `option_chain` was called three times:

```text
2099-01-16
2099-01-16
2099-01-23
```

## After

Each expiration is requested once:

```text
2099-01-16
2099-01-23
```

## Tests

```bash
python -m pytest \
providers/yfinance/tests/test_yfinance_fetchers.py::test_y_finance_options_chains_fetches_each_expiration_once \
providers/yfinance/tests/test_yfinance_fetchers.py::test_y_finance_options_chains_fetcher \
-v
```

```bash
python -m pytest providers/yfinance/tests -v
```

## Quality checks

```bash
python -m ruff format \
providers/yfinance/openbb_yfinance/models/options_chains.py \
providers/yfinance/tests/test_yfinance_fetchers.py

python -m ruff check \
providers/yfinance/openbb_yfinance/models/options_chains.py \
providers/yfinance/tests/test_yfinance_fetchers.py
```
