### PR TITLE
fix: set INR symbol (₹) tick prefix for Indian equity symbols instead of dollar symbol ($) (.NS)

### DIFF
--- a/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
+++ b/openbb_platform/obbject_extensions/charting/openbb_charting/charts/price_historical.py
@@ -40,6 +40,10 @@ def price_historical(  # noqa: PLR0912
     if "date" in data.columns:
         data = data.set_index("date")
 
+    # Determine ticker symbol and corresponding currency tick prefix
+    symbol_str = str(kwargs.get("symbol", "") or "")
+    currency_symbol = "₹" if symbol_str.endswith((".NS")) else "$"
+
     target = str(kwargs.get("target"))
     normalize = kwargs.get("normalize") is True
     returns = kwargs.get("returns") is True
@@ -157,6 +161,7 @@ def price_historical(  # noqa: PLR0912
                 mirror=True,
                 showline=True,
                 tickfont=dict(size=14),
+                tickprefix=f"{currency_symbol} " if not (normalize or returns) else "",
             ),
             yaxis2=dict(
                 ticklen=0,
@@ -282,6 +287,7 @@ def price_historical(  # noqa: PLR0912
                 ),
                 tickfont=dict(size=14),
                 anchor="x",
+                tickprefix=f"{currency_symbol} " if not (normalize or returns) else "",
             )
         ),
         yaxis2=(
@@ -295,6 +301,7 @@ def price_historical(  # noqa: PLR0912
                 ),
                 tickfont=dict(size=14),
                 anchor="x",
+                tickprefix=f"{currency_symbol} " if not (normalize or returns) else "",
             )
             if y2title
             else None


### PR DESCRIPTION

## Description
This PR updates the `price_historical` charting extension to dynamically apply the Indian Rupee symbol (`₹`) as the Y-axis `tickprefix` when plotting historical price data for Indian equities (`.NS` tickers). 
Only for Indian equities while preserving the default `$` for all other tickers.

## Changes Made
- Added ticker suffix detection in `price_historical.py` to identify `.NS` (NSE) symbols.

## Testing & Verification
- Tested locally using `RELIANCE.NS`.