### PR TITLE
fix(sec): 13F-HR parser — guard zero total_value, preserve XML entities

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/parse_13f.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/parse_13f.py
@@ -134,6 +134,21 @@ async def parse_13f_hr(filing: str):
     if filing.startswith("https://"):
         filing = await get_complete_submission(filing)  # type: ignore
 
+    # A Complete Submission TXT file is SGML-wrapped and not well-formed XML.
+    # Feeding it to the XML parser as-is triggers lxml's recover mode, which
+    # silently drops character entities: "S&amp;P500" becomes "SP500" and
+    # "BABCOCK &amp; WILCOX" loses its ampersand in nameOfIssuer/titleOfClass.
+    # Extract the embedded well-formed <XML> blocks (form header + information
+    # table) and reassemble them under a synthetic root so the strict XML path
+    # is used and entities are preserved. Inputs that are already bare XML
+    # (no <XML> wrapper) are passed through unchanged.
+    import re as _re  # noqa: PLC0415
+
+    _xml_blocks = _re.findall(r"<XML>(.*?)</XML>", filing, _re.DOTALL | _re.IGNORECASE)
+    if _xml_blocks:
+        _decl = _re.compile(r"<\?xml[^>]*\?>")
+        filing = "<root>" + "".join(_decl.sub("", b) for b in _xml_blocks) + "</root>"
+
     soup = BeautifulSoup(filing, "xml")
 
     info_table = soup.find_all("informationTable")
@@ -221,7 +236,13 @@ async def parse_13f_hr(filing: str):
             df.drop(columns=col, inplace=True)
 
     total_value = df.value.sum()
-    df["weight"] = round(df.value.astype(float) / total_value, 6)
+    # Guard against empty filings: managers with no reportable holdings file a
+    # single placeholder row (value=0), making total_value 0. Without the guard,
+    # 0/0 becomes NaN, which `.replace({nan: None})` below turns into None and
+    # the required `weight: float` field then fails validation.
+    df["weight"] = (
+        round(df.value.astype(float) / total_value, 6) if total_value else 0.0
+    )
 
     return (
         df.reset_index()


### PR DESCRIPTION
# fix(sec): 13F-HR parser — guard zero total_value, preserve XML entities

## Why

Two independent bugs in `openbb_sec/utils/parse_13f.py`, both verified against live EDGAR filings (details + repro in the two linked issues):

1. **Empty filings crash.** Managers with no reportable holdings file a single placeholder row (`value=0`). `total_value` is then 0, `weight = 0/0 = NaN`, `.replace({nan: None})` turns it into `None`, and the required `weight: float` field fails validation — the whole fetch raises `ValidationError`. Repro: CIK `1562087` (Thiel Macro), any quarter since 2025-Q4.

2. **`&` silently dropped from names.** The parser soups the entire SGML-wrapped Complete Submission TXT, which is not well-formed XML; lxml recover mode drops character entities, so `S&P500 EQL WGT` becomes `SP500 EQL WGT` with no error. Every filer holding S&P ETFs is affected every quarter. Repro: CIK `1536411` (Duquesne), 2026-03-31.

## What

- `parse_13f_hr`: extract the embedded well-formed `<XML>` blocks (form header + information table), strip their `<?xml?>` declarations and reassemble under a synthetic root before parsing — strict XML path, entities preserved. Bare-XML inputs pass through unchanged.
- `parse_13f_hr`: guard the weight division — `weight = ... if total_value else 0.0`.

No public API change; `SecForm13FHRData` model untouched.

## Testing

Against live EDGAR (openbb-sec 1.6.6 == 1.6.7 == `main` for the affected lines):

- Empty filing (CIK 1562087, 2026-03-31 and 2025-12-31): no longer raises; returns placeholder row with `weight=0.0`.
- Normal filing (CIK 1536411, 2026-03-31, 70 positions): all `&` preserved (`S&P500 EQL WGT`, `Ishares S&P Gsci Commodity-`, `State Str Spdr S&P 500 Etf T`), `sum(weight) == 1.0` exactly, values/shares byte-identical to a direct parse of the standalone information-table XML.
- Cross-checked 14 filings across 7 institutions (incl. options positions with `putCall`, and a $1000s-convention filer) — field-level identical to an independent parser fed the standalone XML.

Fixes #7618 and #7619.
