### PR TITLE
fix: don't call create_task in ClientSession.__del__ without a running loop

### DIFF
--- a/openbb_platform/core/openbb_core/provider/utils/client.py
+++ b/openbb_platform/core/openbb_core/provider/utils/client.py
@@ -38,6 +38,11 @@ def get_user_agent() -> str:
     return random.choice(user_agent_strings)  # nosec # noqa: S311
 
 
+# Session-close tasks spawned from __del__. The event loop only keeps weak
+# references to tasks, so they are held here until they complete.
+_BACKGROUND_TASKS: set[asyncio.Task] = set()
+
+
 class ClientResponse(aiohttp.ClientResponse):
     """Client response class."""
 
@@ -81,8 +86,29 @@ class ClientSession(aiohttp.ClientSession):
     # pylint: disable=unused-argument
     def __del__(self, _warnings: Any = warnings) -> None:
         """Close the session."""
-        if not self.closed:
-            asyncio.create_task(self.close())
+        if self.closed:
+            return
+
+        # __del__ runs during garbage collection, which may happen with no
+        # running loop at all (sync context, interpreter shutdown). Calling
+        # create_task() there raises RuntimeError, and exceptions in __del__
+        # are swallowed and printed — so the session would silently never
+        # close. Fall back to the ResourceWarning aiohttp itself emits.
+        try:
+            loop = asyncio.get_running_loop()
+        except RuntimeError:
+            _warnings.warn(
+                f"Unclosed client session {self!r}",
+                ResourceWarning,
+                source=self,
+            )
+            return
+
+        # The loop only keeps a weak reference to a task, so a discarded close()
+        # can be collected before it finishes. Hold it until it completes.
+        task = loop.create_task(self.close())
+        _BACKGROUND_TASKS.add(task)
+        task.add_done_callback(_BACKGROUND_TASKS.discard)
 
     async def get(self, url: str, **kwargs) -> ClientResponse:  # type: ignore
         """Send GET request."""


### PR DESCRIPTION
## The problem

`ClientSession.__del__` closes the session by scheduling a task:

```python
def __del__(self, _warnings: Any = warnings) -> None:
    """Close the session."""
    if not self.closed:
        asyncio.create_task(self.close())
```

`__del__` runs during garbage collection, and that can happen with **no running event loop** — a sync context, or interpreter shutdown. `asyncio.create_task()` raises `RuntimeError` there:

```console
>>> s = ClientSession(); del s        # no running loop
RuntimeError: no running event loop
sys:1: RuntimeWarning: coroutine 'ClientSession.close' was never awaited
```

Exceptions raised inside `__del__` are swallowed by Python and printed to stderr rather than propagated, so this does not crash anything — **the session simply never closes** and the connection leaks, with a stray warning as the only sign.

There is a second, smaller issue on the path that does work: when a loop *is* running, the task is discarded, and [the loop only keeps a weak reference](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task), so the close can be collected before it finishes.

## What aiohttp itself does

Worth noting because this class subclasses `aiohttp.ClientSession` — upstream's `__del__` never schedules anything (`aiohttp/client.py:427`):

```python
def __del__(self, _warnings: Any = warnings) -> None:
    if not self.closed:
        _warnings.warn(f"Unclosed client session {self!r}", ResourceWarning, source=self)
        context = {"client_session": self, "message": "Unclosed client session"}
        ...
        self._loop.call_exception_handler(context)
```

It warns and hands off to the exception handler, precisely because `__del__` cannot rely on a loop being available. The override here departs from that.

## The change

Check for a running loop first; fall back to the same `ResourceWarning` upstream emits. When a loop is available, keep the close task referenced until it completes.

```python
try:
    loop = asyncio.get_running_loop()
except RuntimeError:
    _warnings.warn(f"Unclosed client session {self!r}", ResourceWarning, source=self)
    return

task = loop.create_task(self.close())
_BACKGROUND_TASKS.add(task)
task.add_done_callback(_BACKGROUND_TASKS.discard)
```

## Verification

Both paths, with the patched `__del__`:

| | before | after |
|---|---|---|
| no running loop | `RuntimeError: no running event loop` + `coroutine … was never awaited` | `ResourceWarning: Unclosed client session` — same as aiohttp |
| running loop | task discarded, collectable mid-close | task held until done |

```console
$ ruff check openbb_platform/core/openbb_core/provider/utils/client.py    # ruff 0.12.12, pinned in .pre-commit-config.yaml
All checks passed!
$ black --check openbb_platform/core/openbb_core/provider/utils/client.py # black 25.1.0
1 file would be left unchanged.
```

No test added: the no-loop path is straightforward to test, but the loop path is a garbage-collection race and a test for it would be flaky by construction. Happy to add a test for the `RuntimeError` case alone if you'd like one.

Found with an AST scan for `create_task` / `ensure_future` results discarded as bare expression statements. This was the only hit under `openbb_platform/`.
