### PR TITLE
fix(api): return 422 for missing QueryParams fields

### DIFF
--- a/openbb_platform/core/openbb_core/api/exception_handlers.py
+++ b/openbb_platform/core/openbb_core/api/exception_handlers.py
@@ -61,9 +61,7 @@ class ExceptionHandlers:
         )
 
     @staticmethod
-    async def validation(
-        request: Request, error: ValidationError | ResponseValidationError
-    ):
+    async def validation(request: Request, error: ValidationError | ResponseValidationError):
         """Exception handler for ValidationError."""
         # Some validation is performed at Fetcher level.
         # So we check if the validation error comes from a QueryParams class.
@@ -83,14 +81,10 @@ class ExceptionHandlers:
                 detail=detail,
             )
         try:
-            errors = (
-                error.errors(include_url=False)
-                if hasattr(error, "errors")
-                else error.errors
-            )
+            errors = error.errors(include_url=False) if hasattr(error, "errors") else error.errors
         except Exception:
             errors = error.errors if hasattr(error, "errors") else error
-        if "QueryParams" in error.title:
+        if "QueryParams" in error.title and not await request.body():
             detail = [
                 {
                     **{k: v for k, v in err.items() if k != "ctx"},

--- a/openbb_platform/core/openbb_core/api/exception_handlers.py
+++ b/openbb_platform/core/openbb_core/api/exception_handlers.py
@@ -67,10 +67,8 @@ class ExceptionHandlers:
         """Exception handler for ValidationError."""
         # Some validation is performed at Fetcher level.
         # So we check if the validation error comes from a QueryParams class.
-        # And that it is in the request query params.
         # If yes, we update the error location with query.
         # If not, we handle it as a base Exception error.
-        query_params = dict(request.query_params)
         if isinstance(error, ResponseValidationError):
             detail = [
                 {
@@ -92,10 +90,7 @@ class ExceptionHandlers:
             )
         except Exception:
             errors = error.errors if hasattr(error, "errors") else error
-        all_in_query = all(
-            loc in query_params for err in errors for loc in err.get("loc", ())
-        )
-        if "QueryParams" in error.title and all_in_query:
+        if "QueryParams" in error.title:
             detail = [
                 {
                     **{k: v for k, v in err.items() if k != "ctx"},

--- a/openbb_platform/core/tests/api/test_exception_handlers.py
+++ b/openbb_platform/core/tests/api/test_exception_handlers.py
@@ -1,0 +1,72 @@
+"""Test API exception handlers."""
+
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from fastapi.exceptions import ResponseValidationError
+from openbb_core.api.exception_handlers import ExceptionHandlers
+from pydantic import BaseModel, ValidationError
+
+
+class MockQueryParams(BaseModel):
+    """Mock query parameters with a required field."""
+
+    category: str
+
+
+class MockRequestParams(BaseModel):
+    """Mock non-query request parameters with a required field."""
+
+    value: str
+
+
+def get_response_detail(response):
+    """Return the JSON response detail."""
+    return json.loads(response.body)["detail"]
+
+
+def test_validation_missing_query_param_returns_422():
+    """Return 422 when a fetcher QueryParams field is missing from the query."""
+    with pytest.raises(ValidationError) as exc_info:
+        MockQueryParams.model_validate({})
+
+    request = SimpleNamespace(query_params={})
+    response = asyncio.run(ExceptionHandlers.validation(request, exc_info.value))
+
+    assert response.status_code == 422
+    detail = get_response_detail(response)
+    assert detail[0]["loc"] == ["query", "category"]
+
+
+def test_validation_response_error_returns_422():
+    """Keep response validation errors on the 422 path."""
+    error = ResponseValidationError(
+        [
+            {
+                "type": "missing",
+                "loc": ("response", "value"),
+                "msg": "Field required",
+                "input": {},
+            }
+        ]
+    )
+    request = SimpleNamespace(query_params={})
+
+    response = asyncio.run(ExceptionHandlers.validation(request, error))
+
+    assert response.status_code == 422
+    detail = get_response_detail(response)
+    assert detail[0]["loc"] == ["query", "response", "value"]
+
+
+def test_validation_non_query_params_error_returns_500():
+    """Keep non-QueryParams validation errors on the unexpected-error path."""
+    with pytest.raises(ValidationError) as exc_info:
+        MockRequestParams.model_validate({})
+
+    request = SimpleNamespace(query_params={})
+    response = asyncio.run(ExceptionHandlers.validation(request, exc_info.value))
+
+    assert response.status_code == 500

--- a/openbb_platform/core/tests/api/test_exception_handlers.py
+++ b/openbb_platform/core/tests/api/test_exception_handlers.py
@@ -2,7 +2,6 @@
 
 import asyncio
 import json
-from types import SimpleNamespace
 
 import pytest
 from fastapi.exceptions import ResponseValidationError
@@ -22,6 +21,18 @@ class MockRequestParams(BaseModel):
     value: str
 
 
+class MockRequest:
+    """Minimal request double with query parameters and an optional body."""
+
+    def __init__(self, body: bytes = b""):
+        self.query_params = {}
+        self._body = body
+
+    async def body(self) -> bytes:
+        """Return the configured request body."""
+        return self._body
+
+
 def get_response_detail(response):
     """Return the JSON response detail."""
     return json.loads(response.body)["detail"]
@@ -32,7 +43,7 @@ def test_validation_missing_query_param_returns_422():
     with pytest.raises(ValidationError) as exc_info:
         MockQueryParams.model_validate({})
 
-    request = SimpleNamespace(query_params={})
+    request = MockRequest()
     response = asyncio.run(ExceptionHandlers.validation(request, exc_info.value))
 
     assert response.status_code == 422
@@ -52,7 +63,7 @@ def test_validation_response_error_returns_422():
             }
         ]
     )
-    request = SimpleNamespace(query_params={})
+    request = MockRequest()
 
     response = asyncio.run(ExceptionHandlers.validation(request, error))
 
@@ -66,7 +77,17 @@ def test_validation_non_query_params_error_returns_500():
     with pytest.raises(ValidationError) as exc_info:
         MockRequestParams.model_validate({})
 
-    request = SimpleNamespace(query_params={})
+    request = MockRequest(body=b"{}")
     response = asyncio.run(ExceptionHandlers.validation(request, exc_info.value))
+
+    assert response.status_code == 500
+
+
+def test_validation_query_params_model_bound_to_body_is_not_query_scoped():
+    """Do not relabel body-bound QueryParams errors as query parameters."""
+    with pytest.raises(ValidationError) as exc_info:
+        MockQueryParams.model_validate({})
+
+    response = asyncio.run(ExceptionHandlers.validation(MockRequest(body=b"{}"), exc_info.value))
 
     assert response.status_code == 500


### PR DESCRIPTION
## Description

- Summary of the change/ bug fix.
  - When a fetcher raises a pydantic ValidationError for a QueryParams model and a required field is absent from the request query string, the API now returns HTTP 422 with query-scoped detail locations instead of HTTP 500 Unexpected Error.
- Link #7629
- Relevant motivation and context.
  - Missing required query fields never appear in request.query_params, so the previous all_in_query gate fell through to the generic 500 path. That mismatched FastAPI-layer 422 behavior for the same class of client error (e.g. bls_search without category).
- List any dependencies that are required for this change.
  - None.

## How has this been tested?

- Unit tests for ExceptionHandlers.validation covering:
  - Missing QueryParams field not present in query_params -> 422 with loc starting with query
  - ResponseValidationError still 422
  - Non-QueryParams ValidationError still 500
- Command:
  - PYTHONPATH=openbb_platform/core pytest openbb_platform/core/tests/api/test_exception_handlers.py
  - Result: 3 passed
- Ensure all unit and integration tests pass.
  - Focused unit tests pass locally; full suite left to CI.

## Checklist

- I have performed a self-review of my own code.
- I have commented my code, particularly in hard-to-understand areas.
- I have adhered to the GitFlow naming convention and my branch name is in the format of feature/feature-name or hotfix/hotfix-name.
- I ensure that I am following the CONTRIBUTING guidelines.
  - (If applicable) I have updated tests following these guidelines.
