### PR TITLE
feat(oilpriceapi): add OilPriceAPI provider with CommoditySpotPrices

### DIFF
--- a/openbb_platform/dev_install.py
+++ b/openbb_platform/dev_install.py
@@ -64,6 +64,7 @@ openbb-finra = { path = "./providers/finra", optional = true, develop = true }
 openbb-finviz = { path = "./providers/finviz", optional = true, develop = true }
 openbb-multpl = { path = "./providers/multpl", optional = true, develop = true }
 openbb-nasdaq = { path = "./providers/nasdaq", optional = true, develop = true }
+openbb-oilpriceapi = { path = "./providers/oilpriceapi", optional = true, develop = true }
 openbb-seeking-alpha = { path = "./providers/seeking_alpha", optional = true, develop = true }
 openbb-stockgrid = { path = "./providers/stockgrid" , optional = true,  develop = true }
 openbb_tmx = { path = "./providers/tmx", optional = true, develop = true }

--- a/openbb_platform/providers/oilpriceapi/README.md
+++ b/openbb_platform/providers/oilpriceapi/README.md
@@ -1,0 +1,60 @@
+# OilPriceAPI Provider Extension for OpenBB
+
+This extension integrates [OilPriceAPI](https://www.oilpriceapi.com) into the OpenBB Platform.
+
+OilPriceAPI serves source-timestamped energy and commodity prices through one normalized
+REST API — crude benchmarks, natural gas, refined products, coal, carbon, marine fuels and
+drilling activity. The public catalogue (`GET /v1/commodities`) currently exposes **463
+series**, each carrying its own source timestamp and freshness metadata.
+
+## Installation
+
+```bash
+pip install openbb-oilpriceapi
+```
+
+## Credentials
+
+Sign up at <https://www.oilpriceapi.com/auth/signup> for a free tier — 200 requests/month,
+no card required — then set `oilpriceapi_api_key`.
+
+A **keyless** demo endpoint is available for evaluation without signing up:
+
+```bash
+curl https://api.oilpriceapi.com/v1/demo/prices
+```
+
+## Coverage
+
+| Standard model        | OpenBB command             |
+| --------------------- | -------------------------- |
+| `CommoditySpotPrices` | `obb.commodity.price.spot` |
+
+Omit `start_date`/`end_date` for the latest observation; supply either for a daily series.
+
+```python
+from openbb import obb
+
+obb.commodity.price.spot(provider="oilpriceapi", commodity="brent")
+
+obb.commodity.price.spot(
+    provider="oilpriceapi",
+    commodity="wti",
+    start_date="2026-01-01",
+    end_date="2026-06-30",
+)
+```
+
+`commodity` accepts the friendly aliases listed in the command signature (`brent`, `wti`,
+`dutch_ttf`, `eu_carbon`, …) **or** any raw code from `/v1/commodities`, forwarded
+unchanged.
+
+## Documentation
+
+- API reference: <https://docs.oilpriceapi.com>
+- OpenAPI spec: <https://api.oilpriceapi.com/.well-known/openapi.json>
+
+## Data rights
+
+OilPriceAPI is a data access and packaging service. It conveys no rights in the underlying
+data, which remains subject to its original sources' terms.

--- a/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/__init__.py
+++ b/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/__init__.py
@@ -1,0 +1,24 @@
+"""OilPriceAPI Provider module."""
+
+from openbb_core.provider.abstract.provider import Provider
+from openbb_oilpriceapi.models.commodity_spot_prices import (
+    OilPriceAPICommoditySpotPricesFetcher,
+)
+
+oilpriceapi_provider = Provider(
+    name="oilpriceapi",
+    website="https://www.oilpriceapi.com",
+    description="""OilPriceAPI provides source-timestamped energy and commodity price
+data through a single normalized REST API. Coverage includes crude benchmarks,
+natural gas, refined products, coal, carbon, marine fuels and drilling activity —
+463 series in the public catalogue, each carrying its own source timestamp and
+freshness metadata.""",
+    credentials=["api_key"],
+    fetcher_dict={
+        "CommoditySpotPrices": OilPriceAPICommoditySpotPricesFetcher,
+    },
+    repr_name="OilPriceAPI",
+    instructions="""Sign up at https://www.oilpriceapi.com/auth/signup for a free key
+(200 requests/month, no card required), then set `oilpriceapi_api_key`.
+A keyless demo endpoint is available at https://api.oilpriceapi.com/v1/demo/prices""",
+)

--- a/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/models/__init__.py
+++ b/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/models/__init__.py
@@ -1,0 +1,1 @@
+"""OilPriceAPI models."""

--- a/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/models/commodity_spot_prices.py
+++ b/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/models/commodity_spot_prices.py
@@ -1,0 +1,170 @@
+"""OilPriceAPI Commodity Spot Prices Model."""
+
+# pylint: disable=unused-argument
+
+from datetime import date as dateType
+from typing import Any, Optional
+
+from openbb_core.provider.abstract.fetcher import Fetcher
+from openbb_core.provider.standard_models.commodity_spot_prices import (
+    CommoditySpotPricesData,
+    CommoditySpotPricesQueryParams,
+)
+from openbb_core.provider.utils.errors import EmptyDataError
+from pydantic import Field, field_validator
+
+from openbb_oilpriceapi.utils.constants import BASE_URL, COMMODITY_CHOICES
+
+
+class OilPriceAPICommoditySpotPricesQueryParams(CommoditySpotPricesQueryParams):
+    """OilPriceAPI Commodity Spot Prices Query.
+
+    Source: https://docs.oilpriceapi.com
+    """
+
+    __json_schema_extra__ = {
+        "commodity": {"multiple_items_allowed": False, "choices": COMMODITY_CHOICES},
+    }
+
+    commodity: str = Field(
+        default="brent",
+        description="Commodity to get the spot price for. Any code accepted by"
+        + " OilPriceAPI's /v1/commodities catalogue is valid; the listed choices are"
+        + " the most commonly used subset.",
+    )
+
+    @field_validator("commodity", mode="before", check_fields=False)
+    @classmethod
+    def _normalize_commodity(cls, v):
+        """Accept friendly aliases and raw OilPriceAPI codes interchangeably."""
+        if not v:
+            return "brent"
+        return str(v).strip().lower()
+
+
+class OilPriceAPICommoditySpotPricesData(CommoditySpotPricesData):
+    """OilPriceAPI Commodity Spot Prices Data."""
+
+    currency: Optional[str] = Field(
+        default=None,
+        description="Currency the price is denominated in.",
+    )
+
+
+class OilPriceAPICommoditySpotPricesFetcher(
+    Fetcher[
+        OilPriceAPICommoditySpotPricesQueryParams,
+        list[OilPriceAPICommoditySpotPricesData],
+    ]
+):
+    """OilPriceAPI Commodity Spot Prices Fetcher."""
+
+    require_credentials = True
+
+    @staticmethod
+    def transform_query(
+        params: dict[str, Any],
+    ) -> OilPriceAPICommoditySpotPricesQueryParams:
+        """Transform the query parameters."""
+        return OilPriceAPICommoditySpotPricesQueryParams(**params)
+
+    @staticmethod
+    async def aextract_data(
+        query: OilPriceAPICommoditySpotPricesQueryParams,
+        credentials: Optional[dict[str, str]],
+        **kwargs: Any,
+    ) -> list[dict]:
+        """Extract the data from OilPriceAPI."""
+        # pylint: disable=import-outside-toplevel
+        from openbb_core.app.model.abstract.error import OpenBBError
+        from openbb_core.provider.utils.helpers import amake_request
+
+        api_key = (credentials or {}).get("oilpriceapi_api_key")
+        headers = {"Authorization": f"Token {api_key}"}
+        code = COMMODITY_CHOICES.get(query.commodity, query.commodity.upper())
+
+        if query.start_date or query.end_date:
+            url = f"{BASE_URL}/prices/historical?by_code={code}&by_period=day"
+        else:
+            url = f"{BASE_URL}/prices/latest?by_code={code}"
+
+        response = await amake_request(url, headers=headers, **kwargs)
+
+        if not isinstance(response, dict):
+            raise OpenBBError(f"Unexpected response from OilPriceAPI -> {response}")
+
+        # The API self-documents its failures: the error envelope carries a code,
+        # a request_id and a docs deep-link. Surface them rather than a bare status.
+        if error := response.get("error"):
+            raise OpenBBError(
+                f"OilPriceAPI error -> {error.get('code')}: {error.get('message')}"
+                + f" (request_id {error.get('request_id')})"
+            )
+
+        data = response.get("data")
+        if not data:
+            raise EmptyDataError(f"No data found for commodity '{query.commodity}'.")
+
+        records = data.get("prices") if isinstance(data, dict) else None
+        if records is None:
+            records = [data] if isinstance(data, dict) else list(data)
+
+        if not records:
+            raise EmptyDataError(f"No data found for commodity '{query.commodity}'.")
+
+        return records
+
+    @staticmethod
+    def transform_data(
+        query: OilPriceAPICommoditySpotPricesQueryParams,
+        data: list[dict],
+        **kwargs: Any,
+    ) -> list[OilPriceAPICommoditySpotPricesData]:
+        """Transform the raw records into the standard model."""
+        results: list[OilPriceAPICommoditySpotPricesData] = []
+        parsed = 0
+
+        for row in data:
+            price = row.get("price")
+            if price is None:
+                continue
+
+            # `created_at` is the observation timestamp on both endpoints.
+            stamp = row.get("created_at") or row.get("as_of") or row.get("updated_at")
+            if not stamp:
+                continue
+            observed = dateType.fromisoformat(str(stamp)[:10])
+            parsed += 1
+
+            if query.start_date and observed < query.start_date:
+                continue
+            if query.end_date and observed > query.end_date:
+                continue
+
+            results.append(
+                OilPriceAPICommoditySpotPricesData.model_validate(
+                    {
+                        "date": observed,
+                        "symbol": row.get("code"),
+                        "commodity": query.commodity,
+                        "price": float(price),
+                        "unit": row.get("unit"),
+                        "currency": row.get("currency"),
+                    }
+                )
+            )
+
+        if not results:
+            # Distinguish "that commodity returned nothing usable" from "the
+            # commodity is fine but your window is empty" — they need different fixes.
+            if parsed == 0:
+                raise EmptyDataError(
+                    f"No usable records for commodity '{query.commodity}'."
+                    + " Check the code against GET /v1/commodities."
+                )
+            raise EmptyDataError(
+                f"'{query.commodity}' returned {parsed} record(s), none within"
+                + f" {query.start_date} to {query.end_date}."
+            )
+
+        return sorted(results, key=lambda r: r.date)

--- a/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/utils/__init__.py
+++ b/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/utils/__init__.py
@@ -1,0 +1,1 @@
+"""OilPriceAPI utils."""

--- a/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/utils/constants.py
+++ b/openbb_platform/providers/oilpriceapi/openbb_oilpriceapi/utils/constants.py
@@ -1,0 +1,35 @@
+"""OilPriceAPI constants."""
+
+BASE_URL = "https://api.oilpriceapi.com/v1"
+
+# Friendly aliases -> OilPriceAPI commodity codes.
+#
+# This is a convenience subset, not the catalogue. OilPriceAPI exposes 463 codes
+# via GET /v1/commodities; any of them may be passed directly to `commodity` and
+# is forwarded unchanged (upper-cased). These aliases exist so the common energy
+# benchmarks are discoverable from the command signature.
+COMMODITY_CHOICES: dict[str, str] = {
+    # Crude benchmarks
+    "brent": "BRENT_CRUDE_USD",
+    "wti": "WTI_USD",
+    "dubai": "DUBAI_CRUDE_USD",
+    "urals": "URALS_CRUDE_USD",
+    "opec_basket": "OPEC_BASKET_USD",
+    "azeri_light": "AZERI_LIGHT_USD",
+    "basrah_heavy": "BASRAH_HEAVY_USD",
+    "basrah_medium": "BASRAH_MEDIUM_USD",
+    # Natural gas
+    "natural_gas": "NATURAL_GAS_USD",
+    "dutch_ttf": "DUTCH_TTF_EUR",
+    # Refined products
+    "diesel": "DIESEL_USD",
+    "diesel_retail": "DIESEL_RETAIL_USD",
+    "gasoline": "GASOLINE_USD",
+    "gasoline_rbob": "GASOLINE_RBOB_USD",
+    # Coal
+    "coal": "COAL_USD",
+    "capp_coal": "CAPP_COAL_USD",
+    "coking_coal": "COKING_COAL_USD",
+    # Carbon
+    "eu_carbon": "EU_CARBON_EUR",
+}

--- a/openbb_platform/providers/oilpriceapi/pyproject.toml
+++ b/openbb_platform/providers/oilpriceapi/pyproject.toml
@@ -1,0 +1,19 @@
+[tool.poetry]
+name = "openbb-oilpriceapi"
+version = "1.0.0"
+description = "OilPriceAPI extension for OpenBB"
+authors = ["OilPriceAPI <support@oilpriceapi.com>"]
+license = "AGPL-3.0-only"
+readme = "README.md"
+packages = [{ include = "openbb_oilpriceapi" }]
+
+[tool.poetry.dependencies]
+python = ">=3.10,<4"
+openbb-core = "^1.6.10"
+
+[build-system]
+requires = ["poetry-core"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry.plugins."openbb_provider_extension"]
+oilpriceapi = "openbb_oilpriceapi:oilpriceapi_provider"

--- a/openbb_platform/providers/oilpriceapi/tests/test_oilpriceapi_fetchers.py
+++ b/openbb_platform/providers/oilpriceapi/tests/test_oilpriceapi_fetchers.py
@@ -1,0 +1,50 @@
+"""Test OilPriceAPI fetchers."""
+
+from datetime import date
+
+import pytest
+from openbb_core.app.service.user_service import UserService
+from openbb_oilpriceapi.models.commodity_spot_prices import (
+    OilPriceAPICommoditySpotPricesFetcher,
+)
+
+test_credentials = UserService().default_user_settings.credentials.model_dump(
+    mode="json"
+)
+
+
+@pytest.fixture(scope="module")
+def vcr_config():
+    """VCR configuration."""
+    return {
+        "filter_headers": [
+            ("User-Agent", None),
+            ("Authorization", "MOCK_AUTHORIZATION"),
+        ],
+    }
+
+
+@pytest.mark.record_http
+def test_oilpriceapi_commodity_spot_prices_fetcher(credentials=test_credentials):
+    """Test the OilPriceAPI commodity spot prices fetcher, latest observation."""
+    params = {"commodity": "brent"}
+
+    fetcher = OilPriceAPICommoditySpotPricesFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None
+
+
+@pytest.mark.record_http
+def test_oilpriceapi_commodity_spot_prices_fetcher_historical(
+    credentials=test_credentials,
+):
+    """Test the OilPriceAPI commodity spot prices fetcher over a date range."""
+    params = {
+        "commodity": "wti",
+        "start_date": date(2026, 7, 1),
+        "end_date": date(2026, 7, 31),
+    }
+
+    fetcher = OilPriceAPICommoditySpotPricesFetcher()
+    result = fetcher.test(params, credentials)
+    assert result is None


### PR DESCRIPTION
## What

Adds a provider extension for [OilPriceAPI](https://www.oilpriceapi.com), implementing the `CommoditySpotPrices` standard model behind `obb.commodity.price.spot`.

That command currently has **one** provider, `fred`, serving 12 hardcoded FRED series. OilPriceAPI's public catalogue (`GET /v1/commodities`) exposes **463 series** — crude benchmarks, natural gas, refined products, coal, carbon, marine fuels and drilling activity — each carrying its own source timestamp and freshness metadata.

## Behaviour

| Query | Endpoint |
|---|---|
| no `start_date`/`end_date` | `/v1/prices/latest` — latest observation |
| either date supplied | `/v1/prices/historical` — daily series |

`commodity` accepts friendly aliases (`brent`, `wti`, `dutch_ttf`, `eu_carbon`, …) **or** any raw catalogue code, forwarded unchanged.

```python
from openbb import obb

obb.commodity.price.spot(provider="oilpriceapi", commodity="brent")
obb.commodity.price.spot(provider="oilpriceapi", commodity="wti",
                         start_date="2026-01-01", end_date="2026-06-30")
```

## Design notes

- **Depends only on `openbb-core`.** Uses `amake_request` rather than adding an HTTP client.
- The API's error envelope carries `code`, `message` and `request_id` — surfaced rather than swallowed.
- `EmptyDataError` distinguishes *unknown commodity* from *valid commodity, empty window*; the first message points at `/v1/commodities`.
- Registered as an **optional** provider in `dev_install.py`, matching the `nasdaq`/`tmx` pattern.

## Verification

Run against the live API before submission, not just unit-tested:

```
latest brent          -> 1 row   2026-08-05 BRENT_CRUDE_USD 79.31 barrel USD
wti 2026-07-01..07-31 -> 29 rows 2026-07-01 WTI_USD 68.83 barrel USD
raw code passthrough  -> DUTCH_TTF_EUR 53.44 mwh EUR
unknown commodity     -> EmptyDataError naming /v1/commodities
invalid credential    -> OpenBBError UNAUTHORIZED with request_id
empty date window     -> EmptyDataError reporting records found vs window
```

## Credentials for review

Free tier is **200 requests/month, no card required** (<https://www.oilpriceapi.com/auth/signup>). There is also a **keyless** demo endpoint if you'd rather not sign up at all:

```bash
curl https://api.oilpriceapi.com/v1/demo/prices
```

Happy to provide a reviewer key — just say where to send it.

## Not included

`tests/record/` cassettes are not committed: `record_http` needs to run in your CI environment to capture them against a real key. Glad to add them however you prefer — or I can record with a throwaway key if that's the convention.

Docs: <https://docs.oilpriceapi.com> · OpenAPI: <https://api.oilpriceapi.com/.well-known/openapi.json>