### PR TITLE
[Hotfix] - Fix SEC statement normalization

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/statement_schema/_imputation.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/statement_schema/_imputation.py
@@ -166,6 +166,15 @@ def _apply_hierarchical_articulation(
             children_detail = " + ".join(contributing_children)
 
             if p_val is None:
+                # Operating income cannot be inferred from a lone revenue or
+                # expense row. Without both sides of the operating equation,
+                # a rollup would manufacture a misleading 100% margin (or its
+                # expense-only equivalent).
+                if (
+                    parent_tag == "total_operating_income"
+                    and len(contributing_children) < 2
+                ):
+                    continue
                 parent_row.values[date] = children_sum
                 parent_row.sources[date] = f"imputed-rollup: {children_detail}"
             else:

--- a/openbb_platform/providers/sec/openbb_sec/utils/statement_schema/schemas/balance_sheet.json
+++ b/openbb_platform/providers/sec/openbb_sec/utils/statement_schema/schemas/balance_sheet.json
@@ -1082,6 +1082,14 @@
           "namespace": "us-gaap"
         },
         {
+          "tag": "NotesAndLoansPayable",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "OtherShortTermBorrowings",
+          "namespace": "us-gaap"
+        },
+        {
           "tag": "ShorttermBorrowings",
           "namespace": "ifrs-full"
         },
@@ -1122,6 +1130,18 @@
         },
         {
           "tag": "CurrentPortionOfLongTermDebt",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtAndCapitalLeaseObligationsCurrent",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtCurrentMaturities",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "DebtCurrent",
           "namespace": "us-gaap"
         },
         {
@@ -3627,6 +3647,14 @@
         {
           "tag": "ShortTermDebtCurrent",
           "namespace": "us-gaap"
+        },
+        {
+          "tag": "NotesAndLoansPayable",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "OtherShortTermBorrowings",
+          "namespace": "us-gaap"
         }
       ]
     },
@@ -3649,6 +3677,18 @@
         },
         {
           "tag": "CurrentPortionOfLongTermDebt",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtAndCapitalLeaseObligationsCurrent",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtCurrentMaturities",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "DebtCurrent",
           "namespace": "us-gaap"
         }
       ]
@@ -3757,12 +3797,6 @@
       "unit": "monetary",
       "period_type": "instant",
       "xbrl_tags": [
-        {
-          "tag": "OtherShortTermBorrowings",
-          "namespace": "us-gaap",
-          "first_year": 2011,
-          "last_year": 2026
-        },
         {
           "tag": "OtherLiabilitiesCurrent",
           "namespace": "us-gaap",
@@ -5871,6 +5905,14 @@
           "namespace": "us-gaap"
         },
         {
+          "tag": "NotesAndLoansPayable",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "OtherShortTermBorrowings",
+          "namespace": "us-gaap"
+        },
+        {
           "tag": "ShorttermBorrowings",
           "namespace": "ifrs-full"
         },
@@ -5911,6 +5953,18 @@
         },
         {
           "tag": "CurrentPortionOfLongTermDebt",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtAndCapitalLeaseObligationsCurrent",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtCurrentMaturities",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "DebtCurrent",
           "namespace": "us-gaap"
         },
         {
@@ -8342,6 +8396,14 @@
           "namespace": "us-gaap"
         },
         {
+          "tag": "NotesAndLoansPayable",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "OtherShortTermBorrowings",
+          "namespace": "us-gaap"
+        },
+        {
           "tag": "ShorttermBorrowings",
           "namespace": "ifrs-full"
         },
@@ -8370,6 +8432,18 @@
         },
         {
           "tag": "CurrentPortionOfLongTermDebt",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtAndCapitalLeaseObligationsCurrent",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "LongTermDebtCurrentMaturities",
+          "namespace": "us-gaap"
+        },
+        {
+          "tag": "DebtCurrent",
           "namespace": "us-gaap"
         }
       ]
@@ -8486,12 +8560,6 @@
       "unit": "monetary",
       "period_type": "instant",
       "xbrl_tags": [
-        {
-          "tag": "OtherShortTermBorrowings",
-          "namespace": "us-gaap",
-          "first_year": 2011,
-          "last_year": 2026
-        },
         {
           "tag": "OtherLiabilitiesCurrent",
           "namespace": "us-gaap",

--- a/openbb_platform/providers/sec/tests/test_company_facts.py
+++ b/openbb_platform/providers/sec/tests/test_company_facts.py
@@ -14,6 +14,10 @@ import openbb_sec.utils.company_facts as cf
 from openbb_sec.utils.company_facts import resolve_company_facts
 from openbb_sec.utils.statement_schema import StatementSchema
 from openbb_sec.utils.statement_schema._detection import get_filing_dates
+from openbb_sec.utils.statement_schema._imputation import (
+    _apply_hierarchical_articulation,
+)
+from openbb_sec.utils.statement_schema._types import RowResult
 
 _FIXTURE_DIR = Path(__file__).parent / "record"
 
@@ -122,6 +126,70 @@ def test_company_type_detection(schema):
         [{"tag": "CostsAndExpenses", "val": 100, "end": "2023-12-31"}]
     )
     assert schema.detect_type(diversified["facts"]) == "diversified"
+
+
+@pytest.mark.parametrize(
+    "profile", ["industrial", "financial", "diversified", "insurance"]
+)
+def test_current_debt_tag_mappings(schema, profile):
+    """Common current-debt spellings map consistently across profiles."""
+    rows = schema._statements["balance_sheet"][profile]  # pylint: disable=W0212
+    tags_by_row = {
+        row["tag"]: {item["tag"] for item in row["xbrl_tags"]} for row in rows
+    }
+
+    assert {"NotesAndLoansPayable", "OtherShortTermBorrowings"} <= tags_by_row[
+        "short_term_debt"
+    ]
+    assert {
+        "LongTermDebtAndCapitalLeaseObligationsCurrent",
+        "LongTermDebtCurrentMaturities",
+        "DebtCurrent",
+    } <= tags_by_row["current_portion_of_long_term_debt"]
+
+    for row in rows:
+        if row["tag"] != "short_term_debt":
+            assert "OtherShortTermBorrowings" not in {
+                item["tag"] for item in row["xbrl_tags"]
+            }
+
+
+def test_operating_income_not_rolled_up_from_single_child():
+    """A lone revenue row must not imply a 100% operating margin."""
+    date = "2025-12-31"
+    rows = [
+        RowResult(
+            tag="total_revenue",
+            label="Total Revenue",
+            description="",
+            parent="total_operating_income",
+            sequence=1,
+            factor="+",
+            balance="credit",
+            unit="monetary",
+            period_type="duration",
+            values={date: 1000.0},
+            sources={date: "us-gaap:Revenues"},
+        ),
+        RowResult(
+            tag="total_operating_income",
+            label="Total Operating Income",
+            description="",
+            parent=None,
+            sequence=2,
+            factor="+",
+            balance="credit",
+            unit="monetary",
+            period_type="duration",
+            values={},
+            sources={},
+        ),
+    ]
+
+    _apply_hierarchical_articulation(rows, {date})
+
+    assert date not in rows[1].values
+    assert date not in rows[1].sources
 
 
 def test_basic_extraction_and_imputation():


### PR DESCRIPTION
## Why?

Fixes #7634. SEC standardized statements were missing several current-debt XBRL spellings, and the hierarchical rollup could infer operating income from revenue alone, producing a misleading 100% operating margin.

## What?

- Maps `NotesAndLoansPayable` and `OtherShortTermBorrowings` to short-term debt across all statement profiles.
- Maps three current-maturity debt tags to current portion of long-term debt across all profiles.
- Removes the duplicate generic-payables mapping for `OtherShortTermBorrowings` where present.
- Prevents operating income rollup unless at least two contributing children are available.
- Adds focused schema and imputation regression tests.

## Impact

Current debt is classified consistently across industrial, financial, diversified, and insurance statements. Missing operating expenses no longer cause revenue to be presented as operating income.

## Testing Done

- `pytest -q openbb_platform/providers/sec/tests/test_company_facts.py -k 'current_debt_tag_mappings or operating_income_not_rolled_up_from_single_child' --tb=short --disable-warnings` (5 passed)
- `pytest -q openbb_platform/providers/sec/tests/test_company_facts.py -k 'TestBLKIncomeStatement' --tb=short --disable-warnings` (15 passed)
- `git diff --check`
- JSON syntax validation with `jq empty`

## Reviewer Notes

The operating-income guard is deliberately limited to `total_operating_income`; other parent rows retain the existing generic rollup behavior.
