### PR TITLE
fix(sec): correct Form 4 date filtering and per-row footnote attribution

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/form4.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/form4.py
@@ -235,16 +235,12 @@ async def get_form_4_urls(
     )
     urls: list = []
     for item in form_4:
-        if (
-            (not start_date or not item.filing_date)  # type: ignore
-            or start_date
-            and item.filing_date < start_date  # type: ignore
+        if start_date and (
+            not item.filing_date or item.filing_date < start_date  # type: ignore
         ):
             continue
-        if (
-            (not end_date or not item.report_date)  # type: ignore
-            or end_date
-            and item.report_date > end_date  # type: ignore
+        if end_date and (
+            not item.report_date or item.report_date > end_date  # type: ignore
         ):
             continue
         to_replace = f"{item.primary_doc.split('/')[0]}/"  # type: ignore
@@ -304,6 +300,27 @@ async def get_form_4_data(url) -> dict:
     )  # type: ignore
 
 
+def resolve_footnotes(footnote_ref, footnote_map: dict) -> str | None:
+    """Resolve a `footnoteId` reference to the footnote text for a single row.
+
+    `footnote_ref` is either one `{"@id": "F1"}` mapping or a list of them.
+    Multiple references are joined in document order. Returns None when the
+    filing carries no matching footnote text.
+    """
+    if not footnote_map or not footnote_ref:
+        return None
+
+    refs = footnote_ref if isinstance(footnote_ref, list) else [footnote_ref]
+    texts = [
+        footnote_map.get(ref["@id"], "")
+        for ref in refs
+        if isinstance(ref, dict) and "@id" in ref
+    ]
+    resolved = "; ".join([text for text in texts if text])
+
+    return resolved if resolved else None
+
+
 async def parse_form_4_data(  # noqa: PLR0915, PLR0912  # pylint: disable=too-many-branches
     data,
 ):
@@ -339,12 +356,17 @@ async def parse_form_4_data(  # noqa: PLR0915, PLR0912  # pylint: disable=too-ma
     else:
         signature_date = None
 
-    footnotes = data.get("footnotes", {})
-    if footnotes:
-        footnote_items = footnotes.get("footnote")
+    footnotes_element = data.get("footnotes", {})
+    footnotes: dict = {}
+    if footnotes_element:
+        footnote_items = footnotes_element.get("footnote")
         if isinstance(footnote_items, dict):
             footnote_items = [footnote_items]
-        footnotes = {item["@id"]: item["#text"] for item in footnote_items}
+        footnotes = {
+            item["@id"]: item.get("#text", "")
+            for item in footnote_items or []
+            if isinstance(item, dict) and "@id" in item
+        }
 
     metadata = {
         "filing_date": signature_date or data.get("periodOfReport"),
@@ -387,63 +409,17 @@ async def parse_form_4_data(  # noqa: PLR0915, PLR0912  # pylint: disable=too-ma
                     )
                 elif isinstance(value, dict):
                     if "footnoteId" in value:
-                        if isinstance(value["footnoteId"], list):
-                            ids = [item["@id"] for item in value["footnoteId"]]
-                            footnotes = (
-                                "; ".join(
-                                    [
-                                        footnotes.get(footnote_id, "")
-                                        for footnote_id in ids
-                                    ]
-                                )
-                                if isinstance(footnotes, dict)
-                                else footnotes
-                            )
-                            new_row["footnote"] = footnotes
-                        else:
-                            footnote_id = value["footnoteId"]["@id"]
-                            new_row["footnote"] = (
-                                (
-                                    footnotes
-                                    if isinstance(footnotes, str)
-                                    else footnotes.get(footnote_id)
-                                )
-                                if footnotes
-                                else None
-                            )
+                        new_row["footnote"] = resolve_footnotes(
+                            value["footnoteId"], footnotes
+                        )
                     for k, v in value.items():
                         if k == "value":
                             new_row[key] = v
                         if isinstance(v, dict):
                             if "footnoteId" in v:
-                                if isinstance(v["footnoteId"], list):
-                                    ids = [item["@id"] for item in v["footnoteId"]]
-                                    footnotes = (
-                                        footnotes
-                                        if isinstance(footnotes, str)
-                                        else (
-                                            "; ".join(
-                                                [
-                                                    footnotes.get(footnote_id, "")
-                                                    for footnote_id in ids
-                                                ]
-                                            )
-                                            if footnotes
-                                            else None
-                                        )
-                                    )
-                                    new_row["footnote"] = footnotes
-                                else:
-                                    footnote_id = v["footnoteId"]["@id"]
-                                    new_row["footnote"] = (
-                                        (
-                                            footnotes
-                                            if isinstance(footnotes, str)
-                                            else footnotes.get(footnote_id)
-                                        )
-                                        if footnotes
-                                        else None
-                                    )
+                                new_row["footnote"] = resolve_footnotes(
+                                    v["footnoteId"], footnotes
+                                )
                             for k1, v1 in v.items():
                                 if k1 == "value":
                                     new_row[k] = v1

--- a/openbb_platform/providers/sec/tests/test_form4.py
+++ b/openbb_platform/providers/sec/tests/test_form4.py
@@ -1,0 +1,196 @@
+"""Test the Form 4 parsing utilities."""
+
+# pylint: disable=W0613,W0621
+# flake8: noqa: D102,D103
+
+from datetime import date
+from unittest.mock import patch
+
+import pytest
+from openbb_sec.utils.form4 import (
+    get_form_4_urls,
+    parse_form_4_data,
+    resolve_footnotes,
+)
+
+
+class _Filing:
+    """Stand-in for a SecCompanyFilingsData record."""
+
+    def __init__(self, filing_date, report_date, accession):
+        self.filing_date = filing_date
+        self.report_date = report_date
+        self.primary_doc = f"{accession}/form4_{accession}.xml"
+        self.report_url = (
+            "https://www.sec.gov/Archives/edgar/data/320193/"
+            f"{accession}/form4_{accession}.xml"
+        )
+
+
+FILINGS = [
+    _Filing(date(2026, 1, 15), date(2026, 1, 13), "000123"),
+    _Filing(date(2026, 4, 15), date(2026, 4, 13), "000124"),
+    _Filing(date(2026, 7, 15), date(2026, 7, 13), "000125"),
+]
+
+
+@pytest.fixture
+def mock_filings():
+    """Patch the company-filings fetcher so no network access is required."""
+
+    class _Fetcher:
+        async def fetch_data(self, *args, **kwargs):
+            return FILINGS
+
+    with patch(
+        "openbb_sec.models.company_filings.SecCompanyFilingsFetcher",
+        _Fetcher,
+    ):
+        yield
+
+
+def _accessions(urls):
+    """Recover the accession number from the returned document URLs."""
+    return [
+        url.split("/")[-1].removeprefix("form4_").removesuffix(".xml") for url in urls
+    ]
+
+
+@pytest.mark.asyncio
+@pytest.mark.parametrize(
+    "start_date,end_date,expected",
+    [
+        # Both bounds supplied - the previously working path, unchanged.
+        (date(2026, 3, 1), date(2026, 12, 31), ["000124", "000125"]),
+        # Only a lower bound: filings on or after start_date.
+        (date(2026, 3, 1), None, ["000124", "000125"]),
+        # Only an upper bound: filings on or before end_date.
+        (None, date(2026, 5, 1), ["000123", "000124"]),
+        # No bounds: no filtering at all.
+        (None, None, ["000123", "000124", "000125"]),
+    ],
+)
+async def test_get_form_4_urls_date_bounds(
+    mock_filings, start_date, end_date, expected
+):
+    """An unbounded side must not filter everything out."""
+    urls = await get_form_4_urls(
+        "AAPL", start_date=start_date, end_date=end_date, use_cache=False
+    )
+    assert _accessions(urls) == expected
+
+
+@pytest.mark.asyncio
+async def test_get_form_4_urls_accepts_iso_strings(mock_filings):
+    """Date bounds passed as ISO strings are coerced before comparison."""
+    urls = await get_form_4_urls(
+        "AAPL", start_date="2026-03-01", end_date=None, use_cache=False
+    )
+    assert _accessions(urls) == ["000124", "000125"]
+
+
+FOOTNOTE_MAP = {
+    "F1": "Sale under a Rule 10b5-1 trading plan.",
+    "F2": "Weighted average price.",
+    "F3": "Shares held by a family trust.",
+}
+
+
+@pytest.mark.parametrize(
+    "ref,expected",
+    [
+        ({"@id": "F1"}, "Sale under a Rule 10b5-1 trading plan."),
+        (
+            [{"@id": "F1"}, {"@id": "F2"}],
+            "Sale under a Rule 10b5-1 trading plan.; Weighted average price.",
+        ),
+        ({"@id": "F9"}, None),
+        (None, None),
+    ],
+)
+def test_resolve_footnotes(ref, expected):
+    """Footnote references resolve to text without mutating the map."""
+    assert resolve_footnotes(ref, FOOTNOTE_MAP) == expected
+    assert FOOTNOTE_MAP["F1"] == "Sale under a Rule 10b5-1 trading plan."
+
+
+def test_resolve_footnotes_without_map():
+    """A filing with no footnotes section resolves to None."""
+    assert resolve_footnotes({"@id": "F1"}, {}) is None
+
+
+def _transaction(day, shares, footnote_ids):
+    """Build one nonDerivativeTransaction with the given footnote references."""
+    refs = [{"@id": fid} for fid in footnote_ids]
+    return {
+        "securityTitle": {"value": "Common Stock"},
+        "transactionDate": {"value": f"2026-04-{day}"},
+        "transactionCoding": {"transactionFormType": "4", "transactionCode": "S"},
+        "transactionAmounts": {
+            "transactionShares": {
+                "value": shares,
+                "footnoteId": refs if len(refs) > 1 else refs[0],
+            },
+            "transactionPricePerShare": {"value": "200.00"},
+            "transactionAcquiredDisposedCode": {"value": "D"},
+        },
+    }
+
+
+OWNERSHIP_DOCUMENT = {
+    "documentType": "4",
+    "periodOfReport": "2026-05-01",
+    "issuer": {
+        "issuerCik": "0000320193",
+        "issuerName": "APPLE INC",
+        "issuerTradingSymbol": "AAPL",
+    },
+    "reportingOwner": {
+        "reportingOwnerId": {"rptOwnerCik": "0001214156", "rptOwnerName": "DOE JANE"},
+        "reportingOwnerRelationship": {"isDirector": "1"},
+    },
+    "nonDerivativeTable": {
+        "nonDerivativeTransaction": [
+            _transaction("28", "1000", ["F1", "F2"]),
+            _transaction("29", "2000", ["F3"]),
+            _transaction("30", "500", ["F4"]),
+        ]
+    },
+    "footnotes": {
+        "footnote": [
+            {"@id": "F1", "#text": "Sale under a Rule 10b5-1 trading plan."},
+            {"@id": "F2", "#text": "Weighted average price."},
+            {"@id": "F3", "#text": "Shares held by a family trust."},
+            {"@id": "F4", "#text": "Shares withheld to satisfy tax withholding."},
+        ]
+    },
+}
+
+
+@pytest.mark.asyncio
+async def test_parse_form_4_data_footnotes_are_per_row():
+    """Each transaction keeps its own footnote text."""
+    rows = await parse_form_4_data(OWNERSHIP_DOCUMENT)
+
+    assert len(rows) == 3
+    assert rows[0]["footnote"] == (
+        "Sale under a Rule 10b5-1 trading plan.; Weighted average price."
+    )
+    assert rows[1]["footnote"] == "Shares held by a family trust."
+    assert rows[2]["footnote"] == "Shares withheld to satisfy tax withholding."
+
+
+@pytest.mark.asyncio
+async def test_parse_form_4_data_handles_empty_footnote_element():
+    """A `<footnote id="F1"/>` element with no text does not raise."""
+    document = {
+        **OWNERSHIP_DOCUMENT,
+        "footnotes": {"footnote": {"@id": "F1"}},
+        "nonDerivativeTable": {
+            "nonDerivativeTransaction": [_transaction("28", "1000", ["F1"])]
+        },
+    }
+    rows = await parse_form_4_data(document)
+
+    assert len(rows) == 1
+    assert rows[0]["footnote"] is None


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

Two independent correctness bugs in the SEC Form 4 path behind `equity.ownership.insider_trading`. Both are in `openbb_platform/providers/sec/openbb_sec/utils/form4.py`. No linked issue — found while reading the parser.

### 1. A one-sided date range returns no data

`get_form_4_urls` filtered with:

```python
if (
    (not start_date or not item.filing_date)
    or start_date
    and item.filing_date < start_date
):
    continue
```

`(not start_date or not item.filing_date)` short-circuits to `True` whenever `start_date` is `None`, so the loop `continue`s on every filing and returns an empty list. The `end_date` guard below it has the same shape.

This is normally hidden because `SecInsiderTradingFetcher.transform_query` backfills a 120-day window — but only when **both** bounds are missing:

```python
if not start_date and not end_date:
    params["start_date"] = (datetime.now() - timedelta(days=120)).date()
    params["end_date"] = datetime.now().date()
```

So supplying exactly one bound leaves the other `None`, no URLs come back, and `get_form_4` raises `No Form 4 data was returned for {symbol}`:

```python
from openbb import obb
obb.equity.ownership.insider_trading(symbol="AAPL", start_date="2026-01-01", provider="sec")
# OpenBBError: No Form 4 data was returned for AAPL.
obb.equity.ownership.insider_trading(symbol="AAPL", end_date="2026-05-01", provider="sec")
# OpenBBError: No Form 4 data was returned for AAPL.
```

The guards now test the bound first, so an absent bound simply doesn't filter. The both-bounds path is unchanged.

### 2. Footnote text leaks from one transaction to the next

`parse_form_4_data` builds `footnotes` as an id → text map, then **rebinds that same name to a joined string** inside the per-transaction loop:

```python
footnotes = ("; ".join([footnotes.get(fid, "") for fid in ids]) if isinstance(footnotes, dict) else footnotes)
new_row["footnote"] = footnotes
```

After the first row that carries footnote references, `footnotes` is no longer a dict. The `isinstance(footnotes, str)` branches downstream then hand that same string to every remaining row in the filing. A three-transaction Form 4 whose rows reference F1+F2, F3 and F4 returns:

```
row 1  ->  'Sale under a Rule 10b5-1 trading plan.; Weighted average price.'
row 2  ->  'Sale under a Rule 10b5-1 trading plan.; Weighted average price.'   # should be F3
row 3  ->  'Sale under a Rule 10b5-1 trading plan.; Weighted average price.'   # should be F4
```

Form 4 footnotes carry the qualification that makes a transaction readable — whether a sale was under a Rule 10b5-1 plan, whether shares were withheld for taxes, whether a position is held indirectly through a trust — so attaching the wrong one to a row is misleading rather than merely cosmetic.

Footnote resolution now goes through a small `resolve_footnotes` helper that reads the map without mutating it, replacing four near-duplicate inline blocks. Building the map also tolerates an empty `<footnote id="F1"/>` element, which previously raised `KeyError: '#text'`.

### Notes for the reviewer

- Both bugs are present in `develop` and survive verbatim into `feature/v5-sec` (#7525), so this isn't superseded by the V5 refactor.
- Two things I deliberately left alone: `get_form_4_urls` filters `start_date` against `filing_date` but `end_date` against `report_date`, and the derivative-table branch never resolves footnotes at all. Both look like separate decisions rather than defects — happy to follow up if you'd like either changed.

## How has this been tested?

New `openbb_platform/providers/sec/tests/test_form4.py`, 12 tests, no network access:

- `get_form_4_urls` across both bounds, start-only, end-only and neither, plus ISO-string bounds.
- `resolve_footnotes` for a single reference, multiple references, an unknown id, a missing reference and an absent footnote map — asserting the map is not mutated.
- `parse_form_4_data` end to end on a three-transaction ownership document, asserting each row keeps its own footnote, and on a document with an empty footnote element.

```
pytest openbb_platform/providers/sec/tests/test_form4.py -q
12 passed
```

Full provider suite, `pytest openbb_platform/providers/sec/tests/ -q`: 233 passed, 2 failed. The two failures (`test_sec_sic_search_fetcher`, `test_sec_equity_ftd_fetcher`) reproduce identically on a clean checkout of `develop` and are unrelated to this change.

`ruff check` and `black --check` clean on both files.

- [x] Ensure all unit and integration tests pass.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] I ensure that I am following the CONTRIBUTING guidelines.
