### PR TITLE
fix: reuse SEC Form 4 download session

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/form4.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/form4.py
@@ -266,7 +266,7 @@ def clean_xml(xml_content):
     return xml_content
 
 
-async def get_form_4_data(url) -> dict:
+async def get_form_4_data(url, session=None) -> dict:
     """Get the form 4 data."""
     # pylint: disable=import-outside-toplevel
     from warnings import warn  # noqa
@@ -277,11 +277,13 @@ async def get_form_4_data(url) -> dict:
         """Response callback function."""
         return await response.read()
 
+    session_kwargs = {"session": session} if session is not None else {}
     response = await amake_request(
         url,
         headers=SEC_HEADERS,
         response_callback=response_callback,
         timeout=30,
+        **session_kwargs,
     )  # type: ignore
     response_text = response.decode("utf-8")  # type: ignore
 
@@ -500,6 +502,7 @@ async def download_data(urls, use_cache: bool = True):  # noqa: PLR0915
     import sqlite3
     from numpy import nan
     from openbb_core.app.utils import get_user_cache_directory
+    from openbb_core.provider.utils.helpers import get_async_requests_session
     from pandas import DataFrame
 
     results: list = []
@@ -547,9 +550,9 @@ async def download_data(urls, use_cache: bool = True):  # noqa: PLR0915
         elif use_cache is False:
             non_cached_urls = urls
 
-        async def get_one(url):
+        async def get_one(url, session):
             """Get the data for one URL."""
-            data = await get_form_4_data(url)
+            data = await get_form_4_data(url, session=session)
             result = await parse_form_4_data(data)
             if not result and use_cache is True:
                 df = DataFrame([{"filing_url": url}])
@@ -590,13 +593,16 @@ async def download_data(urls, use_cache: bool = True):  # noqa: PLR0915
             )
 
         if len(non_cached_urls) > 0:
-            async with asyncio.Semaphore(8):
+            session = await get_async_requests_session()
+            try:
                 for url_chunk in [
                     non_cached_urls[i : i + 8]
                     for i in range(0, len(non_cached_urls), 8)
                 ]:
-                    await asyncio.gather(*[get_one(url) for url in url_chunk])
+                    await asyncio.gather(*[get_one(url, session) for url in url_chunk])
                     await asyncio.sleep(1.125)
+            finally:
+                await session.close()
 
         if use_cache is True:
             close_db(conn, db_path)

--- a/openbb_platform/providers/sec/tests/test_form4.py
+++ b/openbb_platform/providers/sec/tests/test_form4.py
@@ -1,0 +1,57 @@
+"""Tests for SEC Form 4 download helpers."""
+
+import asyncio
+
+from openbb_sec.utils import form4
+
+
+def test_download_data_reuses_one_session(monkeypatch):
+    """Reuse one HTTP session across every URL in a download batch."""
+    created_sessions = []
+    request_sessions = []
+
+    class FakeSession:
+        def __init__(self):
+            self.close_calls = 0
+
+        async def close(self):
+            self.close_calls += 1
+
+    async def get_session(**_kwargs):
+        session = FakeSession()
+        created_sessions.append(session)
+        return session
+
+    async def make_request(url, **kwargs):
+        request_sessions.append((url, kwargs.get("session")))
+        return b"<ownershipDocument />"
+
+    async def parse_data(_data):
+        return []
+
+    async def no_sleep(_delay):
+        return None
+
+    monkeypatch.setattr(
+        "openbb_core.provider.utils.helpers.get_async_requests_session", get_session
+    )
+    monkeypatch.setattr(
+        "openbb_core.provider.utils.helpers.amake_request", make_request
+    )
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    monkeypatch.setattr(form4, "parse_form_4_data", parse_data)
+
+    result = asyncio.run(
+        form4.download_data(
+            ["https://example.com/one.xml", "https://example.com/two.xml"],
+            use_cache=False,
+        )
+    )
+
+    assert result == []
+    assert len(created_sessions) == 1
+    assert request_sessions == [
+        ("https://example.com/one.xml", created_sessions[0]),
+        ("https://example.com/two.xml", created_sessions[0]),
+    ]
+    assert created_sessions[0].close_calls == 1


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

- [x] Reuse one `aiohttp` session across every uncached Form 4 filing in a `download_data()` call, and close it in a `finally` block.
- [x] Fixes #7651.
- [ ] Screenshot of the feature or the bug before/after fix, if applicable. Not applicable to this backend-only change.
- [x] Avoid per-request TLS session setup and teardown while preserving the existing eight-request chunking and delay.
- [x] No new dependencies are required.

## How has this been tested?

- `.venv/bin/python -m pytest openbb_platform/providers/sec/tests/test_form4.py -q` — 1 passed. The regression verifies that two filing requests receive the same session and that it is closed exactly once.
- `.venv/bin/python -m pytest openbb_platform/providers/sec/tests/test_form4.py openbb_platform/providers/sec/tests/test_sec_fetchers.py openbb_platform/providers/sec/tests/test_company_facts.py -q` — 147 passed.
- `.venv/bin/ruff check openbb_platform/providers/sec/openbb_sec/utils/form4.py openbb_platform/providers/sec/tests/test_form4.py` — passed.
- `git diff --check` — passed.
- [ ] Ensure all unit and integration tests pass. An initial all-SEC run reached 174 passed before 22 failures and 2 errors from live SEC/FASB TLS EOFs; it was interrupted after 4m14s. After installing the repository test tooling, the recorded SEC fetcher suite passed 23/23.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas. No new explanatory comments were needed for the small control-flow change.
- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] I ensure that I am following the [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBB/blob/develop/openbb_platform/CONTRIBUTING.md).
  - [x] Added a focused regression test for session reuse and cleanup.
