### PR TITLE
feat(standard-models): add SovereignCreditRating and SovereignCdsSpread

### DIFF
--- a/openbb_platform/core/openbb_core/provider/standard_models/sovereign_cds_spread.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/sovereign_cds_spread.py
@@ -1,0 +1,43 @@
+"""Sovereign CDS Spread Standard Model."""
+
+from datetime import date as dateType
+
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.abstract.query_params import QueryParams
+from openbb_core.provider.utils.descriptions import (
+    DATA_DESCRIPTIONS,
+    QUERY_DESCRIPTIONS,
+)
+from pydantic import Field
+
+
+class SovereignCdsSpreadQueryParams(QueryParams):
+    """Sovereign CDS Spread Query."""
+
+    country: str | None = Field(
+        default=None,
+        description=QUERY_DESCRIPTIONS.get("country", "")
+        + " Accepts an ISO-3166 alpha-3 code or a country name.",
+    )
+    as_of_date: dateType | None = Field(
+        default=None,
+        description="Return spreads as of this date rather than the latest available.",
+    )
+
+
+class SovereignCdsSpreadData(Data):
+    """Sovereign CDS Spread Data."""
+
+    date: dateType = Field(description=DATA_DESCRIPTIONS.get("date", ""))
+    country: str = Field(description=DATA_DESCRIPTIONS.get("country", ""))
+    cds_spread: float | None = Field(
+        default=None,
+        description="10-year sovereign CDS spread, as a normalized percent.",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
+    )
+    cds_spread_net_of_benchmark: float | None = Field(
+        default=None,
+        description="CDS spread net of the lowest-risk sovereign benchmark"
+        " (Switzerland in the source dataset), as a normalized percent.",
+        json_schema_extra={"x-unit_measurement": "percent", "x-frontend_multiply": 100},
+    )

--- a/openbb_platform/core/openbb_core/provider/standard_models/sovereign_credit_rating.py
+++ b/openbb_platform/core/openbb_core/provider/standard_models/sovereign_credit_rating.py
@@ -1,0 +1,41 @@
+"""Sovereign Credit Rating Standard Model."""
+
+from datetime import date as dateType
+
+from openbb_core.provider.abstract.data import Data
+from openbb_core.provider.abstract.query_params import QueryParams
+from openbb_core.provider.utils.descriptions import (
+    DATA_DESCRIPTIONS,
+    QUERY_DESCRIPTIONS,
+)
+from pydantic import Field
+
+
+class SovereignCreditRatingQueryParams(QueryParams):
+    """Sovereign Credit Rating Query."""
+
+    country: str | None = Field(
+        default=None,
+        description=QUERY_DESCRIPTIONS.get("country", "")
+        + " Accepts an ISO-3166 alpha-3 code or a country name.",
+    )
+    as_of_date: dateType | None = Field(
+        default=None,
+        description="Return ratings as of this date rather than the latest available.",
+    )
+
+
+class SovereignCreditRatingData(Data):
+    """Sovereign Credit Rating Data."""
+
+    date: dateType = Field(description=DATA_DESCRIPTIONS.get("date", ""))
+    country: str = Field(description=DATA_DESCRIPTIONS.get("country", ""))
+    moodys_rating: str | None = Field(
+        default=None, description="Moody's long-term foreign-currency sovereign rating."
+    )
+    sp_rating: str | None = Field(
+        default=None, description="S&P long-term foreign-currency sovereign rating."
+    )
+    fitch_rating: str | None = Field(
+        default=None, description="Fitch long-term foreign-currency sovereign rating."
+    )


### PR DESCRIPTION
## Description

- Adds two new standard models: `SovereignCreditRating` (Moody's/S&P/Fitch long-term sovereign ratings by country) and `SovereignCdsSpread` (sovereign 10-year CDS spreads, raw and net of a benchmark).
- No existing standard model covers this. `RiskPremium` looked like a candidate but isn't — its `total_equity_risk_premium`/`country_risk_premium` fields are *equity* risk premium by country (Damodaran), a different concept from a government's own credit ratings or the market price of insuring its debt. Confirmed by checking `fetcher_dict` registrations across every installed provider, not just standard-model file existence.
- The underlying data (surfaced to me via an EODHD marketplace feed, source-attributed to Damodaran/NYU Stern) is a public, provider-agnostic dataset — this isn't "give one provider a bespoke model," it's a gap in the standard-models catalog itself.
- Kept as two separate models rather than one combined model, following the existing `PriceTarget`/`PriceTargetConsensus` and `GdpReal`/`GdpNominal` precedent — a provider with only ratings or only CDS data shouldn't need to fake the other.
- Rating fields are `str`, not a closed `Literal`, since the notch alphabet spans three independent agencies (Aaa..C, AAA..D) and isn't fixed the way e.g. `ESGRiskRating`'s A+..F scale is.
- `cds_spread_net_of_benchmark` avoids baking one source's specific benchmark choice (Switzerland, in the dataset I checked) into the field name; the description carries that detail instead.
- **This PR is the standard-model definitions only.** No fetcher/provider implementation is included — I wanted the model shape reviewed on its own merits before building a provider around it. Happy to follow up with a provider fetcher (I maintain an EODHD provider extension) once/if this lands.

## How has this been tested

- Both files pass `py_compile`.
- Both classes were instantiated directly against the real, installed `openbb-core` package (not just parsed) with data shaped like the actual source feed, confirming `QUERY_DESCRIPTIONS`/`DATA_DESCRIPTIONS` keys resolve and both `QueryParams`/`Data` subclasses validate correctly:

  ```
  >>> SovereignCreditRatingData(date="2026-01-01", country="United States", moodys_rating="Aa1", sp_rating="AA+", fitch_rating="AA+")
  date=datetime.date(2026, 1, 1) country='United States' moodys_rating='Aa1' sp_rating='AA+' fitch_rating='AA+'
  >>> SovereignCdsSpreadData(date="2026-01-01", country="United States", cds_spread=0.0044, cds_spread_net_of_benchmark=0.003)
  date=datetime.date(2026, 1, 1) country='United States' cds_spread=0.0044 cds_spread_net_of_benchmark=0.003
  ```

- No fetcher exists yet, so no unit/integration tests apply per the standard fetcher-testing flow — will add them alongside the provider implementation in a follow-up PR if this shape is accepted.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] My branch name follows `feature/feature-name`.
- [x] I am following the CONTRIBUTING guidelines for proposing a new standard model.
- [ ] N/A: no fetcher/provider in this PR, so provider/fetcher test guidelines don't apply yet.

## A process question I'd like to raise alongside this

Feel free to skip this section if it's out of scope for a PR thread — happy to move it to a Discussion if that's a better venue.

CONTRIBUTING.md is clear that "the standard models are created and maintained by the OpenBB team," and that's a reasonable bar for the case it's written for: a new model is normally a meaningful engineering investment, so central review makes sense at low volume. What prompted me to open this PR is that the investment required to reach this point (survey EODHD's full API surface, cross-check every installed provider's `fetcher_dict` for something the data could already back, and confirm `RiskPremium` doesn't fit before drafting a new model to your existing conventions) took one focused session with an AI coding agent, not the multi-day research effort it would have taken by hand a couple of years ago. If proposing a well-formed, precedent-following model gets this cheap for anyone with an API key, the bottleneck shifts from "can someone draft this" to "can the core team review it at whatever volume shows up" — and I don't think that's a bad thing, but it might be worth a lighter-weight lane for it.

One structural note in the framework's own terms: the docs say "we standardize fields that are shared between two or more providers." That's the right bar for a *mature* model, but it can't be the *admission* bar for a new one — no field can be shared between providers until at least one is allowed to register it first. Every standard model in this repo cleared full core-team review while still describing only one provider's data.

A possible middle path: a lighter-weight "provisional" tier for new standard models — reviewed for shape/schema sanity rather than long-term commitment, promotable to full status once a second provider actually adopts it (the framework's own stated bar for standardization). This PR is offered as a real, concrete example to anchor that conversation if it's useful, not as a demand that it happen before this can merge on its own merits.

🤖 Generated with [Claude Code](https://claude.com/claude-code)