### PR TITLE
fix(sec): persist company facts HTTP cache

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
@@ -532,7 +532,7 @@ async def get_standardized_financials(
     period : PeriodType
         Which periods to return.
     use_cache : bool
-        Whether to use in-memory HTTP caching (6-hour TTL).
+        Whether to use persistent HTTP caching (6-hour TTL).
     pit_mode : bool
         If True, skip the 10-K vintage override for quarterly data,
         preserving point-in-time fidelity for backtesting.
@@ -572,12 +572,22 @@ async def get_standardized_financials(
     async def _fetch(cik_str: str) -> dict:
         url = f"https://data.sec.gov/api/xbrl/companyfacts/CIK{cik_str}.json"
         if use_cache:
+            from aiohttp_client_cache import (
+                SQLiteBackend,
+            )  # pylint: disable=import-outside-toplevel
             from aiohttp_client_cache.session import (
                 CachedSession,
             )  # pylint: disable=import-outside-toplevel
+            from openbb_core.app.utils import (
+                get_user_cache_directory,
+            )  # pylint: disable=import-outside-toplevel
 
-            async with CachedSession(expire_after=3600 * 6) as session:
+            cache_dir = f"{get_user_cache_directory()}/http/sec_company_facts"
+            async with CachedSession(
+                cache=SQLiteBackend(cache_dir, expire_after=3600 * 6)
+            ) as session:
                 try:
+                    await session.delete_expired_responses()
                     resp = await amake_request(
                         url, headers=HEADERS, session=session, timeout=300
                     )

--- a/openbb_platform/providers/sec/tests/test_company_facts_cache.py
+++ b/openbb_platform/providers/sec/tests/test_company_facts_cache.py
@@ -1,0 +1,71 @@
+"""Tests for SEC company-facts HTTP caching."""
+
+import pytest
+from openbb_sec.utils import company_facts
+
+
+@pytest.mark.asyncio
+async def test_company_facts_uses_persistent_sqlite_cache(monkeypatch, tmp_path):
+    """Repeated calls should target the same persistent six-hour cache."""
+    import aiohttp_client_cache
+    import aiohttp_client_cache.session as cache_session
+    import openbb_core.app.utils as app_utils
+    import openbb_core.provider.utils.helpers as request_helpers
+
+    backends = []
+    sessions = []
+
+    class FakeBackend:
+        def __init__(self, cache_name, expire_after=None):
+            self.cache_name = cache_name
+            self.expire_after = expire_after
+            backends.append(self)
+
+    class FakeCachedSession:
+        def __init__(self, *, cache=None, expire_after=None):
+            self.cache = cache
+            self.expire_after = expire_after
+            self.deleted_expired = False
+            self.closed = False
+            sessions.append(self)
+
+        async def __aenter__(self):
+            return self
+
+        async def __aexit__(self, exc_type, exc, tb):
+            return False
+
+        async def delete_expired_responses(self):
+            self.deleted_expired = True
+
+        async def close(self):
+            self.closed = True
+
+    async def fake_amake_request(url, **kwargs):
+        assert url.endswith("CIK0000000123.json")
+        assert kwargs["session"] in sessions
+        return {"entityName": "Test Company", "cik": 123, "facts": {}}
+
+    monkeypatch.setattr(aiohttp_client_cache, "SQLiteBackend", FakeBackend)
+    monkeypatch.setattr(cache_session, "CachedSession", FakeCachedSession)
+    monkeypatch.setattr(app_utils, "get_user_cache_directory", lambda: tmp_path)
+    monkeypatch.setattr(request_helpers, "amake_request", fake_amake_request)
+    monkeypatch.setattr(
+        company_facts,
+        "resolve_company_facts",
+        lambda facts_json, **kwargs: facts_json,
+    )
+
+    await company_facts.get_standardized_financials(cik=123, use_cache=True)
+    await company_facts.get_standardized_financials(cik=123, use_cache=True)
+
+    expected_cache = f"{tmp_path}/http/sec_company_facts"
+    assert len(backends) == 2
+    assert [backend.cache_name for backend in backends] == [
+        expected_cache,
+        expected_cache,
+    ]
+    assert all(backend.expire_after == 3600 * 6 for backend in backends)
+    assert all(session.cache in backends for session in sessions)
+    assert all(session.deleted_expired for session in sessions)
+    assert all(session.closed for session in sessions)


### PR DESCRIPTION
Fixes #7655.

get_standardized_financials previously created a fresh default in-memory CachedSession backend per invocation, so repeated income, balance, and cash calls re-downloaded the same SEC companyfacts payload.

This fix uses the existing OpenBB SEC SQLiteBackend pattern at <user-cache>/http/sec_company_facts, keeps the six-hour TTL and use_cache=False behavior, cleans expired responses, and closes sessions.

The focused network-free regression test openbb_platform/providers/sec/tests/test_company_facts_cache.py verifies repeated calls target the same persistent cache path, TTL, backend injection, expired-response cleanup, and session closure.


No new dependencies.