### PR TITLE
fix(sec): serialize Form 4 cache lifecycle

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/form4.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/form4.py
@@ -2,8 +2,11 @@
 
 import logging
 from datetime import date as dateType
+from threading import Lock
 
 from openbb_core.app.model.abstract.error import OpenBBError
+
+_FORM4_CACHE_LOCK = Lock()
 
 SEC_HEADERS: dict[str, str] = {
     "User-Agent": "Jesus Window Washing jesus@stainedglass.com",
@@ -504,9 +507,14 @@ async def download_data(urls, use_cache: bool = True):  # noqa: PLR0915
 
     results: list = []
     non_cached_urls: list = []
+    conn = None
+    db_path = None
+    cache_lock_acquired = False
 
     try:
         if use_cache is True:
+            await asyncio.to_thread(_FORM4_CACHE_LOCK.acquire)
+            cache_lock_acquired = True
             db_dir = f"{get_user_cache_directory()}/sql"
             db_path = f"{db_dir}/sec_form4.db"
             # Decompress the database file
@@ -598,19 +606,26 @@ async def download_data(urls, use_cache: bool = True):  # noqa: PLR0915
                     await asyncio.gather(*[get_one(url) for url in url_chunk])
                     await asyncio.sleep(1.125)
 
-        if use_cache is True:
-            close_db(conn, db_path)
+        if conn is not None and db_path is not None:
+            connection = conn
+            conn = None
+            close_db(connection, db_path)
 
         results = [entry for entry in results if entry.get("filing_date")]
 
         return sorted(results, key=lambda x: x["filing_date"], reverse=True)
 
     except Exception as e:  # pylint: disable=broad-except
-        if use_cache is True:
-            close_db(conn, db_path)
+        if conn is not None and db_path is not None:
+            connection = conn
+            conn = None
+            close_db(connection, db_path)
         raise OpenBBError(
             f"Unexpected error while downloading and processing data -> {e.__class__.__name__}: {e}"
         ) from e
+    finally:
+        if cache_lock_acquired:
+            _FORM4_CACHE_LOCK.release()
 
 
 def get_cached_data(urls, conn):

--- a/openbb_platform/providers/sec/tests/test_form4.py
+++ b/openbb_platform/providers/sec/tests/test_form4.py
@@ -1,0 +1,105 @@
+"""Tests for the SEC Form 4 utilities."""
+
+import asyncio
+import sqlite3
+from unittest.mock import Mock
+
+import pandas
+import pytest
+from openbb_core.app import utils as app_utils
+from openbb_core.app.model.abstract.error import OpenBBError
+from openbb_sec.utils import form4
+
+
+@pytest.mark.asyncio
+async def test_download_data_serializes_cached_calls(monkeypatch, tmp_path):
+    """Cached calls serialize their lifecycle but retain per-URL concurrency."""
+
+    class FakeDataFrame:
+        """Minimal DataFrame replacement for empty parsed filings."""
+
+        def __init__(self, *_args, **_kwargs):
+            pass
+
+        def to_sql(self, *_args, **_kwargs):
+            """Stand in for a cache write."""
+
+    real_sleep = asyncio.sleep
+    active_urls = 0
+    active_groups: dict[str, int] = {}
+    max_active_urls = 0
+    max_active_groups = 0
+
+    async def fake_get_form_4_data(url):
+        nonlocal active_urls, max_active_groups, max_active_urls
+        group = url.split("/")[0]
+        active_urls += 1
+        active_groups[group] = active_groups.get(group, 0) + 1
+        max_active_urls = max(max_active_urls, active_urls)
+        max_active_groups = max(max_active_groups, len(active_groups))
+        try:
+            await real_sleep(0.02)
+        finally:
+            active_urls -= 1
+            active_groups[group] -= 1
+            if active_groups[group] == 0:
+                del active_groups[group]
+        return {}
+
+    async def fake_parse_form_4_data(_data):
+        return []
+
+    async def skip_rate_limit_delay(_delay):
+        await real_sleep(0)
+
+    connections = []
+    close_calls = []
+
+    def fake_connect(_path):
+        connection = object()
+        connections.append(connection)
+        return connection
+
+    monkeypatch.setattr(app_utils, "get_user_cache_directory", lambda: str(tmp_path))
+    monkeypatch.setattr(sqlite3, "connect", fake_connect)
+    monkeypatch.setattr(pandas, "DataFrame", FakeDataFrame)
+    monkeypatch.setattr(form4, "setup_database", lambda _conn: None)
+    monkeypatch.setattr(form4, "get_cached_data", lambda _urls, _conn: [])
+    monkeypatch.setattr(form4, "get_form_4_data", fake_get_form_4_data)
+    monkeypatch.setattr(form4, "parse_form_4_data", fake_parse_form_4_data)
+    monkeypatch.setattr(
+        form4, "close_db", lambda conn, path: close_calls.append((conn, path))
+    )
+    monkeypatch.setattr(asyncio, "sleep", skip_rate_limit_delay)
+
+    results = await asyncio.gather(
+        form4.download_data(["first/1", "first/2"]),
+        form4.download_data(["second/1", "second/2"]),
+    )
+
+    assert results == [[], []]
+    assert len(connections) == 2
+    assert len(close_calls) == 2
+    assert max_active_groups == 1
+    assert max_active_urls == 2
+
+
+@pytest.mark.asyncio
+async def test_download_data_handles_failure_before_connection(monkeypatch, tmp_path):
+    """A cache failure before connect preserves the original error."""
+    db_dir = tmp_path / "sql"
+    db_dir.mkdir()
+    (db_dir / "sec_form4.db.gz").write_bytes(b"corrupt")
+    close_db = Mock()
+
+    def fail_decompression(_db_path):
+        raise OSError("corrupt cache")
+
+    monkeypatch.setattr(app_utils, "get_user_cache_directory", lambda: str(tmp_path))
+    monkeypatch.setattr(form4, "decompress_db", fail_decompression)
+    monkeypatch.setattr(form4, "close_db", close_db)
+
+    with pytest.raises(OpenBBError, match="OSError: corrupt cache"):
+        await form4.download_data([])
+
+    close_db.assert_not_called()


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

- [x] Serialize the complete lifecycle of the shared `sec_form4.db` / `.gz` cache with a process-wide lock.
- [x] Acquire the lock through `asyncio.to_thread` so a waiting cached call does not block the event loop.
- [x] Guard cleanup with initialized connection state so decompression or connection failures preserve the original error.
- [x] Preserve the existing eight-URL concurrent batches and the `use_cache=False` path.
- [x] Fixes #7656.
- [x] Screenshot not applicable; this is a backend concurrency fix.
- [x] No new dependencies are required.

Open PRs #7653 and #7642 touch the same Form 4 utility and test path for separate fixes; neither addresses the shared cache lifecycle.

## How has this been tested?

- `.venv/bin/pytest openbb_platform/providers/sec/tests/test_form4.py -q` — 2 passed.
- `.venv/bin/ruff check --no-fix openbb_platform/providers/sec/openbb_sec/utils/form4.py openbb_platform/providers/sec/tests/test_form4.py` — passed.
- `git diff --check` — passed.
- The concurrency regression verifies cached lifecycles do not overlap while each call retains concurrent per-URL downloads.
- The failure regression verifies an exception before SQLite connection creation is reported without attempting database cleanup.

- [ ] Ensure all unit and integration tests pass.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I have adhered to the GitFlow naming convention and my branch name is in the format of `feature/feature-name` or `hotfix/hotfix-name`.
- [x] I ensure that I am following the [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBB/blob/develop/openbb_platform/CONTRIBUTING.md).
  - [x] I have added focused regression tests for the changed behavior.
