### PR TITLE
[BugFix] `openbb-sec`: Resolve per-share facts tagged only with share-class dimensions

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/models/balance_sheet.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/balance_sheet.py
@@ -665,6 +665,7 @@ class SecBalanceSheetFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="balance_sheet",
         )
         return {
             "result": result,

--- a/openbb_platform/providers/sec/openbb_sec/models/balance_sheet_growth.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/balance_sheet_growth.py
@@ -617,6 +617,7 @@ class SecBalanceSheetGrowthFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="balance_sheet",
         )
         return {"result": result, "statement": "balance_sheet"}
 

--- a/openbb_platform/providers/sec/openbb_sec/models/cash_flow.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/cash_flow.py
@@ -431,6 +431,7 @@ class SecCashFlowStatementFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="cash_flow",
         )
         return {
             "result": result,

--- a/openbb_platform/providers/sec/openbb_sec/models/cash_flow_growth.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/cash_flow_growth.py
@@ -427,6 +427,7 @@ class SecCashFlowStatementGrowthFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="cash_flow",
         )
         return {"result": result, "statement": "cash_flow"}
 

--- a/openbb_platform/providers/sec/openbb_sec/models/income_statement.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/income_statement.py
@@ -596,6 +596,7 @@ class SecIncomeStatementFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="income_statement",
         )
         return {
             "result": result,

--- a/openbb_platform/providers/sec/openbb_sec/models/income_statement_growth.py
+++ b/openbb_platform/providers/sec/openbb_sec/models/income_statement_growth.py
@@ -569,6 +569,7 @@ class SecIncomeStatementGrowthFetcher(
             use_cache=query.use_cache,
             include_preliminary=query.include_preliminary,
             pit_mode=query.pit_mode,
+            statement="income_statement",
         )
         return {"result": result, "statement": "income_statement"}
 

--- a/openbb_platform/providers/sec/openbb_sec/utils/_dimensional_facts.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/_dimensional_facts.py
@@ -1,0 +1,676 @@
+"""Fallback for per-share facts reported only with stock-class dimensions."""
+
+from __future__ import annotations
+
+from decimal import Decimal, InvalidOperation
+from io import BytesIO
+from typing import Any
+from warnings import warn
+
+_PER_SHARE_RULES: dict[str, dict[str, Any]] = {
+    "0000317540": {
+        "default_member": "CommonClassUndefinedMember",
+        "members": {"COKE": "CommonClassUndefinedMember"},
+        "facts": {
+            "EarningsPerShareBasic": {
+                "source_tags": ("us-gaap_EarningsPerShareBasic",),
+                "strategy": "member",
+                "unit": "USD/shares",
+            },
+            "EarningsPerShareDiluted": {
+                "source_tags": ("us-gaap_EarningsPerShareDiluted",),
+                "strategy": "member",
+                "unit": "USD/shares",
+            },
+            "WeightedAverageNumberOfSharesOutstandingBasic": {
+                "source_tags": (
+                    "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic",
+                ),
+                "strategy": "sum_members",
+                "unit": "shares",
+            },
+            # The senior class's diluted count is already an as-converted
+            # figure that includes the junior class, so it must not be summed.
+            "WeightedAverageNumberOfDilutedSharesOutstanding": {
+                "source_tags": (
+                    "us-gaap_WeightedAverageNumberOfDilutedSharesOutstanding",
+                ),
+                "strategy": "member",
+                "unit": "shares",
+            },
+        },
+    },
+    "0001067983": {
+        "default_member": "EquivalentClassAMember",
+        "members": {
+            "BRK-A": "EquivalentClassAMember",
+            "BRK-B": "EquivalentClassBMember",
+        },
+        "facts": {
+            "EarningsPerShareBasic": {
+                "source_tags": ("us-gaap_EarningsPerShareBasic",),
+                "strategy": "member",
+                "unit": "USD/shares",
+            },
+            "WeightedAverageNumberOfSharesOutstandingBasic": {
+                "source_tags": (
+                    "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic",
+                ),
+                "strategy": "member",
+                "unit": "shares",
+            },
+        },
+    },
+    "0000004457": {
+        "default_member": "CommonClassAMember",
+        "members": {
+            "UHAL": "CommonClassAMember",
+            "UHAL-B": "NonvotingCommonStockMember",
+        },
+        "facts": {
+            # U-Haul's face-of-statement basic EPS concept. The EPS note's
+            # Undistributed + Distributed pair cannot be summed blindly: in a
+            # loss period the undistributed component is tagged as a positive
+            # magnitude carrying a negated presentation label, so adding the
+            # dividend overstates the result.
+            "EarningsPerShareBasic": {
+                "source_tags": (
+                    "us-gaap_IncomeLossFromContinuingOperationsPerBasicShare",
+                ),
+                "strategy": "member",
+                "unit": "USD/shares",
+            },
+            # U-Haul files diluted EPS as IncomeLossFromContinuingOperations*,
+            # not EarningsPerShareDiluted; companyfacts carries neither target
+            # tag, so there is nothing to conflict with.
+            "EarningsPerShareDiluted": {
+                "source_tags": (
+                    "us-gaap_IncomeLossFromContinuingOperationsPerDilutedShare",
+                ),
+                "strategy": "member",
+                "unit": "USD/shares",
+            },
+            # U-Haul is a genuine ASC 260 two-class filer whose classes carry
+            # DIFFERENT EPS (only the non-voting class receives the dividend),
+            # so no single (EPS, share count) pair reconciles to consolidated
+            # net income -- that is inherent to the two-class method, not a
+            # defect here. The share count is therefore emitted on the same
+            # company-wide basis SEC itself uses for this issuer's
+            # undimensioned series, which keeps the column continuous; a
+            # per-class count would make it alternate between bases depending
+            # on which periods companyfacts happens to cover.
+            "WeightedAverageNumberOfSharesOutstandingBasic": {
+                "source_tags": (
+                    "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic",
+                ),
+                "strategy": "sum_members",
+                "unit": "shares",
+            },
+            "WeightedAverageNumberOfDilutedSharesOutstanding": {
+                "source_tags": (
+                    "us-gaap_WeightedAverageNumberOfDilutedSharesOutstanding",
+                ),
+                "strategy": "sum_members",
+                "unit": "shares",
+            },
+        },
+    },
+}
+
+
+# SEC archive documents are immutable, so an instance can be cached far longer
+# than the submissions index, which gains a filing each quarter.
+_SUBMISSIONS_CACHE_TTL = 3600 * 6
+_INSTANCE_CACHE_TTL = 3600 * 24 * 30
+
+# A 10-K carries three comparative years, so four filings reach back ~7 years,
+# which closes the history gap the issue reports (COKE 'nothing since FY2019').
+_DEFAULT_ANNUAL_FILINGS = 4
+_DEFAULT_QUARTERLY_FILINGS = 4
+
+
+def _normalize_cik(cik: str | int) -> str:
+    """Return a ten-digit SEC CIK."""
+    return str(cik).lstrip("0").zfill(10)
+
+
+def _normalize_symbol(symbol: str | None) -> str:
+    """Normalize common separators used for share-class tickers."""
+    return (symbol or "").upper().replace(".", "-").replace("/", "-")
+
+
+def _local_name(name: Any) -> str:
+    """Return the local part of an XBRL QName."""
+    return str(name or "").rsplit(":", maxsplit=1)[-1]
+
+
+def discover_equity_classes(
+    instance_facts: dict[str, list[dict[str, Any]]],
+) -> set[str]:
+    """Enumerate common-stock class members from the filing cover page.
+
+    ``dei:EntityCommonStockSharesOutstanding`` is tagged once per class of
+    common stock and never for preferred stock or listed debt, so it is a
+    reliable, issuer-agnostic enumeration of the equity classes.
+    """
+    classes: set[str] = set()
+    for fact in instance_facts.get("dei_EntityCommonStockSharesOutstanding", []):
+        for value in (fact.get("dimensions") or {}).values():
+            member = _local_name(value.get("member"))
+            if member:
+                classes.add(member)
+    return classes
+
+
+_CLASS_TOKEN_NOISE = ("EQUIVALENT", "COMMON", "STOCK", "CLASS", "MEMBER", "CAPITAL")
+
+
+def _class_token(member: str) -> str:
+    """Reduce a class member name to its distinguishing token (A, B, C, ...)."""
+    token = _local_name(member).upper()
+    for word in _CLASS_TOKEN_NOISE:
+        token = token.replace(word, "")
+    return token or _local_name(member).upper()
+
+
+def _align_member(member: str, equity_classes: set[str]) -> str | None:
+    """Match a statement member to a cover-page class by its class token.
+
+    Berkshire tags the cover page with ``CommonClassAMember`` but the income
+    statement with ``brka:EquivalentClassAMember``; both reduce to "A".
+    """
+    token = _class_token(member)
+    matches = [cls for cls in equity_classes if _class_token(cls) == token]
+    return matches[0] if len(matches) == 1 else None
+
+
+def discover_ticker_members(
+    instance_facts: dict[str, list[dict[str, Any]]],
+    equity_classes: set[str],
+) -> dict[str, str]:
+    """Map each listed ticker to its class member using the filing cover page.
+
+    ``dei:TradingSymbol`` is tagged per class on the same axis the issuer uses
+    for that filing, so this self-corrects when an issuer moves a member
+    between axes or renames it between filings (U-Haul tags the voting class
+    as ``CommonStockMember`` in its 10-Qs and ``CommonClassAMember`` in its
+    10-K). Tickers for listed debt are excluded because their members never
+    appear on ``dei:EntityCommonStockSharesOutstanding``.
+    """
+    mapping: dict[str, str] = {}
+    for fact in instance_facts.get("dei_TradingSymbol", []):
+        symbol = _normalize_symbol(str(fact.get("value") or "").strip())
+        dimensions = fact.get("dimensions") or {}
+        members = [
+            _local_name(value.get("member"))
+            for value in dimensions.values()
+            if _local_name(value.get("member")) in equity_classes
+        ]
+        if symbol and len(dimensions) == 1 and len(members) == 1:
+            mapping[symbol] = members[0]
+    return mapping
+
+
+def _sole_member(fact: dict[str, Any]) -> str | None:
+    """Return the member of a fact carrying exactly one dimension.
+
+    A fact with two or more dimensions is an aggregate (U-Haul tags its
+    company-wide total on the class axis AND the equity-components axis) or a
+    segment breakdown, and is never class-scoped.
+    """
+    dimensions = fact.get("dimensions") or {}
+    if len(dimensions) != 1:
+        return None
+    member = _local_name(next(iter(dimensions.values())).get("member"))
+    return member or None
+
+
+def _member_alias(
+    instance_facts: dict[str, list[dict[str, Any]]],
+    tag: str,
+    equity_classes: set[str],
+) -> dict[str, str]:
+    """Map the members this concept uses onto the cover-page equity classes.
+
+    Matching is on the MEMBER, not the axis, because issuers move the same
+    member between ``StatementClassOfStockAxis`` and
+    ``StatementEquityComponentsAxis`` between filings (U-Haul does this every
+    year). When a concept uses an entirely separate vocabulary -- Berkshire
+    reports ``brka:EquivalentClassAMember`` while its cover page says
+    ``us-gaap:CommonClassAMember`` -- the members are aligned by class token,
+    but only if that alignment is unambiguous and total.
+    """
+    used = {
+        member for fact in instance_facts.get(tag, []) if (member := _sole_member(fact))
+    }
+    direct = {member: member for member in used if member in equity_classes}
+    if direct:
+        return direct
+    aligned: dict[str, str] = {}
+    for member in used:
+        match = _align_member(member, equity_classes)
+        if match:
+            aligned[member] = match
+    # Only trust an alias that covers the whole class set one-to-one.
+    if len(aligned) == len(set(aligned.values())) == len(equity_classes):
+        return aligned
+    return {}
+
+
+def _decimal_value(value: Any) -> Decimal | None:
+    """Parse a finite numeric XBRL value."""
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, TypeError, ValueError):
+        return None
+    return parsed if parsed.is_finite() else None
+
+
+def _period_member_values(
+    instance_facts: dict[str, list[dict[str, Any]]],
+    tag: str,
+    equity_classes: set[str],
+) -> dict[tuple[str, str], dict[str, Decimal]]:
+    """Group one XBRL tag by duration period and class member."""
+    output: dict[tuple[str, str], dict[str, Decimal]] = {}
+    alias = _member_alias(instance_facts, tag, equity_classes)
+    for fact in instance_facts.get(tag, []):
+        start = fact.get("start")
+        end = fact.get("end")
+        member = alias.get(_sole_member(fact) or "")
+        value = _decimal_value(fact.get("value"))
+        if not start or not end or member is None or value is None:
+            continue
+        output.setdefault((start, end), {}).setdefault(member, value)
+    return output
+
+
+def _metadata_index(
+    facts_json: dict[str, Any],
+) -> dict[tuple[str, str, str, str], dict]:
+    """Index fiscal metadata already present in companyfacts."""
+    output: dict[tuple[str, str, str, str], dict] = {}
+    for namespace in facts_json.get("facts", {}).values():
+        for tag_data in namespace.values():
+            for entries in tag_data.get("units", {}).values():
+                for entry in entries:
+                    key = (
+                        entry.get("accn", ""),
+                        entry.get("start", ""),
+                        entry.get("end", ""),
+                        entry.get("form", ""),
+                    )
+                    if all(key):
+                        output.setdefault(
+                            key,
+                            {
+                                field: entry[field]
+                                for field in ("fy", "fp", "frame")
+                                if field in entry
+                            },
+                        )
+    return output
+
+
+def _has_company_fact(
+    facts_json: dict[str, Any],
+    tag: str,
+    start: str,
+    end: str,
+    *,
+    accession: str,
+    filed: str,
+) -> bool:
+    """Check whether an equal-or-newer reported value already covers the period.
+
+    Keyed on the accession number, which is the identity of a filing vintage.
+    Keying on ``form`` instead would (a) miss when companyfacts carries the
+    original 10-Q and the fallback parses the 10-Q/A, and (b) let the first
+    vintage processed suppress every later restatement of the same period.
+    Every vintage is appended, exactly as companyfacts itself does, and
+    ``compute_ref_filings`` arbitrates by filing date. The ``filed`` clause
+    keeps the documented invariant that a reported value from an equal-or-later
+    filing always outranks a synthesized one.
+    """
+    tag_data = facts_json.get("facts", {}).get("us-gaap", {}).get(tag, {})
+    return any(
+        entry.get("start") == start
+        and entry.get("end") == end
+        and (entry.get("accn") == accession or str(entry.get("filed", "")) >= filed)
+        for entries in tag_data.get("units", {}).values()
+        for entry in entries
+    )
+
+
+_BASIS_TOLERANCE = Decimal("0.01")
+_SHARE_COUNT_TAG = "WeightedAverageNumberOfSharesOutstandingBasic"
+
+
+def _company_fact_value(
+    facts_json: dict[str, Any], tag: str, start: str, end: str
+) -> Decimal | None:
+    """Return the undimensioned companyfacts value for a period, if any."""
+    tag_data = facts_json.get("facts", {}).get("us-gaap", {}).get(tag, {})
+    for entries in tag_data.get("units", {}).values():
+        for entry in entries:
+            if entry.get("start") == start and entry.get("end") == end:
+                return _decimal_value(entry.get("val"))
+    return None
+
+
+def _basis_conflict(
+    facts_json: dict[str, Any],
+    instance_totals: dict[tuple[str, str], Decimal],
+    start: str,
+    end: str,
+) -> bool:
+    """Detect a share-basis mismatch between this filing and companyfacts.
+
+    companyfacts carries whichever vintage the SEC last published, which for
+    some issuers is the as-filed figure and is never restated.  When a filing
+    reports a materially different share count for the same period, the two are
+    on different bases (a stock split between the vintages), and mixing a value
+    from this filing with the companyfacts figure would produce a row whose
+    EPS and share count disagree by the split ratio.
+    """
+    reported = _company_fact_value(facts_json, _SHARE_COUNT_TAG, start, end)
+    filed = instance_totals.get((start, end))
+    if reported is None or filed is None or not reported or not filed:
+        return False
+    return abs(filed - reported) / reported > _BASIS_TOLERANCE
+
+
+def merge_dimensional_per_share_facts(
+    facts_json: dict[str, Any],
+    instance_facts: dict[str, list[dict[str, Any]]],
+    filing: dict[str, Any],
+    symbol: str | None = None,
+    *,
+    metadata_index: dict[tuple[str, str, str, str], dict] | None = None,
+) -> int:
+    """Merge class-dimensioned instance facts into companyfacts shape.
+
+    Reported facts from an equal-or-later filing always win. The return value
+    is the number of synthesized companyfact entries added.
+    """
+    cik = _normalize_cik(facts_json.get("cik", ""))
+    rule = _PER_SHARE_RULES.get(cik)
+    if rule is None:
+        return 0
+
+    equity_classes = discover_equity_classes(instance_facts)
+    if not equity_classes:
+        return 0
+
+    normalized_symbol = _normalize_symbol(symbol)
+    # Prefer the member this filing itself associates with the ticker; fall back
+    # to the configured map only when the cover page is not class-dimensioned.
+    filing_members = discover_ticker_members(instance_facts, equity_classes)
+    member = filing_members.get(normalized_symbol) or rule["members"].get(
+        normalized_symbol, rule["default_member"]
+    )
+    if member not in equity_classes:
+        member = _align_member(member, equity_classes) or member
+
+    # This filing's own company-wide basic share count per period, used to
+    # detect a split-basis mismatch against companyfacts.
+    instance_totals = {
+        period: sum(values.values(), Decimal(0))
+        for period, values in _period_member_values(
+            instance_facts, f"us-gaap_{_SHARE_COUNT_TAG}", equity_classes
+        ).items()
+        if set(values) == equity_classes
+    }
+
+    metadata = (
+        metadata_index if metadata_index is not None else _metadata_index(facts_json)
+    )
+    accession = filing.get("accessionNumber", "")
+    form = filing.get("form", "")
+    filed = filing.get("filingDate", "")
+    added = 0
+
+    for target_tag, spec in rule["facts"].items():
+        grouped = {
+            tag: _period_member_values(instance_facts, tag, equity_classes)
+            for tag in spec["source_tags"]
+        }
+        periods = {period for values in grouped.values() for period in values}
+
+        for start, end in sorted(periods):
+            if _basis_conflict(facts_json, instance_totals, start, end):
+                continue
+
+            if _has_company_fact(
+                facts_json,
+                target_tag,
+                start,
+                end,
+                accession=accession,
+                filed=filed,
+            ):
+                continue
+
+            value: Decimal | None = None
+            if spec["strategy"] == "sum_members":
+                member_values = grouped[spec["source_tags"][0]].get((start, end), {})
+                # Never emit a partial sum: a class missing for this period
+                # would silently understate a company-wide total.
+                if member_values and set(member_values) == equity_classes:
+                    value = sum(member_values.values(), Decimal(0))
+            elif spec["strategy"] == "sum_components":
+                components = [
+                    values[(start, end)][member]
+                    for values in grouped.values()
+                    if member in values.get((start, end), {})
+                ]
+                if components:
+                    value = sum(components, Decimal(0))
+            else:
+                value = (
+                    grouped[spec["source_tags"][0]].get((start, end), {}).get(member)
+                )
+
+            if value is None:
+                continue
+
+            numeric_value: int | float = (
+                int(value) if spec["unit"] == "shares" else float(value)
+            )
+            entry = {
+                "start": start,
+                "end": end,
+                "val": numeric_value,
+                "accn": accession,
+                "form": form,
+                "filed": filed,
+            }
+            entry.update(metadata.get((accession, start, end, form), {}))
+
+            us_gaap = facts_json.setdefault("facts", {}).setdefault("us-gaap", {})
+            target = us_gaap.setdefault(target_tag, {"units": {}})
+            target.setdefault("units", {}).setdefault(spec["unit"], []).append(entry)
+            added += 1
+
+    return added
+
+
+def _select_filings(
+    submissions: dict[str, Any],
+    period: str,
+    fiscal_years: list[int] | None,
+) -> list[dict[str, Any]]:
+    """Select the smallest useful set of recent inline-XBRL filings."""
+    recent = submissions.get("filings", {}).get("recent", {})
+    forms = recent.get("form", [])
+    records = [
+        {key: values[index] for key, values in recent.items() if index < len(values)}
+        for index in range(len(forms))
+    ]
+    records = [
+        record
+        for record in records
+        if record.get("form") in {"10-K", "10-K/A", "10-Q", "10-Q/A"}
+        and str(record.get("isInlineXBRL", "0")) == "1"
+        and record.get("primaryDocument")
+    ]
+
+    # Prefer the original filing over an amendment for the same period: a
+    # Part III-only 10-K/A still carries inline-XBRL cover-page tagging, so it
+    # passes the filters above while containing no financial statements.
+    deduped: dict[tuple[str, str], dict[str, Any]] = {}
+    for record in records:
+        form = record["form"]
+        key = (form.split("/")[0], record.get("reportDate", ""))
+        incumbent = deduped.get(key)
+        if incumbent is None or ("/" in incumbent["form"] and "/" not in form):
+            deduped[key] = record
+
+    ordered = list(deduped.values())
+    annual = [record for record in ordered if record["form"].startswith("10-K")]
+    quarterly = [record for record in ordered if record["form"].startswith("10-Q")]
+    annual_mode = period in {"annual", "yoy"}
+
+    def report_year(record: dict[str, Any]) -> int | None:
+        """Return the calendar year of a filing's report date."""
+        try:
+            return int(str(record.get("reportDate", ""))[:4])
+        except ValueError:
+            return None
+
+    if fiscal_years:
+        years = set(fiscal_years)
+        # Always read the newest 10-K alongside the year-matched ones so a
+        # restatement (e.g. a stock split) is available; filings are merged
+        # newest-first below so the restated vintage is the one that lands.
+        annual_selected = []
+        seen_accn: set[str] = set()
+        for record in annual[:1] + [r for r in annual if report_year(r) in years]:
+            accession = record.get("accessionNumber", "")
+            if accession not in seen_accn:
+                seen_accn.add(accession)
+                annual_selected.append(record)
+        quarterly_selected = [
+            record for record in quarterly if report_year(record) in years
+        ]
+    else:
+        # Each 10-K carries three comparative years, so this reaches back far
+        # enough to close the reported history gap without a large fan-out.
+        annual_selected = annual[:_DEFAULT_ANNUAL_FILINGS]
+        quarterly_selected = quarterly[:_DEFAULT_QUARTERLY_FILINGS]
+
+    selected = annual_selected if annual_mode else annual_selected + quarterly_selected
+    # Newest first: `_has_company_fact` blocks an older vintage once a newer one
+    # has been merged, so a restatement can never be overwritten by the figures
+    # it restates (COKE's 10-for-1 split).
+    return sorted(
+        selected, key=lambda record: record.get("filingDate", ""), reverse=True
+    )
+
+
+def _instance_url(cik: str, filing: dict[str, Any]) -> str:
+    """Build the SEC extracted-instance URL for an inline filing."""
+    accession = filing["accessionNumber"].replace("-", "")
+    primary = filing["primaryDocument"]
+    stem = primary.rsplit(".", 1)[0]
+    return (
+        f"https://www.sec.gov/Archives/edgar/data/{int(cik)}/"
+        f"{accession}/{stem}_htm.xml"
+    )
+
+
+async def add_dimensional_per_share_facts(
+    facts_json: dict[str, Any],
+    symbol: str | None,
+    period: str,
+    fiscal_years: list[int] | None,
+    use_cache: bool,
+) -> int:
+    """Fetch recent filing instances and add configured dimensional facts."""
+    normalized_cik = _normalize_cik(facts_json.get("cik", ""))
+    if normalized_cik not in _PER_SHARE_RULES:
+        return 0
+
+    # pylint: disable=import-outside-toplevel
+    import asyncio
+
+    from openbb_sec.utils.cache import cached_request
+    from openbb_sec.utils.definitions import HEADERS
+    from openbb_sec.utils.xbrl_taxonomy_helper import XBRLParser
+
+    async def json_callback(response, _):
+        """Return a SEC response as JSON."""
+        return await response.json()
+
+    async def bytes_callback(response, _):
+        """Return a SEC response as bytes."""
+        return await response.read()
+
+    try:
+        submissions = await cached_request(
+            f"https://data.sec.gov/submissions/CIK{normalized_cik}.json",
+            use_cache=use_cache,
+            expire=_SUBMISSIONS_CACHE_TTL,
+            headers=HEADERS,
+            response_callback=json_callback,
+            timeout=300,
+        )
+
+        if not isinstance(submissions, dict):
+            return 0
+        filings = _select_filings(submissions, period, fiscal_years)
+        if not filings:
+            return 0
+
+        # gather() preserves position, so each response stays paired with the
+        # filing that produced it even when some requests fail.
+        responses = await asyncio.gather(
+            *(
+                cached_request(
+                    _instance_url(normalized_cik, filing),
+                    use_cache=use_cache,
+                    expire=_INSTANCE_CACHE_TTL,
+                    headers=HEADERS,
+                    response_callback=bytes_callback,
+                    timeout=300,
+                )
+                for filing in filings
+            ),
+            return_exceptions=True,
+        )
+
+        parser = XBRLParser()
+        metadata = _metadata_index(facts_json)
+        added = 0
+        for filing, response in zip(filings, responses):
+            if isinstance(response, Exception) or not isinstance(response, bytes):
+                continue
+            try:
+                _, _, instance_facts = parser.parse_instance(BytesIO(response))
+            except Exception as error:
+                warn(
+                    f"Failed to parse dimensional facts from "
+                    f"{filing.get('accessionNumber', 'SEC filing')}: {error}"
+                )
+                continue
+            try:
+                added += merge_dimensional_per_share_facts(
+                    facts_json,
+                    instance_facts,
+                    filing,
+                    symbol,
+                    metadata_index=metadata,
+                )
+            except Exception as error:  # one bad filing must not abandon the rest
+                warn(
+                    f"Failed to merge dimensional facts from "
+                    f"{filing.get('accessionNumber', 'SEC filing')}: {error}"
+                )
+                continue
+        return added
+    except Exception as error:  # The original companyfacts result remains usable.
+        warn(
+            f"Failed to load dimensional per-share facts for CIK {normalized_cik}: "
+            f"{error}"
+        )
+        return 0

--- a/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
@@ -14,6 +14,12 @@ from openbb_sec.utils.statement_schema import (
     ValidationWarning,
 )
 
+StatementType = Literal[
+    "income_statement",
+    "balance_sheet",
+    "cash_flow",
+]
+
 PeriodType = Literal[
     "annual", "quarterly", "both", "ttm", "yoy", "yoy_quarterly", "pop"
 ]
@@ -512,6 +518,7 @@ async def get_standardized_financials(
     use_cache: bool = True,
     pit_mode: bool = False,
     include_preliminary: bool = False,
+    statement: StatementType | None = None,
 ) -> StandardizedStatements:
     """Fetch company facts from SEC and return standardized financial statements.
 
@@ -538,6 +545,11 @@ async def get_standardized_financials(
     include_preliminary : bool
         If True, include 8-K filing data for periods not yet covered
         by a 10-Q/K.
+    statement : StatementType | None
+        Which statement the caller needs.  The class-dimensioned per-share
+        fallback is income-statement-only and costs extra SEC requests, so it
+        is skipped for balance sheet and cash flow requests.  Unrecognised
+        values fail safe by running the fallback.
 
     Returns
     -------
@@ -545,6 +557,7 @@ async def get_standardized_financials(
     """
     from openbb_core.app.model.abstract.error import OpenBBError
 
+    from openbb_sec.utils._dimensional_facts import add_dimensional_per_share_facts
     from openbb_sec.utils.cache import cached_request
     from openbb_sec.utils.definitions import HEADERS
     from openbb_sec.utils.helpers import symbol_map
@@ -590,6 +603,19 @@ async def get_standardized_financials(
             "cik": primary.get("cik", ""),
             "facts": merged_facts,
         }
+
+    # The per-share fields this fills are income-statement-only, so balance
+    # sheet and cash flow requests must not pay for the extra SEC downloads.
+    # Expressed as a denylist so an unrecognised value fails safe (runs the
+    # fallback) rather than silently disabling it.
+    if statement not in ("balance_sheet", "cash_flow"):
+        await add_dimensional_per_share_facts(
+            facts_json,
+            symbol=symbol,
+            period=period,
+            fiscal_years=fiscal_years,
+            use_cache=use_cache,
+        )
 
     return resolve_company_facts(
         facts_json,

--- a/openbb_platform/providers/sec/tests/test_dimensional_facts.py
+++ b/openbb_platform/providers/sec/tests/test_dimensional_facts.py
@@ -1,0 +1,530 @@
+"""Tests for the class-dimensioned per-share companyfacts fallback."""
+
+# flake8: noqa: D103
+
+import pytest
+
+from openbb_sec.utils._dimensional_facts import (
+    _decimal_value,
+    _instance_url,
+    _select_filings,
+    merge_dimensional_per_share_facts,
+)
+
+_START = "2026-04-04"
+_END = "2026-07-03"
+
+
+def _fact(value, member, start=_START, end=_END, axis="StatementClassOfStockAxis"):
+    return {
+        "start": start,
+        "end": end,
+        "value": str(value),
+        "dimensions": {
+            f"us-gaap:{axis}": {
+                "member": member,
+                "label": member,
+            }
+        },
+    }
+
+
+def _multi_axis_fact(value, members, start=_START, end=_END):
+    """Build a fact carrying one member on each of several axes."""
+    return {
+        "start": start,
+        "end": end,
+        "value": str(value),
+        "dimensions": {
+            f"us-gaap:{axis}": {"member": member, "label": member}
+            for axis, member in members.items()
+        },
+    }
+
+
+def _cover(*members):
+    """Cover-page facts that enumerate the issuer's common-stock classes."""
+    return {
+        "dei_EntityCommonStockSharesOutstanding": [
+            {
+                "value": str(1_000 + index),
+                "dimensions": {
+                    "us-gaap:StatementClassOfStockAxis": {
+                        "member": member,
+                        "label": member,
+                    }
+                },
+            }
+            for index, member in enumerate(members)
+        ]
+    }
+
+
+def _facts_json(cik, start=_START, end=_END):
+    return {
+        "cik": cik,
+        "entityName": "Test Company",
+        "facts": {
+            "us-gaap": {
+                "Revenues": {
+                    "units": {
+                        "USD": [
+                            {
+                                "start": start,
+                                "end": end,
+                                "val": 1,
+                                "accn": "0000000000-26-000001",
+                                "fy": 2026,
+                                "fp": "Q2",
+                                "form": "10-Q",
+                                "filed": "2026-08-01",
+                                "frame": "CY2026Q2",
+                            }
+                        ]
+                    }
+                }
+            }
+        },
+    }
+
+
+def _filing(form="10-Q", accession="0000000000-26-000001", filed="2026-08-01"):
+    return {
+        "accessionNumber": accession,
+        "form": form,
+        "filingDate": filed,
+        "reportDate": _END,
+        "primaryDocument": "test-20260703.htm",
+    }
+
+
+def _values(facts_json, tag, unit):
+    return facts_json["facts"]["us-gaap"][tag]["units"][unit]
+
+
+def test_coke_sums_basic_shares_but_not_diluted_shares():
+    """COKE basic counts sum classes while diluted uses its senior class."""
+    facts_json = _facts_json(317540)
+    instance_facts = {
+        **_cover("coke:CommonClassUndefinedMember", "us-gaap:CommonClassBMember"),
+        "us-gaap_EarningsPerShareBasic": [
+            _fact("2.39", "coke:CommonClassUndefinedMember"),
+            _fact("2.39", "us-gaap:CommonClassBMember"),
+        ],
+        "us-gaap_EarningsPerShareDiluted": [
+            _fact("2.38", "coke:CommonClassUndefinedMember"),
+            _fact("2.38", "us-gaap:CommonClassBMember"),
+        ],
+        "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic": [
+            _fact(56_517_000, "coke:CommonClassUndefinedMember"),
+            _fact(10_047_000, "us-gaap:CommonClassBMember"),
+        ],
+        "us-gaap_WeightedAverageNumberOfDilutedSharesOutstanding": [
+            _fact(66_649_000, "coke:CommonClassUndefinedMember"),
+            _fact(10_132_000, "us-gaap:CommonClassBMember"),
+        ],
+    }
+
+    added = merge_dimensional_per_share_facts(
+        facts_json, instance_facts, _filing(), "COKE"
+    )
+
+    assert added == 4
+    assert _values(facts_json, "EarningsPerShareBasic", "USD/shares")[0]["val"] == 2.39
+    assert (
+        _values(facts_json, "EarningsPerShareDiluted", "USD/shares")[0]["val"] == 2.38
+    )
+    assert (
+        _values(facts_json, "WeightedAverageNumberOfSharesOutstandingBasic", "shares")[
+            0
+        ]["val"]
+        == 66_564_000
+    )
+    assert (
+        _values(
+            facts_json, "WeightedAverageNumberOfDilutedSharesOutstanding", "shares"
+        )[0]["val"]
+        == 66_649_000
+    )
+    assert (
+        _values(facts_json, "EarningsPerShareBasic", "USD/shares")[0]["frame"]
+        == "CY2026Q2"
+    )
+
+
+def test_existing_companyfact_wins_over_dimensional_fallback():
+    """Never replace an SEC-provided undimensioned value."""
+    facts_json = _facts_json(317540)
+    facts_json["facts"]["us-gaap"]["EarningsPerShareBasic"] = {
+        "units": {
+            "USD/shares": [
+                {
+                    "start": _START,
+                    "end": _END,
+                    "val": 9.99,
+                    "form": "10-Q",
+                    "filed": "2026-08-01",
+                }
+            ]
+        }
+    }
+
+    added = merge_dimensional_per_share_facts(
+        facts_json,
+        {
+            **_cover("coke:CommonClassUndefinedMember", "us-gaap:CommonClassBMember"),
+            "us-gaap_EarningsPerShareBasic": [
+                _fact("2.39", "coke:CommonClassUndefinedMember")
+            ],
+        },
+        _filing(),
+        "COKE",
+    )
+
+    assert added == 0
+    assert _values(facts_json, "EarningsPerShareBasic", "USD/shares")[0]["val"] == 9.99
+
+
+def test_newer_vintage_is_appended_not_suppressed():
+    """A later restatement must not be blocked by an earlier vintage.
+
+    COKE's 10-for-1 split means the FY2024 10-K reports pre-split figures that
+    the FY2025 10-K restates.  Both vintages have to reach ``facts_json`` so
+    ``compute_ref_filings`` can pick the newest by filing date.
+    """
+    facts_json = _facts_json(317540)
+    cover = _cover("coke:CommonClassUndefinedMember", "us-gaap:CommonClassBMember")
+
+    merge_dimensional_per_share_facts(
+        facts_json,
+        {
+            **cover,
+            "us-gaap_EarningsPerShareBasic": [
+                _fact("70.10", "coke:CommonClassUndefinedMember")
+            ],
+        },
+        _filing(accession="0000000000-25-000001", filed="2025-02-20"),
+        "COKE",
+    )
+    merge_dimensional_per_share_facts(
+        facts_json,
+        {
+            **cover,
+            "us-gaap_EarningsPerShareBasic": [
+                _fact("7.01", "coke:CommonClassUndefinedMember")
+            ],
+        },
+        _filing(accession="0000000000-26-000002", filed="2026-02-18"),
+        "COKE",
+    )
+
+    entries = _values(facts_json, "EarningsPerShareBasic", "USD/shares")
+    assert [entry["val"] for entry in entries] == [70.10, 7.01]
+    assert max(entries, key=lambda entry: entry["filed"])["val"] == 7.01
+
+
+def test_brk_b_uses_class_b_equivalent_values_without_adding_classes():
+    """BRK-B selects its equivalent class instead of summing representations."""
+    facts_json = _facts_json(1067983)
+    instance_facts = {
+        **_cover("us-gaap:CommonClassAMember", "us-gaap:CommonClassBMember"),
+        "us-gaap_EarningsPerShareBasic": [
+            _fact(17_868, "brka:EquivalentClassAMember"),
+            _fact("11.91", "brka:EquivalentClassBMember"),
+        ],
+        "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic": [
+            _fact(1_436_443, "brka:EquivalentClassAMember"),
+            _fact(2_154_664_073, "brka:EquivalentClassBMember"),
+        ],
+    }
+
+    merge_dimensional_per_share_facts(facts_json, instance_facts, _filing(), "BRK.B")
+
+    assert _values(facts_json, "EarningsPerShareBasic", "USD/shares")[0]["val"] == 11.91
+    assert (
+        _values(facts_json, "WeightedAverageNumberOfSharesOutstandingBasic", "shares")[
+            0
+        ]["val"]
+        == 2_154_664_073
+    )
+    assert "EarningsPerShareDiluted" not in facts_json["facts"]["us-gaap"]
+
+
+def test_uhal_b_uses_the_face_of_statement_basic_eps_concept():
+    """U-Haul basic EPS comes from the concept its statement actually tags.
+
+    The EPS note's ``Undistributed`` + ``Distributed`` pair cannot be summed:
+    in a loss period the undistributed component is tagged as a positive
+    magnitude with a negated presentation label, so adding the dividend
+    overstates the result (0.28 against a filed 0.18).
+    """
+    facts_json = _facts_json(4457, start="2026-04-01", end="2026-06-30")
+    filing = _filing()
+    filing["reportDate"] = "2026-06-30"
+    instance_facts = {
+        **_cover("us-gaap:CommonClassAMember", "us-gaap:NonvotingCommonStockMember"),
+        "us-gaap_IncomeLossFromContinuingOperationsPerBasicShare": [
+            _fact(
+                "0.63",
+                "us-gaap:NonvotingCommonStockMember",
+                "2026-04-01",
+                "2026-06-30",
+            ),
+            _fact(
+                "0.58",
+                "us-gaap:CommonClassAMember",
+                "2026-04-01",
+                "2026-06-30",
+            ),
+        ],
+    }
+
+    merge_dimensional_per_share_facts(facts_json, instance_facts, filing, "UHAL-B")
+
+    assert _values(facts_json, "EarningsPerShareBasic", "USD/shares")[0]["val"] == 0.63
+
+
+def test_basis_conflict_skips_a_period_on_a_different_share_basis():
+    """Never mix a restated value with a stale companyfacts figure.
+
+    U-Haul's FY2022 basic share count in companyfacts is the as-filed
+    pre-split 19,607,788 and was never restated, so injecting a post-split EPS
+    beside it would understate the implied earnings by the split ratio.
+    """
+    facts_json = _facts_json(4457)
+    facts_json["facts"]["us-gaap"]["WeightedAverageNumberOfSharesOutstandingBasic"] = {
+        "units": {
+            "shares": [
+                {
+                    "start": _START,
+                    "end": _END,
+                    "val": 19_607_788,
+                    "accn": "0000004457-22-000041",
+                    "form": "10-K",
+                    "filed": "2022-05-25",
+                }
+            ]
+        }
+    }
+    instance_facts = {
+        **_cover("us-gaap:CommonClassAMember", "us-gaap:NonvotingCommonStockMember"),
+        "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic": [
+            _fact(19_607_788, "us-gaap:CommonClassAMember"),
+            _fact(176_470_092, "us-gaap:NonvotingCommonStockMember"),
+        ],
+        "us-gaap_IncomeLossFromContinuingOperationsPerBasicShare": [
+            _fact("0.58", "us-gaap:CommonClassAMember"),
+            _fact("0.63", "us-gaap:NonvotingCommonStockMember"),
+        ],
+    }
+
+    added = merge_dimensional_per_share_facts(
+        facts_json, instance_facts, _filing(form="10-K"), "UHAL"
+    )
+
+    assert added == 0
+    assert "EarningsPerShareBasic" not in facts_json["facts"]["us-gaap"]
+
+
+def test_class_member_matches_on_member_not_axis():
+    """U-Haul moves its voting class onto the equity-components axis.
+
+    In the Sep/Dec 10-Qs the voting class is tagged on
+    ``StatementEquityComponentsAxis`` and the company-wide total carries both
+    axes.  Matching on the member rather than the axis is what keeps the summed
+    total at the real 196,077,880 instead of a single class's 176,470,092.
+    """
+    facts_json = _facts_json(4457)
+    instance_facts = {
+        **_cover("us-gaap:CommonStockMember", "us-gaap:NonvotingCommonStockMember"),
+        "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic": [
+            _fact(
+                19_607_788,
+                "us-gaap:CommonStockMember",
+                axis="StatementEquityComponentsAxis",
+            ),
+            _fact(176_470_092, "us-gaap:NonvotingCommonStockMember"),
+            _multi_axis_fact(
+                196_077_880,
+                {
+                    "StatementClassOfStockAxis": "us-gaap:NonvotingCommonStockMember",
+                    "StatementEquityComponentsAxis": "us-gaap:CommonStockMember",
+                },
+            ),
+        ],
+    }
+
+    merge_dimensional_per_share_facts(facts_json, instance_facts, _filing(), "UHAL")
+
+    values = _values(
+        facts_json, "WeightedAverageNumberOfSharesOutstandingBasic", "shares"
+    )
+    assert [entry["val"] for entry in values] == [196_077_880]
+
+
+def test_sum_members_skips_period_with_incomplete_class_coverage():
+    """A partial sum must degrade to None rather than a wrong total."""
+    facts_json = _facts_json(317540)
+    instance_facts = {
+        **_cover("coke:CommonClassUndefinedMember", "us-gaap:CommonClassBMember"),
+        "us-gaap_WeightedAverageNumberOfSharesOutstandingBasic": [
+            _fact(56_517_000, "coke:CommonClassUndefinedMember")
+        ],
+    }
+
+    added = merge_dimensional_per_share_facts(
+        facts_json, instance_facts, _filing(), "COKE"
+    )
+
+    assert added == 0
+    assert (
+        "WeightedAverageNumberOfSharesOutstandingBasic"
+        not in facts_json["facts"]["us-gaap"]
+    )
+
+
+def test_unconfigured_cik_is_a_no_op():
+    """Issuers without a rule must not be touched."""
+    facts_json = _facts_json(320193)
+    before = str(facts_json)
+
+    added = merge_dimensional_per_share_facts(
+        facts_json,
+        {
+            **_cover("us-gaap:CommonClassAMember"),
+            "us-gaap_EarningsPerShareBasic": [
+                _fact("1.23", "us-gaap:CommonClassAMember")
+            ],
+        },
+        _filing(),
+        "AAPL",
+    )
+
+    assert added == 0
+    assert str(facts_json) == before
+
+
+def test_merge_without_cover_page_is_a_no_op():
+    """Without a cover page the class set is unknown, so nothing is synthesized."""
+    facts_json = _facts_json(317540)
+
+    added = merge_dimensional_per_share_facts(
+        facts_json,
+        {
+            "us-gaap_EarningsPerShareBasic": [
+                _fact("2.39", "coke:CommonClassUndefinedMember")
+            ]
+        },
+        _filing(),
+        "COKE",
+    )
+
+    assert added == 0
+
+
+@pytest.mark.parametrize(
+    "value", ["NaN", "sNaN", "Infinity", "-Infinity", "junk", None]
+)
+def test_decimal_value_rejects_non_numeric_and_non_finite(value):
+    """``int(value)`` on the shares branch must never see NaN or Infinity."""
+    assert _decimal_value(value) is None
+
+
+def test_select_filings_uses_one_annual_and_four_quarterly_by_default():
+    """Quarterly enrichment stays bounded to the useful recent filings."""
+    submissions = {
+        "filings": {
+            "recent": {
+                "form": ["10-Q", "10-Q", "10-K", "10-Q", "10-Q", "10-Q"],
+                "reportDate": [
+                    "2026-06-30",
+                    "2026-03-31",
+                    "2025-12-31",
+                    "2025-09-30",
+                    "2025-06-30",
+                    "2025-03-31",
+                ],
+                "filingDate": [
+                    "2026-08-01",
+                    "2026-05-01",
+                    "2026-02-01",
+                    "2025-11-01",
+                    "2025-08-01",
+                    "2025-05-01",
+                ],
+                "accessionNumber": [f"0000000000-26-00000{i}" for i in range(6)],
+                "primaryDocument": [f"filing-{i}.htm" for i in range(6)],
+                "isInlineXBRL": [1, 1, 1, 1, 1, 1],
+            }
+        }
+    }
+
+    selected = _select_filings(submissions, "quarterly", None)
+
+    assert len(selected) == 5
+    assert sum(record["form"] == "10-K" for record in selected) == 1
+    assert sum(record["form"] == "10-Q" for record in selected) == 4
+    # Newest first, so a restatement is merged before the figures it restates.
+    assert selected == sorted(
+        selected, key=lambda record: record["filingDate"], reverse=True
+    )
+
+
+def test_select_filings_always_reads_the_newest_annual_for_a_past_fiscal_year():
+    """A past-year request must still read the newest 10-K.
+
+    Otherwise the only vintage available is the pre-restatement one and a stock
+    split silently changes the value of a fiscal year.
+    """
+    submissions = {
+        "filings": {
+            "recent": {
+                "form": ["10-K", "10-K", "10-K"],
+                "reportDate": ["2025-12-31", "2024-12-31", "2023-12-31"],
+                "filingDate": ["2026-02-18", "2025-02-20", "2024-02-22"],
+                "accessionNumber": [f"0000000000-2{i}-000001" for i in (6, 5, 4)],
+                "primaryDocument": [f"coke-{y}.htm" for y in (2025, 2024, 2023)],
+                "isInlineXBRL": [1, 1, 1],
+            }
+        }
+    }
+
+    selected = _select_filings(submissions, "annual", [2024])
+    report_dates = [record["reportDate"] for record in selected]
+
+    assert "2025-12-31" in report_dates
+    assert "2024-12-31" in report_dates
+    assert selected == sorted(
+        selected, key=lambda record: record["filingDate"], reverse=True
+    )
+    assert selected[0]["reportDate"] == "2025-12-31"
+
+
+def test_amendment_does_not_supersede_the_original_filing():
+    """A Part III-only 10-K/A carries cover-page XBRL but no statements."""
+    submissions = {
+        "filings": {
+            "recent": {
+                "form": ["10-K/A", "10-K"],
+                "reportDate": ["2025-12-31", "2025-12-31"],
+                "filingDate": ["2026-04-01", "2026-02-18"],
+                "accessionNumber": ["0000000000-26-000002", "0000000000-26-000001"],
+                "primaryDocument": ["amend-2025.htm", "orig-2025.htm"],
+                "isInlineXBRL": [1, 1],
+            }
+        }
+    }
+
+    selected = _select_filings(submissions, "annual", None)
+
+    assert len(selected) == 1
+    assert selected[0]["form"] == "10-K"
+    assert selected[0]["primaryDocument"] == "orig-2025.htm"
+
+
+def test_instance_url_uses_sec_extracted_instance_filename():
+    """Derive the standard SEC extracted-instance filename."""
+    assert _instance_url("0000317540", _filing()) == (
+        "https://www.sec.gov/Archives/edgar/data/317540/"
+        "000000000026000001/test-20260703_htm.xml"
+    )

--- a/openbb_platform/providers/sec/tests/test_sec_fetchers.py
+++ b/openbb_platform/providers/sec/tests/test_sec_fetchers.py
@@ -298,6 +298,7 @@ def blk_facts():
 
 def _mock_get_standardized(blk_facts):
     async def _inner(
+        *,
         symbol=None,
         cik=None,
         fiscal_years=None,
@@ -305,6 +306,7 @@ def _mock_get_standardized(blk_facts):
         use_cache=True,
         pit_mode=False,
         include_preliminary=False,
+        statement=None,
     ):
         return resolve_company_facts(
             blk_facts,


### PR DESCRIPTION
# Pull Request the OpenBB Platform

## Description

Fixes #7645.

`get_standardized_financials` returned `None` for `basic_eps`, `diluted_eps`, `weighted_ave_basic_shares_os` and `weighted_ave_diluted_shares_os` for issuers that tag those concepts only with share-class dimensions. The SEC companyfacts API carries undimensioned facts only, so the fields were empty even though every filing contains the values.

Adds a fallback in the standardizer: for periods companyfacts does not cover, the filing's extracted instance is parsed with the existing `XBRLParser.parse_instance` and the class-dimensioned values are merged in before `resolve_company_facts` runs.

Share classes are discovered **per filing** — from the cover page (`dei:EntityCommonStockSharesOutstanding`), with tickers mapped via `dei:TradingSymbol` — and matched on the **member**, not the axis. That matters: U-Haul tags its voting class on `StatementClassOfStockAxis` in some quarters and `StatementEquityComponentsAxis` in others, and keying on the axis silently drops it.

Per the issue's semantics, basic counts are summed across classes while a senior class's diluted count is taken as-converted and never summed (COKE FY2025 emits 83,807,000, not the ~94,000,000 a naive sum gives).

Safeguards, each found against live SEC data and covered by a test:

- **Fail-closed sums** — a cross-class sum is emitted only when the members present cover the whole class set, so a partially tagged period degrades to `None`, never to an understated total.
- **Restatements win** — filings merge newest-first. COKE's 10-for-1 split previously made `fiscal_years=[2023]` and `fiscal_years=None` return values 10x apart for the same year.
- **Share-basis guard** — periods where the filing and companyfacts disagree on the share count are skipped, so a post-split value is never paired with a stale pre-split one (U-Haul FY2021–22).
- **U-Haul basic EPS** uses `IncomeLossFromContinuingOperationsPerBasicShare`. The note's `Undistributed` + `Distributed` pair cannot be summed — in a loss period the undistributed component is a positive magnitude with a negated presentation label, which overstated the result (0.28 vs a filed 0.18).
- Amendments no longer supersede the filing carrying the statements; reported facts always outrank synthesized ones.

The fallback is income-statement-only, so `get_standardized_financials` gained a `statement` hint and balance sheet / cash flow requests skip the extra SEC requests. No new dependencies.

**Scope:** covers the three issuers in the issue. The discovery pieces are already issuer-agnostic, so generalizing is a natural follow-up PR. I'll raise two questions on the issue first — whether synthesized values should carry a distinguishable `source`, and whether `weighted_ave_basic_shares_os` should be the cross-class sum or the requested class, since COKE and U-Haul use opposite conventions in their own tagging.

## How has this been tested?

`openbb_platform/providers/sec/tests/test_dimensional_facts.py` — 20 tests, no network. All pre-commit hooks pass.

```
pytest openbb_platform/providers/sec/tests/ -q
243 passed
```

The issue's reproduction now returns `basic_eps 6.82 / diluted_eps 6.81` (was `None`), and every value the issue quotes reproduces: COKE 2.39 with 66,564,000 basic shares (56,517,000 + 10,047,000); BRK-A 17,868/quarter; BRK-B 11.91/quarter; U-Haul's two-class method at 196,077,880.

Populated per-share values, fallback disabled → enabled:

| Issuer | Annual | Quarterly |
|---|---|---|
| COKE | 36 → 60 | 116 → 154 |
| BRK-A / BRK-B | 7 → 19 | 47 → 68 |
| UHAL / UHAL-B | 8 → 21 | 17 → 36 |

Regression check across 10 configurations (5 symbols × annual/quarterly, all three statements): **no SEC-reported value changes and no row is lost** — only the intended new rows appear. Single-class issuers (AAPL, MSFT, JNJ) are a no-op with zero extra HTTP requests.

- [x] Ensure all unit and integration tests pass.
- [x] Ensure the command(s) execute with the expected output — Python interface.

## Checklist

- [x] I have performed a self-review of my own code.
- [x] I have commented my code, particularly in hard-to-understand areas.
- [x] I ensure that I am following the [CONTRIBUTING guidelines](https://github.com/OpenBB-finance/OpenBB/blob/main/CONTRIBUTING.md).
- [x] (If applicable) I have updated tests.