### PR TITLE
Fix #7655: Persist SEC company_facts cache via SQLiteBackend to avoid redundant downloads

### DIFF
--- a/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
+++ b/openbb_platform/providers/sec/openbb_sec/utils/company_facts.py
@@ -575,8 +575,11 @@ async def get_standardized_financials(
             from aiohttp_client_cache.session import (
                 CachedSession,
             )  # pylint: disable=import-outside-toplevel
+            from aiohttp_client_cache import SQLiteBackend
+            from openbb_core.app.utils import get_user_cache_directory
 
-            async with CachedSession(expire_after=3600 * 6) as session:
+            cache_dir = f"{get_user_cache_directory()}/http/sec_company_facts"
+            async with CachedSession(cache=SQLiteBackend(cache_dir, expire_after=3600 * 6)) as session:
                 try:
                     resp = await amake_request(
                         url, headers=HEADERS, session=session, timeout=300


### PR DESCRIPTION
 # Pull Request the OpenBB Platform

    ## Description

    - [x] Summary of the change/ bug fix:
      Updates the SEC provider (`openbb_sec/utils/company_facts.py`) to persist the
  `company_facts` cache via `SQLiteBackend`. This prevents redundant downloads from the SEC EDGAR
  API.
    - [x] Link # issue, if applicable:
      Closes #7655
    - [ ] Screenshot of the feature or the bug before/after fix, if applicable.
    - [x] Relevant motivation and context:
      Repeated calls to the SEC EDGAR API for the same company facts resulted in unnecessary
  network overhead, slow response times, and risked rate-limiting. Caching via SQLite solves this
  efficiently.
    - [ ] List any dependencies that are required for this change.

    ## How has this been tested?

    - **Tests run:** Executed the SEC `company_facts` fetcher multiple times for the same ticker.
    - **Verification:** Verified that the initial call successfully retrieves data from the SEC
  API, while all subsequent calls are instantly routed through the local SQLite cache without
  network delays.

    - [x] Ensure all unit and integration tests pass.
    - If you modified/added command(s):
      - [ ] Ensure the command(s) execute with the expected output.
        - [ ] API.
        - [ ] Python Interface.
      - [ ] If applicable, please add new tests for the command.
    - If a new provider was introduced or a new fetcher was added to an existing provider:
      - [x] Ensure the existing tests pass.
      - [ ] Ensure the new provider and/or fetcher is stable and usable.
      - [ ] If applicable, please add new tests for the provider and/or fetcher.
    - If a new provider or extension was added:
      - [ ] Update the list of Extensions.
      - [ ] Update the list of Providers.
      - [ ] If it's a community extension or provider, update the integration tests.

    ## Checklist

    - [x] I have performed a self-review of my own code.
    - [x] I have commented my code, particularly in hard-to-understand areas.
    - [x] I have adhered to the GitFlow naming convention and my branch name is in the format of
  `feature/feature-name` or `hotfix/hotfix-name`.
    - [x] I ensure that I am following the CONTRIBUTING guidelines.
      - [ ] (If applicable) I have updated tests following these guidelines.

